### PR TITLE
Add groupYearlyBudgets reducers and operations and test

### DIFF
--- a/src/components/budget/YearlyBudgetsRow.tsx
+++ b/src/components/budget/YearlyBudgetsRow.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  fetchYearlyBudgets,
-  deleteCustomBudgets,
-  fetchStandardBudgets,
-} from '../../reducks/budgets/operations';
+import { fetchYearlyBudgets, deleteCustomBudgets } from '../../reducks/budgets/operations';
 import { YearlyBudgetsList } from '../../reducks/budgets/types';
 import { State } from '../../reducks/store/types';
 import TableRow from '@material-ui/core/TableRow';
@@ -15,7 +11,7 @@ import CreateIcon from '@material-ui/icons/Create';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { standardBudgetType } from '../../lib/constant';
-import { getStandardBudgets, getYearlyBudgets } from '../../reducks/budgets/selectors';
+import { getYearlyBudgets } from '../../reducks/budgets/selectors';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -35,17 +31,12 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
   const dispatch = useDispatch();
   const year = props.years;
   const selector = useSelector((state: State) => state);
-  const standardBudgets = getStandardBudgets(selector);
   const yearlyBudgets = getYearlyBudgets(selector);
   const [yearBudget, setYearBudget] = useState<YearlyBudgetsList>({
     year: '',
     yearly_total_budget: 0,
     monthly_budgets: [],
   });
-
-  useEffect(() => {
-    if (standardBudgets) dispatch(fetchStandardBudgets());
-  }, []);
 
   useEffect(() => {
     dispatch(fetchYearlyBudgets(year));

--- a/src/reducks/groupBudgets/operations.ts
+++ b/src/reducks/groupBudgets/operations.ts
@@ -1,7 +1,12 @@
-import { updateGroupStandardBudgetsActions } from './actions';
+import { updateGroupStandardBudgetsActions, fetchGroupYearlyBudgetsActions } from './actions';
 import axios from 'axios';
 import { Action, Dispatch } from 'redux';
-import { GroupStandardBudgetsList, GroupStandardBudgetsListRes, GroupBudgetsReq } from './types';
+import {
+  GroupStandardBudgetsList,
+  GroupStandardBudgetsListRes,
+  GroupBudgetsReq,
+  GroupYearlyBudgetsList,
+} from './types';
 import { errorHandling, isValidBudgetFormat } from '../../lib/validation';
 import { State } from '../store/types';
 
@@ -61,6 +66,25 @@ export const editGroupStandardBudgets = (groupBudgets: GroupBudgetsReq) => {
         });
 
         dispatch(updateGroupStandardBudgetsActions(nextGroupStandardBudgetsList));
+      })
+      .catch((error) => {
+        errorHandling(dispatch, error);
+      });
+  };
+};
+
+export const fetchGroupYearlyBudgets = () => {
+  return async (dispatch: Dispatch<Action>): Promise<void> => {
+    await axios
+      .get<GroupYearlyBudgetsList>(
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/1/budgets/2020`,
+        {
+          withCredentials: true,
+        }
+      )
+      .then((res) => {
+        const groupYearlyBudgetsList = res.data;
+        dispatch(fetchGroupYearlyBudgetsActions(groupYearlyBudgetsList));
       })
       .catch((error) => {
         errorHandling(dispatch, error);

--- a/src/reducks/groupBudgets/reducers.ts
+++ b/src/reducks/groupBudgets/reducers.ts
@@ -12,6 +12,11 @@ export const groupBudgetsReducer = (
         ...state,
         groupStandardBudgetsList: [...action.payload],
       };
+    case Actions.FETCH_GROUP_YEARLY_BUDGETS:
+      return {
+        ...state,
+        groupYearlyBudgetsList: action.payload,
+      };
     default:
       return state;
   }

--- a/test/group-budgets-test/GroupBudgets.test.tsx
+++ b/test/group-budgets-test/GroupBudgets.test.tsx
@@ -7,9 +7,11 @@ import configureStore from 'redux-mock-store';
 import {
   fetchGroupStandardBudgets,
   editGroupStandardBudgets,
+  fetchGroupYearlyBudgets,
 } from '../../src/reducks/groupBudgets/operations';
 import groupStandardBudgets from './fetchGroupStandardBudgetsResponse.json';
 import groupEditedStandardBudgets from './editGroupStandardBudgetsResponse.json';
+import groupYearlyBudgets from './fetchGroupYearlyBudgetsResponse.json';
 
 const axiosMock = new axiosMockAdapter(axios);
 const middlewares = [thunk];
@@ -144,6 +146,35 @@ describe('async actions editGroupStandardBudgets', () => {
       // @ts-ignore
       getState
     );
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+});
+
+describe('async actions getGroupYearlyBudgets', () => {
+  beforeEach(() => {
+    store.clearActions();
+  });
+  const store = mockStore({ groupBudgets: { groupYearlyBudgetsList: [] } });
+
+  const date = new Date();
+  const year = date.getFullYear();
+
+  const groupId = 1;
+  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${year}`;
+
+  it('Get groupYearlyBudgets if fetch succeeds', async () => {
+    const mockResponse = groupYearlyBudgets;
+
+    const expectedActions = [
+      {
+        type: actionTypes.FETCH_GROUP_YEARLY_BUDGETS,
+        payload: mockResponse,
+      },
+    ];
+
+    axiosMock.onGet(url).reply(200, mockResponse);
+
+    await fetchGroupYearlyBudgets()(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/test/group-budgets-test/fetchGroupYearlyBudgetsResponse.json
+++ b/test/group-budgets-test/fetchGroupYearlyBudgetsResponse.json
@@ -1,0 +1,66 @@
+{
+  "year": "2020-01-01T00:00:00Z",
+  "yearly_total_budget": 900000,
+  "monthly_budgets": [
+    {
+      "month": "2020年01月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 100000
+    },
+    {
+      "month": "2020年02月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 70000
+    },
+    {
+      "month": "2020年03月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 70000
+    },
+    {
+      "month": "2020年04月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 70000
+    },
+    {
+      "month": "2020年05月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 70000
+    },
+    {
+      "month": "2020年06月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 70000
+    },
+    {
+      "month": "2020年07月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 100000
+    },
+    {
+      "month": "2020年08月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 70000
+    },
+    {
+      "month": "2020年09月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 70000
+    },
+    {
+      "month": "2020年10月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 70000
+    },
+    {
+      "month": "2020年11月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 70000
+    },
+    {
+      "month": "2020年12月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 100000
+    }
+  ]
+}


### PR DESCRIPTION
- グループの年別予算を取得するfetchGroupYearlyBudgetsを実装しました。

- fetchGroupYearlyBudgetsのテストを実装しました。

- YearlyBudgetsRowで不要にStandardBudgetsを取得していたのでfetchStandardBudgetsを削除しました。

確認よろしくお願いします。