### PR TITLE
Add test for editCustomBudgets function

### DIFF
--- a/src/reducks/budgets/operations.ts
+++ b/src/reducks/budgets/operations.ts
@@ -8,7 +8,7 @@ import {
   fetchCustomBudgetsRes,
   CustomBudgetsList,
   BudgetsReq,
-  AddCustomBudgetsRes,
+  CustomBudgetsRes,
   fetchStandardBudgetsRes,
   YearlyBudgetsList,
   StandardBudgetsList,
@@ -143,7 +143,7 @@ export const addCustomBudgets = (
     }
 
     await axios
-      .post<AddCustomBudgetsRes>(
+      .post<CustomBudgetsRes>(
         `http://127.0.0.1:8081/custom-budgets/${selectYear}-${selectMonth}`,
         JSON.stringify(data),
         {
@@ -184,7 +184,7 @@ export const editCustomBudgets = (
     }
 
     await axios
-      .put<AddCustomBudgetsRes>(
+      .put<CustomBudgetsRes>(
         `http://127.0.0.1:8081/custom-budgets/${selectYear}-${selectMonth}`,
         JSON.stringify(data),
         {
@@ -205,7 +205,7 @@ export const editCustomBudgets = (
           }
           return standardBudget;
         });
-        dispatch(updateStandardBudgets(nextCustomBudgetsList));
+        dispatch(updateCustomBudgets(nextCustomBudgetsList));
       })
       .catch((error) => {
         if (error && error.response) {

--- a/src/reducks/budgets/types.ts
+++ b/src/reducks/budgets/types.ts
@@ -35,7 +35,7 @@ export interface BudgetReq {
   big_category_id: number;
   budget: number;
 }
-export interface AddCustomBudgetsRes {
+export interface CustomBudgetsRes {
   custom_budgets: Budget[];
 }
 

--- a/test/budgets-test/Budgets.test.tsx
+++ b/test/budgets-test/Budgets.test.tsx
@@ -10,12 +10,14 @@ import {
   getYearlyBudgets,
   fetchCustomBudgets,
   addCustomBudgets,
+  editCustomBudgets,
 } from '../../src/reducks/budgets/operations';
 import standardBudgets from './fetchBudgetsResponse.json';
 import yearlyBudgets from './fetchYearlyBudgetsResponse.json';
 import customBudgets from './fetchCustomBudgetsResponse.json';
 import editBudgets from './editBudgetsResponse.json';
 import addCustomBudget from './addCustomBudgetsResponse.json';
+import editCustomBudget from './editCustomBudgetsResponse.json';
 
 const axiosMock = new axiosMockAdapter(axios);
 const middlewares = [thunk];
@@ -23,6 +25,9 @@ const mockStore = configureStore(middlewares);
 process.on('unhandledRejection', console.dir);
 
 describe('async actions fetchBudgets', () => {
+  beforeEach(() => {
+    store.clearActions();
+  });
   const store = mockStore({ budgets: { standard_budgets_list: [] } });
   const url = 'http://127.0.0.1:8081/standard-budgets';
 
@@ -44,6 +49,9 @@ describe('async actions fetchBudgets', () => {
 });
 
 describe('async actions editStandardBudgets', () => {
+  beforeEach(() => {
+    store.clearActions();
+  });
   const store = mockStore({ standardBudgets });
   const url = 'http://127.0.0.1:8081/standard-budgets';
 
@@ -142,6 +150,9 @@ describe('async actions editStandardBudgets', () => {
 });
 
 describe('async actions getYearlyBudgets', () => {
+  beforeEach(() => {
+    store.clearActions();
+  });
   const store = mockStore({ budgets: { yearly_budgets_list: [] } });
   const url = 'http://127.0.0.1:8081/budgets/2020';
 
@@ -163,6 +174,9 @@ describe('async actions getYearlyBudgets', () => {
 });
 
 describe('async actions getCustomBudgets', () => {
+  beforeEach(() => {
+    store.clearActions();
+  });
   const selectYear = '2020';
   const selectMonth = '07';
   const store = mockStore({ budgets: { custom_budgets_list: [] } });
@@ -186,6 +200,9 @@ describe('async actions getCustomBudgets', () => {
 });
 
 describe('async actions addCustomBudgets', () => {
+  beforeEach(() => {
+    store.clearActions();
+  });
   const selectYear = '2020';
   const selectMonth = '07';
   const store = mockStore({ customBudgets });
@@ -270,13 +287,121 @@ describe('async actions addCustomBudgets', () => {
       },
     ];
 
-    axiosMock.onPost(url).reply(200, mockCustomBudgets);
+    axiosMock.onPost(url).reply(201, mockCustomBudgets);
 
     await addCustomBudgets(
       selectYear,
       selectMonth,
       nextCustomBudgets.custom_budgets
     )(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe('async actions editCustomBudgets', () => {
+  beforeEach(() => {
+    store.clearActions();
+  });
+  const selectYear = '2020';
+  const selectMonth = '07';
+  const store = mockStore({ addCustomBudget });
+  const url = `http://127.0.0.1:8081/custom-budgets/${selectYear}-${selectMonth}`;
+
+  it('Edit custom_budgets if fetch succeeds', async () => {
+    const getState = () => {
+      return {
+        budgets: {
+          custom_budgets_list: customBudgets.custom_budgets,
+        },
+      };
+    };
+
+    const nextCustomBudgets = {
+      custom_budgets: [
+        {
+          big_category_id: 2,
+          budget: 38000,
+        },
+        {
+          big_category_id: 3,
+          budget: 4000,
+        },
+        {
+          big_category_id: 4,
+          budget: 7500,
+        },
+        {
+          big_category_id: 5,
+          budget: 1000,
+        },
+        {
+          big_category_id: 6,
+          budget: 1000,
+        },
+        {
+          big_category_id: 7,
+          budget: 0,
+        },
+        {
+          big_category_id: 8,
+          budget: 4900,
+        },
+        {
+          big_category_id: 9,
+          budget: 4400,
+        },
+        {
+          big_category_id: 10,
+          budget: 10000,
+        },
+        {
+          big_category_id: 11,
+          budget: 15000,
+        },
+        {
+          big_category_id: 12,
+          budget: 3000,
+        },
+        {
+          big_category_id: 13,
+          budget: 0,
+        },
+        {
+          big_category_id: 14,
+          budget: 3800,
+        },
+        {
+          big_category_id: 15,
+          budget: 0,
+        },
+        {
+          big_category_id: 16,
+          budget: 0,
+        },
+        {
+          big_category_id: 17,
+          budget: 0,
+        },
+      ],
+    };
+
+    const mockCustomBudgets = editCustomBudget;
+
+    const expectedActions = [
+      {
+        type: actionTypes.UPDATE_CUSTOM_BUDGETS,
+        payload: mockCustomBudgets.custom_budgets,
+      },
+    ];
+
+    axiosMock.onPut(url).reply(200, mockCustomBudgets);
+
+    await editCustomBudgets(
+      selectYear,
+      selectMonth,
+      nextCustomBudgets.custom_budgets
+      // @ts-ignore
+    )(store.dispatch, getState);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/test/budgets-test/editCustomBudgetsResponse.json
+++ b/test/budgets-test/editCustomBudgetsResponse.json
@@ -1,0 +1,84 @@
+{
+  "custom_budgets": [
+    {
+      "big_category_id": 2,
+      "big_category_name": "食費",
+      "budget": 38000
+    },
+    {
+      "big_category_id": 3,
+      "big_category_name": "日用品",
+      "budget": 4000
+    },
+    {
+      "big_category_id": 4,
+      "big_category_name": "趣味・娯楽",
+      "budget": 7500
+    },
+    {
+      "big_category_id": 5,
+      "big_category_name": "交際費",
+      "budget": 1000
+    },
+    {
+      "big_category_id": 6,
+      "big_category_name": "交通費",
+      "budget": 1000
+    },
+    {
+      "big_category_id": 7,
+      "big_category_name": "衣服・美容",
+      "budget": 0
+    },
+    {
+      "big_category_id": 8,
+      "big_category_name": "健康・医療",
+      "budget": 4900
+    },
+    {
+      "big_category_id": 9,
+      "big_category_name": "通信費",
+      "budget": 4400
+    },
+    {
+      "big_category_id": 10,
+      "big_category_name": "教養・教育",
+      "budget": 10000
+    },
+    {
+      "big_category_id": 11,
+      "big_category_name": "住宅",
+      "budget": 15000
+    },
+    {
+      "big_category_id": 12,
+      "big_category_name": "水道・光熱費",
+      "budget": 3000
+    },
+    {
+      "big_category_id": 13,
+      "big_category_name": "自動車",
+      "budget": 0
+    },
+    {
+      "big_category_id": 14,
+      "big_category_name": "保険",
+      "budget": 3800
+    },
+    {
+      "big_category_id": 15,
+      "big_category_name": "税金・社会保険",
+      "budget": 0
+    },
+    {
+      "big_category_id": 16,
+      "big_category_name": "現金・カード",
+      "budget": 0
+    },
+    {
+      "big_category_id": 17,
+      "big_category_name": "その他",
+      "budget": 0
+    }
+  ]
+}


### PR DESCRIPTION
-カスタム予算を編集する処理を行うeditCustomBudgets関数のテストを実装しました。

-editCustomBudgetsのactionTypeをupdateStandardBudgetsとしていたので、updateCustomBudgetsに修正しました。

-budgetsのテストでは、 store.clearActions()を実装していなかったので追加しました。

確認よろしくお願いします。