### PR TITLE
Move the type definition of operations to types

### DIFF
--- a/src/reducks/budgets/operations.ts
+++ b/src/reducks/budgets/operations.ts
@@ -2,15 +2,7 @@ import { updateStandardBudgets, fetchYearlyBudgets, updateCustomBudgets } from '
 import axios from 'axios';
 import { Dispatch, Action } from 'redux';
 import { push } from 'connected-react-router';
-import { FetchYearlyBudgetsList } from './types';
-
-interface fetchStandardBudgetsRes {
-  standard_budgets: [];
-}
-
-interface fetchCustomBudgetsRes {
-  custom_budgets: [];
-}
+import { FetchYearlyBudgetsList, fetchStandardBudgetsRes, fetchCustomBudgetsRes } from './types';
 
 export const fetchStandardBudgets = () => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {

--- a/src/reducks/budgets/types.ts
+++ b/src/reducks/budgets/types.ts
@@ -26,3 +26,11 @@ export interface StandardBudgetsList extends Array<StandardBudget> {}
 export interface MonthlyBudgetsList extends Array<MonthlyBudget> {}
 export interface FetchYearlyBudgetsList extends Array<FetchYearlyBudget> {}
 export interface CustomBudgetsList extends Array<CustomBudget> {}
+
+export interface fetchStandardBudgetsRes {
+  standard_budgets: [];
+}
+
+export interface fetchCustomBudgetsRes {
+  custom_budgets: [];
+}

--- a/src/reducks/categories/operations.ts
+++ b/src/reducks/categories/operations.ts
@@ -2,41 +2,16 @@ import { updateIncomeCategoriesAction, updateExpenseCategoriesAction } from './a
 import axios from 'axios';
 import { Dispatch, Action } from 'redux';
 import { push } from 'connected-react-router';
-import { Category } from './types';
+import {
+  Category,
+  fetchCategoriesRes,
+  addCustomReq,
+  addCustomRes,
+  editCustomReq,
+  editCustomRes,
+  deleteCustomRes,
+} from './types';
 import { State } from '../store/types';
-
-interface fetchCategoriesRes {
-  income_categories_list: [];
-  expense_categories_list: [];
-}
-
-interface addCustomReq {
-  name: string;
-  big_category_id: number;
-}
-
-interface addCustomRes {
-  category_type: string;
-  id: number;
-  name: string;
-  big_category_id: number;
-}
-
-interface editCustomReq {
-  name: string;
-  big_category_id: number;
-}
-
-interface editCustomRes {
-  category_type: string;
-  id: number;
-  name: string;
-  big_category_id: number;
-}
-
-interface deleteCustomRes {
-  message: string;
-}
 
 export const fetchCategories = () => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {

--- a/src/reducks/categories/types.ts
+++ b/src/reducks/categories/types.ts
@@ -12,5 +12,39 @@ export interface AssociatedCategory {
   name: string;
   big_category_id: number;
 }
+
 export type AssociatedCategories = Array<AssociatedCategory>;
 export type Categories = Array<Category>;
+
+export interface fetchCategoriesRes {
+  income_categories_list: [];
+  expense_categories_list: [];
+}
+
+export interface addCustomReq {
+  name: string;
+  big_category_id: number;
+}
+
+export interface addCustomRes {
+  category_type: string;
+  id: number;
+  name: string;
+  big_category_id: number;
+}
+
+export interface editCustomReq {
+  name: string;
+  big_category_id: number;
+}
+
+export interface editCustomRes {
+  category_type: string;
+  id: number;
+  name: string;
+  big_category_id: number;
+}
+
+export interface deleteCustomRes {
+  message: string;
+}

--- a/src/reducks/users/operations.ts
+++ b/src/reducks/users/operations.ts
@@ -2,39 +2,12 @@ import { signUpAction, logInAction, logOutAction } from './actions';
 import { Dispatch, Action } from 'redux';
 import { push } from 'connected-react-router';
 import axios from 'axios';
+import { SignupReq, SignupRes, LoginReq, LoginRes, LogoutRes } from './types';
 
 export const isValidEmailFormat = (email: string): boolean => {
   const regex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
   return regex.test(email);
 };
-
-interface SignupReq {
-  id: string;
-  name: string;
-  email: string;
-  password: string;
-}
-
-interface SignupRes {
-  id: string;
-  name: string;
-  email: string;
-}
-
-interface LoginReq {
-  email: string;
-  password: string;
-}
-
-interface LoginRes {
-  id: string;
-  name: string;
-  email: string;
-}
-
-interface LogoutRes {
-  message: string;
-}
 
 export const signUp = (
   userId: string,

--- a/src/reducks/users/types.ts
+++ b/src/reducks/users/types.ts
@@ -5,3 +5,31 @@ export interface UserState {
   password: string;
   confirm_password: string;
 }
+
+export interface SignupReq {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+}
+
+export interface SignupRes {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface LoginReq {
+  email: string;
+  password: string;
+}
+
+export interface LoginRes {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export interface LogoutRes {
+  message: string;
+}


### PR DESCRIPTION
users, categories, budgetsのoperationsで定義していたrequest, responseの型定義をtypes.tsに移動し、
importして使用する形に修正。
