### PR TITLE
Modify fetch yearly budgets and fetch transactions list

### DIFF
--- a/src/components/budget/YearlyBudgetsRow.tsx
+++ b/src/components/budget/YearlyBudgetsRow.tsx
@@ -16,6 +16,7 @@ import CreateIcon from '@material-ui/icons/Create';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { standardBudgetType } from '../../lib/constant';
+import { getStandardBudgets, getYearlyBudgets } from '../../reducks/budgets/selectors';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -33,8 +34,10 @@ interface YearlyBudgetsRowProps {
 const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
   const classes = useStyles();
   const dispatch = useDispatch();
+  const year = props.years;
   const selector = useSelector((state: State) => state);
-  const yearlyBudgets = selector.budgets.yearly_budgets_list;
+  const standardBudgets = getStandardBudgets(selector);
+  const yearlyBudgets = getYearlyBudgets(selector);
   const [yearBudget, setYearBudget] = useState<YearlyBudgetsList>({
     year: '',
     yearly_total_budget: 0,
@@ -42,12 +45,12 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
   });
 
   useEffect(() => {
-    dispatch(fetchStandardBudgets());
+    if (standardBudgets) dispatch(fetchStandardBudgets());
   }, []);
 
   useEffect(() => {
-    dispatch(fetchYearlyBudgets());
-  }, []);
+    dispatch(fetchYearlyBudgets(year));
+  }, [year]);
 
   useEffect(() => {
     setYearBudget(yearlyBudgets);
@@ -65,7 +68,7 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
       };
       const selectYear = budget.month.slice(0, 4);
       const selectMonth = budget.month.slice(5, 7);
-      const lastDate = new Date(props.years, Number(selectMonth), 0).getDate();
+      const lastDate = new Date(year, Number(selectMonth), 0).getDate();
       return (
         <TableRow key={index}>
           <TableCell className={classes.tableSize} component="th" scope="row">

--- a/src/components/uikit/InputModal.tsx
+++ b/src/components/uikit/InputModal.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { addTransactions } from '../../reducks/transactions/operations';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Modal from '@material-ui/core/Modal';
 import IconButton from '@material-ui/core/IconButton';
 import CreateIcon from '@material-ui/icons/Create';
-import DeleteIcon from '@material-ui/icons/Delete';
 import { GenericButton, DatePicker, CategoryInput, TextInput, KindSelectBox } from '../uikit/index';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -18,7 +19,7 @@ const useStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(1, 2, 2),
     },
     buttonPosition: {
-      display: 'flex',
+      textAlign: 'center',
     },
     smallSpaceRight: {
       marginRight: 40,
@@ -37,6 +38,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 const InputModal = () => {
   const classes = useStyles();
+  const dispatch = useDispatch();
   const [open, setOpen] = useState<boolean>(false);
   const [amount, setAmount] = useState<string>('');
   const [memo, setMemo] = useState<string>('');
@@ -177,16 +179,24 @@ const InputModal = () => {
       </form>
       <div className={classes.smallSpaceTop} />
       <div className={classes.buttonPosition}>
-        <IconButton
-          className={classes.smallSpaceRight}
-          color={'inherit'}
-          onClick={() => console.log(bigCategoryId, mediumCategoryId, customCategoryId)}
-          size={'small'}
-        >
-          <DeleteIcon />
-          削除する
-        </IconButton>
-        <GenericButton label={'更新する'} onClick={handleClose} disabled={false} />
+        <GenericButton
+          label={'更新する'}
+          onClick={() =>
+            dispatch(
+              addTransactions(
+                transactionsType,
+                transactionDate,
+                shop,
+                memo,
+                amount,
+                bigCategoryId,
+                mediumCategoryId,
+                customCategoryId
+              )
+            ) && handleClose()
+          }
+          disabled={false}
+        />
       </div>
     </div>
   );

--- a/src/reducks/budgets/operations.ts
+++ b/src/reducks/budgets/operations.ts
@@ -77,10 +77,10 @@ export const editStandardBudgets = (budgets: BudgetsReq) => {
   };
 };
 
-export const fetchYearlyBudgets = () => {
+export const fetchYearlyBudgets = (year: number) => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {
     await axios
-      .get<YearlyBudgetsList>(`${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/2020`, {
+      .get<YearlyBudgetsList>(`${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/${year}`, {
         withCredentials: true,
       })
       .then((res) => {

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -12,12 +12,15 @@ import {
 import moment from 'moment';
 import { isValidAmountFormat, errorHandling } from '../../lib/validation';
 
-export const fetchTransactionsList = () => {
+export const fetchTransactionsList = (year: string, customMonth: string) => {
   return async (dispatch: Dispatch<Action>) => {
     await axios
-      .get<fetchTransactionsRes>(`${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/2020-07`, {
-        withCredentials: true,
-      })
+      .get<fetchTransactionsRes>(
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${customMonth}`,
+        {
+          withCredentials: true,
+        }
+      )
       .then((res) => {
         if (res.data.message) {
           alert(res.data.message);
@@ -190,7 +193,7 @@ export const deleteTransactions = (id: number) => {
         }
       )
       .then((res) => {
-        const message = res.data;
+        const message = res.data.message;
 
         const nextTransactionsList = transactionsList.filter((transaction) => {
           if (transaction.id !== id) {

--- a/test/budgets-test/Budgets.test.tsx
+++ b/test/budgets-test/Budgets.test.tsx
@@ -155,8 +155,10 @@ describe('async actions getYearlyBudgets', () => {
   beforeEach(() => {
     store.clearActions();
   });
+  const date = new Date();
+  const year = date.getFullYear();
   const store = mockStore({ budgets: { yearly_budgets_list: [] } });
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/2020`;
+  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/${year}`;
 
   it('Get yearly_budgets if fetch succeeds', async () => {
     const mockYearlyBudgets = yearlyBudgets;
@@ -170,7 +172,7 @@ describe('async actions getYearlyBudgets', () => {
 
     axiosMock.onGet(url).reply(200, mockYearlyBudgets);
 
-    await fetchYearlyBudgets()(store.dispatch);
+    await fetchYearlyBudgets(year)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/test/transactions-test/Transactions.test.tsx
+++ b/test/transactions-test/Transactions.test.tsx
@@ -24,7 +24,11 @@ process.on('unhandledRejection', console.dir);
 
 describe('async actions fetchTransactionsList', () => {
   const store = mockStore({ transactionsList: [] });
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/2020-07`;
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const customMonth = ('0' + month).slice(-2);
+  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${customMonth}`;
 
   beforeEach(() => {
     store.clearActions();
@@ -42,7 +46,7 @@ describe('async actions fetchTransactionsList', () => {
 
     axiosMock.onGet(url).reply(200, fetchResTransactions);
 
-    await fetchTransactionsList()(store.dispatch);
+    await fetchTransactionsList(String(year), customMonth)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAddActions);
   });
 });


### PR DESCRIPTION
- 年別の予算を取得する処理を行うfetchYearlyBudgetsを選択された年のデーターを取得するように修正しました。

- 家計簿入力データーを取得するfetchTransactionsListを現在の年と月のデーターを取得するように修正しました。

- 現在の月の家計簿入力履歴を表示するMonthlyHistoryに入力されたtransactionsListを表示するように修正しました。

- InputModalで家計簿入力を行えるように家計簿入力処理を行うaddTransactions functionを追加しました。

確認よろしくお願いします。

