### PR TITLE
Add reducers and operations of yearly budgets

### DIFF
--- a/src/reducks/budgets/actions.ts
+++ b/src/reducks/budgets/actions.ts
@@ -1,5 +1,7 @@
 import { StandardBudgetsList, FetchYearlyBudgetsList, CustomBudgetsList } from './types';
-export type budgetsActions = ReturnType<typeof updateStandardBudgets | typeof fetchYearlyBudgets>;
+export type budgetsActions = ReturnType<
+  typeof updateStandardBudgets | typeof fetchYearlyBudgets | typeof updateCustomBudgets
+>;
 
 export const UPDATE_STANDARD_BUDGETS = 'UPDATE_STANDARD_BUDGETS';
 export const updateStandardBudgets = (

--- a/src/reducks/budgets/actions.ts
+++ b/src/reducks/budgets/actions.ts
@@ -1,4 +1,4 @@
-import { StandardBudgetsList, FetchYearlyBudgetsList } from './types';
+import { StandardBudgetsList, FetchYearlyBudgetsList, CustomBudgetsList } from './types';
 export type budgetsActions = ReturnType<typeof updateStandardBudgets | typeof fetchYearlyBudgets>;
 
 export const UPDATE_STANDARD_BUDGETS = 'UPDATE_STANDARD_BUDGETS';
@@ -18,5 +18,15 @@ export const fetchYearlyBudgets = (
   return {
     type: FETCH_YEARLY_BUDGETS,
     payload: yearly_budgets_list,
+  };
+};
+
+export const UPDATE_CUSTOM_BUDGETS = 'UPDATE_CUSTOM_BUDGETS';
+export const updateCustomBudgets = (
+  custom_budgets_list: CustomBudgetsList
+): { type: string; payload: CustomBudgetsList } => {
+  return {
+    type: UPDATE_CUSTOM_BUDGETS,
+    payload: custom_budgets_list,
   };
 };

--- a/src/reducks/budgets/actions.ts
+++ b/src/reducks/budgets/actions.ts
@@ -1,5 +1,5 @@
 import { StandardBudgetsList, FetchYearlyBudgetsList } from './types';
-export type budgetsActions = ReturnType<typeof updateStandardBudgets>;
+export type budgetsActions = ReturnType<typeof updateStandardBudgets | typeof fetchYearlyBudgets>;
 
 export const UPDATE_STANDARD_BUDGETS = 'UPDATE_STANDARD_BUDGETS';
 export const updateStandardBudgets = (

--- a/src/reducks/budgets/operations.ts
+++ b/src/reducks/budgets/operations.ts
@@ -1,4 +1,4 @@
-import { updateStandardBudgets, fetchYearlyBudgets } from './actions';
+import { updateStandardBudgets, fetchYearlyBudgets, updateCustomBudgets } from './actions';
 import axios from 'axios';
 import { Dispatch, Action } from 'redux';
 import { push } from 'connected-react-router';
@@ -6,6 +6,10 @@ import { FetchYearlyBudgetsList } from './types';
 
 interface fetchStandardBudgetsRes {
   standard_budgets: [];
+}
+
+interface fetchCustomBudgetsRes {
+  custom_budgets: [];
 }
 
 export const fetchStandardBudgets = () => {
@@ -45,6 +49,32 @@ export const getYearlyBudgets = () => {
         if (error.response.status === 401) {
           alert(error.response.data.error.message);
           dispatch(push('/login'));
+        }
+
+        if (error.response.status === 500) {
+          alert(error.response.data.error.message);
+        }
+      });
+  };
+};
+
+export const fetchCustomBudgets = () => {
+  return async (dispatch: Dispatch<Action>): Promise<void> => {
+    await axios
+      .get<fetchCustomBudgetsRes>('http://127.0.0.1:8081/custom-budgets/2020-07', {
+        withCredentials: true,
+      })
+      .then((res) => {
+        const customBudgets = res.data.custom_budgets;
+        dispatch(updateCustomBudgets(customBudgets));
+      })
+      .catch((error) => {
+        if (error.response.status === 400) {
+          alert(error.response.data.error.message);
+        }
+
+        if (error.response.status === 401) {
+          alert(error.response.data.error.message);
         }
 
         if (error.response.status === 500) {

--- a/src/reducks/budgets/operations.ts
+++ b/src/reducks/budgets/operations.ts
@@ -1,21 +1,45 @@
-import { updateStandardBudgets } from './actions';
+import { updateStandardBudgets, fetchYearlyBudgets } from './actions';
 import axios from 'axios';
 import { Dispatch, Action } from 'redux';
 import { push } from 'connected-react-router';
+import { FetchYearlyBudgetsList } from './types';
 
-interface fetchBudgetsRes {
+interface fetchStandardBudgetsRes {
   standard_budgets: [];
 }
 
 export const fetchStandardBudgets = () => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {
     await axios
-      .get<fetchBudgetsRes>('http://127.0.0.1:8081/standard-budgets', {
+      .get<fetchStandardBudgetsRes>('http://127.0.0.1:8081/standard-budgets', {
         withCredentials: true,
       })
       .then((res) => {
         const standardBudgetsList = res.data.standard_budgets;
         dispatch(updateStandardBudgets(standardBudgetsList));
+      })
+      .catch((error) => {
+        if (error.response.status === 401) {
+          alert(error.response.data.error.message);
+          dispatch(push('/login'));
+        }
+
+        if (error.response.status === 500) {
+          alert(error.response.data.error.message);
+        }
+      });
+  };
+};
+
+export const getYearlyBudgets = () => {
+  return async (dispatch: Dispatch<Action>): Promise<void> => {
+    await axios
+      .get<FetchYearlyBudgetsList>('http://127.0.0.1:8081/budgets/2020', {
+        withCredentials: true,
+      })
+      .then((res) => {
+        const yearlyBudgetsList = res.data;
+        dispatch(fetchYearlyBudgets(yearlyBudgetsList));
       })
       .catch((error) => {
         if (error.response.status === 401) {

--- a/src/reducks/budgets/reducers.ts
+++ b/src/reducks/budgets/reducers.ts
@@ -14,6 +14,11 @@ export const budgetsReducer = (state = initialState.budgets, action: budgetsActi
         ...state,
         yearly_budgets_list: action.payload,
       };
+    case Actions.UPDATE_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        custom_budgets_list: [...action.payload],
+      };
     default:
       return state;
   }

--- a/src/reducks/budgets/reducers.ts
+++ b/src/reducks/budgets/reducers.ts
@@ -9,6 +9,11 @@ export const budgetsReducer = (state = initialState.budgets, action: budgetsActi
         ...state,
         standard_budgets_list: [...action.payload],
       };
+    case Actions.FETCH_YEARLY_BUDGETS:
+      return {
+        ...state,
+        yearly_budgets_list: action.payload,
+      };
     default:
       return state;
   }

--- a/src/reducks/budgets/selectors.ts
+++ b/src/reducks/budgets/selectors.ts
@@ -11,3 +11,7 @@ export const getYearlyBudgets = createSelector(
   [budgetsSelector],
   (state) => state.yearly_budgets_list
 );
+export const getCustomBudgets = createSelector(
+  [budgetsSelector],
+  (state) => state.custom_budgets_list
+);

--- a/src/reducks/budgets/types.ts
+++ b/src/reducks/budgets/types.ts
@@ -1,4 +1,4 @@
-export interface FetchStandardBudgets {
+export interface StandardBudget {
   big_category_id: number;
   big_category_name: string;
   budget: number;
@@ -16,6 +16,13 @@ export interface FetchYearlyBudget {
   monthly_budgets: MonthlyBudget;
 }
 
-export interface StandardBudgetsList extends Array<FetchStandardBudgets> {}
+export interface CustomBudget {
+  big_category_id: number;
+  big_category_name: string;
+  budget: number;
+}
+
+export interface StandardBudgetsList extends Array<StandardBudget> {}
 export interface MonthlyBudgetsList extends Array<MonthlyBudget> {}
 export interface FetchYearlyBudgetsList extends Array<FetchYearlyBudget> {}
+export interface CustomBudgetsList extends Array<CustomBudget> {}

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -9,6 +9,7 @@ const initialState = {
   budgets: {
     standard_budgets_list: [],
     yearly_budgets_list: [],
+    custom_budgets_list: [],
   },
   users: {
     user_id: '',

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -1,8 +1,7 @@
 import { Categories } from '../categories/types';
 import { Groups } from '../groups/types';
 import { TransactionsList } from '../transactions/types';
-import { StandardBudgetsList } from '../budgets/types';
-import { FetchYearlyBudgetsList } from '../budgets/types';
+import { StandardBudgetsList, FetchYearlyBudgetsList, CustomBudgetsList } from '../budgets/types';
 import { TodoLists } from '../todoLists/types';
 
 export interface State {
@@ -16,6 +15,7 @@ export interface State {
   budgets: {
     standard_budgets_list: StandardBudgetsList;
     yearly_budgets_list: FetchYearlyBudgetsList;
+    custom_budgets_list: CustomBudgetsList;
   };
   users: {
     user_id: string;

--- a/test/budgets-test/Budgets.test.tsx
+++ b/test/budgets-test/Budgets.test.tsx
@@ -4,9 +4,9 @@ import axios from 'axios';
 import axiosMockAdapter from 'axios-mock-adapter';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
-import { fetchStandardBudgets } from '../../src/reducks/budgets/operations';
+import { fetchStandardBudgets, getYearlyBudgets } from '../../src/reducks/budgets/operations';
 import standardBudgets from './fetchBudgetsResponse.json';
-import { UPDATE_STANDARD_BUDGETS } from '../../src/reducks/budgets/actions';
+import yearlyBudgets from './fetchYearlyBudgetsReponse.json';
 
 const axiosMock = new axiosMockAdapter(axios);
 const middlewares = [thunk];
@@ -30,6 +30,27 @@ describe('async actions fetchBudgets', () => {
     axiosMock.onGet(url).reply(200, mockStandardBudgets);
 
     await fetchStandardBudgets()(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe('async actions getYearlyBudgets', () => {
+  const store = mockStore({ budgets: { yearly_budgets_list: [] } });
+  const url = 'http://127.0.0.1:8081/budgets/2020';
+
+  it('Get yearly_budgets if fetch succeeds', async () => {
+    const mockYearlyBudgets = yearlyBudgets;
+
+    const expectedActions = [
+      {
+        type: actionTypes.FETCH_YEARLY_BUDGETS,
+        payload: mockYearlyBudgets,
+      },
+    ];
+
+    axiosMock.onGet(url).reply(200, mockYearlyBudgets);
+
+    await getYearlyBudgets()(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/test/budgets-test/Budgets.test.tsx
+++ b/test/budgets-test/Budgets.test.tsx
@@ -4,9 +4,14 @@ import axios from 'axios';
 import axiosMockAdapter from 'axios-mock-adapter';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
-import { fetchStandardBudgets, getYearlyBudgets } from '../../src/reducks/budgets/operations';
+import {
+  fetchStandardBudgets,
+  getYearlyBudgets,
+  fetchCustomBudgets,
+} from '../../src/reducks/budgets/operations';
 import standardBudgets from './fetchBudgetsResponse.json';
 import yearlyBudgets from './fetchYearlyBudgetsReponse.json';
+import customBudgets from './fetchCustomBudgetsResponse.json';
 
 const axiosMock = new axiosMockAdapter(axios);
 const middlewares = [thunk];
@@ -51,6 +56,27 @@ describe('async actions getYearlyBudgets', () => {
     axiosMock.onGet(url).reply(200, mockYearlyBudgets);
 
     await getYearlyBudgets()(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe('async actions getCustomBudgets', () => {
+  const store = mockStore({ budgets: { custom_budgets_list: [] } });
+  const url = 'http://127.0.0.1:8081/custom-budgets/2020-07';
+
+  it('Get custom_budgets if fetch succeeds', async () => {
+    const mockCustomBudgets = customBudgets;
+
+    const expectedActions = [
+      {
+        type: actionTypes.UPDATE_CUSTOM_BUDGETS,
+        payload: mockCustomBudgets.custom_budgets,
+      },
+    ];
+
+    axiosMock.onGet(url).reply(200, mockCustomBudgets);
+
+    await fetchCustomBudgets()(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/test/budgets-test/fetchCustomBudgetsResponse.json
+++ b/test/budgets-test/fetchCustomBudgetsResponse.json
@@ -1,0 +1,84 @@
+{
+  "custom_budgets": [
+    {
+      "big_category_id": 2,
+      "big_category_name": "食費",
+      "budget": 25000
+    },
+    {
+      "big_category_id": 3,
+      "big_category_name": "日用品",
+      "budget": 5000
+    },
+    {
+      "big_category_id": 4,
+      "big_category_name": "趣味・娯楽",
+      "budget": 4500
+    },
+    {
+      "big_category_id": 5,
+      "big_category_name": "交際費",
+      "budget": 1000
+    },
+    {
+      "big_category_id": 6,
+      "big_category_name": "交通費",
+      "budget": 1000
+    },
+    {
+      "big_category_id": 7,
+      "big_category_name": "衣服・美容",
+      "budget": 0
+    },
+    {
+      "big_category_id": 8,
+      "big_category_name": "健康・医療",
+      "budget": 4900
+    },
+    {
+      "big_category_id": 9,
+      "big_category_name": "通信費",
+      "budget": 4400
+    },
+    {
+      "big_category_id": 10,
+      "big_category_name": "教養・教育",
+      "budget": 10000
+    },
+    {
+      "big_category_id": 11,
+      "big_category_name": "住宅",
+      "budget": 15000
+    },
+    {
+      "big_category_id": 12,
+      "big_category_name": "水道・光熱費",
+      "budget": 3000
+    },
+    {
+      "big_category_id": 13,
+      "big_category_name": "自動車",
+      "budget": 0
+    },
+    {
+      "big_category_id": 14,
+      "big_category_name": "保険",
+      "budget": 9800
+    },
+    {
+      "big_category_id": 15,
+      "big_category_name": "税金・社会保険",
+      "budget": 0
+    },
+    {
+      "big_category_id": 16,
+      "big_category_name": "現金・カード",
+      "budget": 0
+    },
+    {
+      "big_category_id": 17,
+      "big_category_name": "その他",
+      "budget": 0
+    }
+  ]
+}

--- a/test/budgets-test/fetchYearlyBudgetsReponse.json
+++ b/test/budgets-test/fetchYearlyBudgetsReponse.json
@@ -1,0 +1,66 @@
+{
+  "year": "2020-01-01T00:00:00Z",
+  "yearly_total_budget": 1024600,
+  "monthly_budgets": [
+    {
+      "month": "2020年01月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    },
+    {
+      "month": "2020年02月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    },
+    {
+      "month": "2020年03月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    },
+    {
+      "month": "2020年04月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    },
+    {
+      "month": "2020年05月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    },
+    {
+      "month": "2020年06月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    },
+    {
+      "month": "2020年07月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 88600
+    },
+    {
+      "month": "2020年08月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    },
+    {
+      "month": "2020年09月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    },
+    {
+      "month": "2020年10月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 100000
+    },
+    {
+      "month": "2020年11月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    },
+    {
+      "month": "2020年12月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 83600
+    }
+  ]
+}


### PR DESCRIPTION
yearlyBudgets（年別予算）取得のreducers, 非同期処理を行うoperations / getYearlyBudgetsを実装しました。
actionsのbudgetsActionsにfetchYearlyBudgetsを含めていなかったので追加しました。
確認よろしくお願いします。