### PR TITLE
Add test and error handling for the editTransactions function

### DIFF
--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -96,6 +96,7 @@ export const addTransactions = (
 };
 
 export const editTransactions = (
+  id: number,
   transaction_type: string,
   transaction_date: Date | null,
   shop: string | null,
@@ -119,9 +120,6 @@ export const editTransactions = (
     }
 
     const transactionsList = getState().transactions.transactionsList;
-    const id = transactionsList.map((transaction) => {
-      return transaction.id;
-    });
 
     const data: transactionsReq = {
       transaction_type: transaction_type,
@@ -147,6 +145,20 @@ export const editTransactions = (
           return transaction;
         });
         dispatch(updateTransactionsAction(nextTransactionsList));
+      })
+      .catch((error) => {
+        if (error.response.status === 400) {
+          alert(error.response.data.error.message.join('\n'));
+        }
+
+        if (error.response.status === 401) {
+          alert(error.response.data.error.message);
+          dispatch(push('/login'));
+        }
+
+        if (error.response.status === 500) {
+          alert(error.response.data.error.message);
+        }
       });
   };
 };

--- a/test/transactions-test/editResponse.json
+++ b/test/transactions-test/editResponse.json
@@ -1,0 +1,12 @@
+{
+  "id": 47,
+  "transaction_type": "expense",
+  "updated_date": "2020-08-09T17:00:15Z",
+  "transaction_date": "07/26(日)",
+  "shop": "MIDWEST",
+  "memo": "RickOwens",
+  "amount": 12000,
+  "big_category_name": "衣服・美容",
+  "medium_category_name": "衣服",
+  "custom_category_name": null
+}

--- a/test/transactions-test/editTransactions.json
+++ b/test/transactions-test/editTransactions.json
@@ -1,0 +1,64 @@
+{
+  "transactions_list": [
+    {
+      "id": 47,
+      "transaction_type": "expense",
+      "updated_date": "2020-08-09T17:00:15Z",
+      "transaction_date": "07/26(日)",
+      "shop": "MIDWEST",
+      "memo": "RickOwens",
+      "amount": 12000,
+      "big_category_name": "衣服・美容",
+      "medium_category_name": "衣服",
+      "custom_category_name": null
+    },
+    {
+      "id": 12,
+      "transaction_type": "income",
+      "updated_date": "2020-08-08T00:08:23Z",
+      "transaction_date": "07/20(月)",
+      "shop": null,
+      "memo": "賞与",
+      "amount": 1000000,
+      "big_category_name": "収入",
+      "medium_category_name": "賞与",
+      "custom_category_name": null
+    },
+    {
+      "id": 13,
+      "transaction_type": "income",
+      "updated_date": "2020-08-08T00:08:23Z",
+      "transaction_date": "07/20(月)",
+      "shop": null,
+      "memo": "株配当金",
+      "amount": 200000,
+      "big_category_name": "収入",
+      "medium_category_name": null,
+      "custom_category_name": "株配当金"
+    },
+    {
+      "id": 8,
+      "transaction_type": "expense",
+      "updated_date": "2020-08-08T00:08:23Z",
+      "transaction_date": "07/05(日)",
+      "shop": null,
+      "memo": "みんなのGo言語",
+      "amount": 2500,
+      "big_category_name": "教養・教育",
+      "medium_category_name": "参考書",
+      "custom_category_name": null
+    },
+    {
+      "id": 1,
+      "transaction_type": "expense",
+      "updated_date": "2020-08-08T00:08:23Z",
+      "transaction_date": "07/01(水)",
+      "shop": "コストコ",
+      "memo": "セールで牛肉購入",
+      "amount": 4500,
+      "big_category_name": "食費",
+      "medium_category_name": "食料品",
+      "custom_category_name": null
+    }
+  ]
+}


### PR DESCRIPTION
家計簿データの編集処理を行うeditTransactions関数のテストを実装しました。
operationsのeditTransactionsでerror処理を実装していなかったので.catch()の部分を追加しました。
確認よろしくお願いします。