### PR TITLE
Add a reducer for groupCustomBudgetsList and an action and reducer an…

### DIFF
--- a/src/reducks/groupBudgets/actions.ts
+++ b/src/reducks/groupBudgets/actions.ts
@@ -35,3 +35,13 @@ export const updateGroupCustomBudgetsActions = (
     payload: groupCustomBudgetsList,
   };
 };
+
+export const COPY_GROUP_STANDARD_BUDGETS = 'COPY_GROUP_STANDARD_BUDGETS';
+export const copyGroupStandardBudgetsActions = (
+  groupCustomBudgetsList: GroupCustomBudgetsList
+): { type: string; payload: GroupCustomBudgetsList } => {
+  return {
+    type: COPY_GROUP_STANDARD_BUDGETS,
+    payload: groupCustomBudgetsList,
+  };
+};

--- a/src/reducks/groupBudgets/operations.ts
+++ b/src/reducks/groupBudgets/operations.ts
@@ -1,8 +1,13 @@
-import { updateGroupStandardBudgetsActions, fetchGroupYearlyBudgetsActions } from './actions';
+import {
+  updateGroupStandardBudgetsActions,
+  fetchGroupYearlyBudgetsActions,
+  copyGroupStandardBudgetsActions,
+} from './actions';
 import axios from 'axios';
 import { Action, Dispatch } from 'redux';
 import {
   GroupStandardBudgetsList,
+  GroupCustomBudgetsList,
   GroupStandardBudgetsListRes,
   GroupBudgetsReq,
   GroupYearlyBudgetsList,
@@ -89,5 +94,25 @@ export const fetchGroupYearlyBudgets = () => {
       .catch((error) => {
         errorHandling(dispatch, error);
       });
+  };
+};
+
+export const copyGroupStandardBudgets = () => {
+  return (dispatch: Dispatch<Action>, getState: () => State) => {
+    const groupStandardBudgets: GroupStandardBudgetsList = getState().groupBudgets
+      .groupStandardBudgetsList;
+
+    const groupCustomBudgets: GroupCustomBudgetsList = getState().groupBudgets
+      .groupCustomBudgetsList;
+
+    const nextGroupCustomBudgets = groupStandardBudgets.map((groupStandardBudget) => {
+      groupCustomBudgets.map((groupCustomBudget) => {
+        return (groupCustomBudget.budget = groupStandardBudget.budget);
+      });
+
+      return groupStandardBudget;
+    });
+
+    dispatch(copyGroupStandardBudgetsActions(nextGroupCustomBudgets));
   };
 };

--- a/src/reducks/groupBudgets/reducers.ts
+++ b/src/reducks/groupBudgets/reducers.ts
@@ -17,6 +17,16 @@ export const groupBudgetsReducer = (
         ...state,
         groupYearlyBudgetsList: action.payload,
       };
+    case Actions.UPDATE_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        groupCustomBudgetsList: [...action.payload],
+      };
+    case Actions.COPY_GROUP_STANDARD_BUDGETS:
+      return {
+        ...state,
+        groupCustomBudgetsList: [...action.payload],
+      };
     default:
       return state;
   }


### PR DESCRIPTION
- グループのカスタム予算のreudcersを追加しました。

- グループのカスタム予算を追加する際に標準予算を表示させた状態でカスタム予算が追加される流れになっておりgroupCustomBudgets 
  にgroupStandardBudgetsをコピーする処理が必要なのでコピー処理を行うcopyGroupStandardBudgetsを実装しました。


確認よろしくお願いします。