### PR TITLE
Modify initialState and types in YearlyBudget

### DIFF
--- a/src/reducks/budgets/actions.ts
+++ b/src/reducks/budgets/actions.ts
@@ -1,4 +1,4 @@
-import { StandardBudgetsList, FetchYearlyBudgetsList, CustomBudgetsList } from './types';
+import { StandardBudgetsList, YearlyBudgetsList, CustomBudgetsList } from './types';
 export type budgetsActions = ReturnType<
   typeof updateStandardBudgets | typeof fetchYearlyBudgets | typeof updateCustomBudgets
 >;
@@ -15,8 +15,8 @@ export const updateStandardBudgets = (
 
 export const FETCH_YEARLY_BUDGETS = 'FETCH_YEARLY_BUDGETS';
 export const fetchYearlyBudgets = (
-  yearly_budgets_list: FetchYearlyBudgetsList
-): { type: string; payload: FetchYearlyBudgetsList } => {
+  yearly_budgets_list: YearlyBudgetsList
+): { type: string; payload: YearlyBudgetsList } => {
   return {
     type: FETCH_YEARLY_BUDGETS,
     payload: yearly_budgets_list,

--- a/src/reducks/budgets/operations.ts
+++ b/src/reducks/budgets/operations.ts
@@ -8,7 +8,7 @@ import {
   editStandardBudgetsReq,
   fetchCustomBudgetsRes,
   fetchStandardBudgetsRes,
-  FetchYearlyBudgetsList,
+  YearlyBudgetsList,
   StandardBudgetsList,
   StandardBudgetsListRes,
 } from './types';
@@ -81,7 +81,7 @@ export const editStandardBudgets = (budgets: editStandardBudgetsReq) => {
 export const getYearlyBudgets = () => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {
     await axios
-      .get<FetchYearlyBudgetsList>('http://127.0.0.1:8081/budgets/2020', {
+      .get<YearlyBudgetsList>('http://127.0.0.1:8081/budgets/2020', {
         withCredentials: true,
       })
       .then((res) => {

--- a/src/reducks/budgets/types.ts
+++ b/src/reducks/budgets/types.ts
@@ -10,10 +10,10 @@ export interface MonthlyBudget {
   monthly_total_budget: number;
 }
 
-export interface FetchYearlyBudget {
+export interface YearlyBudgetsList {
   year: Date;
   yearly_total_budget: number;
-  monthly_budgets: MonthlyBudget;
+  monthly_budgets: MonthlyBudgetsList;
 }
 
 export interface StandardBudgetsListRes {
@@ -21,7 +21,6 @@ export interface StandardBudgetsListRes {
 }
 export interface StandardBudgetsList extends Array<Budget> {}
 export interface MonthlyBudgetsList extends Array<MonthlyBudget> {}
-export interface FetchYearlyBudgetsList extends Array<FetchYearlyBudget> {}
 export interface CustomBudgetsList extends Array<Budget> {}
 
 export interface fetchStandardBudgetsRes {

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -8,7 +8,11 @@ const initialState = {
   },
   budgets: {
     standard_budgets_list: [],
-    yearly_budgets_list: [],
+    yearly_budgets_list: {
+      year: '',
+      yearly_total_budget: 0,
+      monthly_budgets: [],
+    },
     custom_budgets_list: [],
   },
   users: {

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -1,7 +1,7 @@
 import { Categories } from '../categories/types';
 import { Groups } from '../groups/types';
 import { TransactionsList } from '../transactions/types';
-import { StandardBudgetsList, FetchYearlyBudgetsList, CustomBudgetsList } from '../budgets/types';
+import { StandardBudgetsList, YearlyBudgetsList, CustomBudgetsList } from '../budgets/types';
 import { TodoLists } from '../todoLists/types';
 import { GroupTodoLists } from '../groupTodoLists/types';
 
@@ -15,7 +15,7 @@ export interface State {
   };
   budgets: {
     standard_budgets_list: StandardBudgetsList;
-    yearly_budgets_list: FetchYearlyBudgetsList;
+    yearly_budgets_list: YearlyBudgetsList;
     custom_budgets_list: CustomBudgetsList;
   };
   users: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "downlevelIteration": true,
     "target": "es5",
     "lib": [
       "dom",


### PR DESCRIPTION
- yearlyBudgetsのinitialStateとtypesを修正しました。

- yearlyBudgetsのtypeを修正後に、budgetsのreducerの方で`downlevelIteration`のオプションを追加するように
  というエラーが表示されるようになったのでts.config.jsonに`"downlevelIteration": true,`を追加しました。

確認よろしくお願いします。