### PR TITLE
Add a message state to fetchTransactions

### DIFF
--- a/src/assets/home/monthly-history.scss
+++ b/src/assets/home/monthly-history.scss
@@ -43,8 +43,7 @@ $large-font_weight:700;
   &__record-second{
     border: solid 1px $border_color;
     padding: 6px;
-    height: auto;
-    min-height: 250px;
+    height: 350px;
     vertical-align: top;
     width: 130px;
   }

--- a/src/components/home/MonthlyHistory.tsx
+++ b/src/components/home/MonthlyHistory.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchTransactionsList } from '../../reducks/transactions/operations';
 import { State } from '../../reducks/store/types';
-import { getTransactions } from '../../reducks/transactions/selectors';
+import { getTransactions, getTransactionsMessage } from '../../reducks/transactions/selectors';
 import { year, month, customMonth } from '../../lib/constant';
 import '../../assets/home/monthly-history.scss';
 import '../../assets/modules/button.scss';
@@ -13,6 +13,8 @@ const MonthlyHistory = () => {
   const dispatch = useDispatch();
   const selector = useSelector((state: State) => state);
   const transactionsList = getTransactions(selector);
+  const message = getTransactionsMessage(selector);
+  console.log(message);
 
   useEffect(() => {
     dispatch(fetchCategories());
@@ -115,6 +117,7 @@ const MonthlyHistory = () => {
   return (
     <div className="box__monthlyExpense">
       <h2>{month}月の支出</h2>
+      {message !== '' && <h3>{message}</h3>}
       <table className="monthlyhistory-table">
         <tbody className="monthlyhistory-table__tbody">
           <tr className="monthlyhistory-table__thead">{rows().headerRow}</tr>

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -9,6 +9,7 @@ const initialState = {
   },
   transactions: {
     transactionsList: [],
+    noTransactionsMessage: '',
   },
   groupTransactions: {
     groupTransactionsList: [],

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -24,6 +24,7 @@ export interface State {
   };
   transactions: {
     transactionsList: TransactionsList;
+    noTransactionsMessage: string;
   };
   groupTransactions: {
     groupTransactionsList: GroupTransactionsList;

--- a/src/reducks/transactions/actions.ts
+++ b/src/reducks/transactions/actions.ts
@@ -5,18 +5,20 @@ export type transactionActions = ReturnType<
 
 export const FETCH_TRANSACTIONS = 'FETCH_TRANSACTIONS';
 export const fetchTransactions = (
-  transactionsList: TransactionsList
-): { type: string; payload: TransactionsList } => {
+  transactionsList: TransactionsList,
+  noTransactionsMessage: string
+) => {
   return {
     type: FETCH_TRANSACTIONS,
-    payload: transactionsList,
+    payload: {
+      transactionsList,
+      noTransactionsMessage,
+    },
   };
 };
 
 export const UPDATE_TRANSACTIONS = 'UPDATE_TRANSACTIONS';
-export const updateTransactionsAction = (
-  transactionsList: TransactionsList
-): { type: string; payload: TransactionsList } => {
+export const updateTransactionsAction = (transactionsList: TransactionsList) => {
   return {
     type: UPDATE_TRANSACTIONS,
     payload: transactionsList,

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -23,7 +23,6 @@ export const fetchTransactionsList = (year: string, customMonth: string) => {
         }
       )
       .then((res) => {
-        console.log(res.data);
         const resMessage = res.data.message;
         const transactionsList = res.data.transactions_list;
 

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -4,10 +4,11 @@ import { Dispatch, Action } from 'redux';
 import { push } from 'connected-react-router';
 import { State } from '../store/types';
 import {
-  fetchTransactionsRes,
-  transactionsReq,
-  transactionsRes,
-  deleteTransactionRes,
+  TransactionsList,
+  FetchTransactionsRes,
+  TransactionsReq,
+  TransactionsRes,
+  DeleteTransactionRes,
 } from './types';
 import moment from 'moment';
 import { isValidAmountFormat, errorHandling } from '../../lib/validation';
@@ -15,22 +16,29 @@ import { isValidAmountFormat, errorHandling } from '../../lib/validation';
 export const fetchTransactionsList = (year: string, customMonth: string) => {
   return async (dispatch: Dispatch<Action>) => {
     await axios
-      .get<fetchTransactionsRes>(
+      .get<FetchTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${customMonth}`,
         {
           withCredentials: true,
         }
       )
       .then((res) => {
-        if (res.data.message) {
-          alert(res.data.message);
-        } else {
-          const transactionsList = res.data.transactions_list;
+        console.log(res.data);
+        const resMessage = res.data.message;
+        const transactionsList = res.data.transactions_list;
+
+        if (transactionsList !== undefined) {
+          const resMessage = '';
           const aligningTransactionsList = transactionsList.sort(
             (a, b) =>
               Number(a.transaction_date.slice(8, 10)) - Number(b.transaction_date.slice(8, 10))
           );
-          dispatch(fetchTransactions(aligningTransactionsList));
+
+          dispatch(fetchTransactions(aligningTransactionsList, resMessage));
+        } else {
+          const emptyTransactionsList: TransactionsList = [];
+
+          dispatch(fetchTransactions(emptyTransactionsList, resMessage));
         }
       })
       .catch((error) => {
@@ -62,7 +70,7 @@ export const addTransactions = (
       alert('金額は数字で入力してください。');
     }
 
-    const data: transactionsReq = {
+    const data: TransactionsReq = {
       transaction_type: transaction_type,
       transaction_date: transaction_date,
       shop: shop,
@@ -73,7 +81,7 @@ export const addTransactions = (
       custom_category_id: custom_category_id,
     };
     await axios
-      .post<transactionsRes>(
+      .post<TransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions`,
         JSON.stringify(data, function (key, value) {
           if (key === 'transaction_date') {
@@ -103,7 +111,7 @@ export const addTransactions = (
           dispatch(push('/login'));
         }
 
-        if (error.reponse.status === 500) {
+        if (error.response.status === 500) {
           alert(error.response.data.error.message);
         }
       });
@@ -136,7 +144,7 @@ export const editTransactions = (
 
     const transactionsList = getState().transactions.transactionsList;
 
-    const data: transactionsReq = {
+    const data: TransactionsReq = {
       transaction_type: transaction_type,
       transaction_date: transaction_date,
       shop: shop,
@@ -147,7 +155,7 @@ export const editTransactions = (
       custom_category_id: custom_category_id,
     };
     await axios
-      .put<transactionsRes>(
+      .put<TransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${id}`,
         JSON.stringify(data),
         {
@@ -186,7 +194,7 @@ export const deleteTransactions = (id: number) => {
   return async (dispatch: Dispatch<Action>, getState: () => State) => {
     const transactionsList = getState().transactions.transactionsList;
     await axios
-      .delete<deleteTransactionRes>(
+      .delete<DeleteTransactionRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${id}`,
         {
           withCredentials: true,

--- a/src/reducks/transactions/reducers.ts
+++ b/src/reducks/transactions/reducers.ts
@@ -10,7 +10,7 @@ export const transactionsReducer = (
     case Actions.FETCH_TRANSACTIONS:
       return {
         ...state,
-        transactionsList: [...action.payload],
+        ...action.payload,
       };
     case Actions.UPDATE_TRANSACTIONS:
       return {

--- a/src/reducks/transactions/selectors.ts
+++ b/src/reducks/transactions/selectors.ts
@@ -6,4 +6,9 @@ const transactionsSelector = (state: State) => state.transactions;
 export const getTransactions = createSelector(
   [transactionsSelector],
   (state) => state.transactionsList
-)
+);
+
+export const getTransactionsMessage = createSelector(
+  [transactionsSelector],
+  (state) => state.noTransactionsMessage
+);

--- a/src/reducks/transactions/types.ts
+++ b/src/reducks/transactions/types.ts
@@ -11,23 +11,12 @@ export interface FetchTransactions {
   custom_category_name?: string | null;
 }
 
-export interface AddTransactions {
-  transaction_type: string;
-  transaction_date: Date;
-  shop?: string | null;
-  memo?: string | null;
-  amount: number;
-  big_category_id: number;
-  medium_category_id?: number | null;
-  custom_category_id?: number | null;
-}
-
-export interface fetchTransactionsRes {
+export interface FetchTransactionsRes {
+  transactions_list: TransactionsList;
   message: string;
-  transactions_list: FetchTransactions[];
 }
 
-export interface transactionsReq {
+export interface TransactionsReq {
   transaction_type: string;
   transaction_date: Date | null;
   shop: string | null;
@@ -38,7 +27,7 @@ export interface transactionsReq {
   custom_category_id: number | null;
 }
 
-export interface transactionsRes {
+export interface TransactionsRes {
   id: number;
   transaction_type: string;
   updated_date: Date;
@@ -51,7 +40,7 @@ export interface transactionsRes {
   custom_category_name: string | null;
 }
 
-export interface deleteTransactionRes {
+export interface DeleteTransactionRes {
   message: string;
 }
 

--- a/test/transactions-test/Transactions.test.tsx
+++ b/test/transactions-test/Transactions.test.tsx
@@ -26,27 +26,29 @@ describe('async actions fetchTransactionsList', () => {
   const store = mockStore({ transactionsList: [] });
   const date = new Date();
   const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const customMonth = ('0' + month).slice(-2);
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${customMonth}`;
+  const month = '08';
+  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${month}`;
 
   beforeEach(() => {
     store.clearActions();
   });
 
   it('Get transactionsList if fetch succeeds', async () => {
-    const fetchResTransactions = transactionsList;
+    const mockResponse = transactionsList.transactions_list;
 
     const expectedAddActions = [
       {
         type: actionTypes.FETCH_TRANSACTIONS,
-        payload: fetchResTransactions.transactions_list,
+        payload: {
+          transactionsList: [],
+          noTransactionsMessage: undefined,
+        },
       },
     ];
 
-    axiosMock.onGet(url).reply(200, fetchResTransactions);
+    axiosMock.onGet(url).reply(200, mockResponse);
 
-    await fetchTransactionsList(String(year), customMonth)(store.dispatch);
+    await fetchTransactionsList(String(year), month)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAddActions);
   });
 });


### PR DESCRIPTION
- transactionを登録していない場合、レスポンスのメッセージをalertを表示させていましたがメッセージをstateとして管理し
  transactionが登録されていない場合は履歴にメッセージを表示させる形に修正しました。

-transactions / types の型定義を小文字で定義していましたがお思い時に統一する形に修正しました。

確認よろしくお願いします。