### PR TITLE
Add a posted date to the transaction and add a posted updated payment…

### DIFF
--- a/src/components/uikit/InputModal.tsx
+++ b/src/components/uikit/InputModal.tsx
@@ -131,7 +131,6 @@ const InputModal = (props: InputModalProps) => {
     categoryId().customCategoryId
   );
 
-  console.log(category);
   const handleAmountChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setAmount(event.target.value);

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -40,6 +40,7 @@ export const addGroupTransactions = (
   shop: string | null,
   memo: string | null,
   amount: string | number,
+  payment_user_id: string,
   big_category_id: number,
   medium_category_id: number | null,
   custom_category_id: number | null
@@ -63,6 +64,7 @@ export const addGroupTransactions = (
       shop: shop,
       memo: memo,
       amount: Number(amount),
+      payment_user_id: payment_user_id,
       big_category_id: big_category_id,
       medium_category_id: medium_category_id,
       custom_category_id: custom_category_id,
@@ -80,6 +82,7 @@ export const addGroupTransactions = (
           withCredentials: true,
         }
       );
+      console.log(result.data);
       const newGroupTransaction = result.data;
 
       const prevGroupTransactions = getState().groupTransactions.groupTransactionsList;
@@ -123,6 +126,7 @@ export const editGroupTransactions = (
   shop: string | null,
   memo: string | null,
   amount: string | number,
+  payment_user_id: string,
   big_category_id: number,
   medium_category_id: number | null,
   custom_category_id: number | null
@@ -146,6 +150,7 @@ export const editGroupTransactions = (
       shop: shop,
       memo: memo,
       amount: Number(amount),
+      payment_user_id: payment_user_id,
       big_category_id: big_category_id,
       medium_category_id: medium_category_id,
       custom_category_id: custom_category_id,
@@ -158,6 +163,7 @@ export const editGroupTransactions = (
           withCredentials: true,
         }
       );
+      console.log(result.data);
       const editedGroupTransaction = result.data;
 
       const groupTransactionsList = getState().groupTransactions.groupTransactionsList;

--- a/src/reducks/groupTransactions/types.ts
+++ b/src/reducks/groupTransactions/types.ts
@@ -1,11 +1,15 @@
 export interface GroupTransactions {
   id: number;
   transaction_type: string;
+  posted_date: Date;
   updated_date: Date;
   transaction_date: string;
   shop?: string | null;
   memo?: string | null;
   amount: number;
+  posted_user_id: string;
+  updated_user_id: string;
+  payment_user_id: string;
   big_category_name: string;
   medium_category_name?: string | null;
   custom_category_name?: string | null;
@@ -19,6 +23,7 @@ export interface GroupTransactionsReq {
   shop: string | null;
   memo: string | null;
   amount: string | number;
+  payment_user_id: string;
   big_category_id: number;
   medium_category_id: number | null;
   custom_category_id: number | null;

--- a/src/reducks/transactions/types.ts
+++ b/src/reducks/transactions/types.ts
@@ -1,6 +1,7 @@
 export interface FetchTransactions {
   id: number;
   transaction_type: string;
+  posted_date: Date;
   updated_date: Date;
   transaction_date: string;
   shop: string | null;
@@ -30,6 +31,7 @@ export interface TransactionsReq {
 export interface TransactionsRes {
   id: number;
   transaction_type: string;
+  posted_date: Date;
   updated_date: Date;
   transaction_date: string;
   shop: string | null;

--- a/test/group-transactions-test/GroupTransactions.test.tsx
+++ b/test/group-transactions-test/GroupTransactions.test.tsx
@@ -89,6 +89,8 @@ describe('async actions addGroupTransactions', () => {
       };
     };
 
+    const payment_user_id = 'suzuki';
+
     const mockResponse = addGroupTransaction;
 
     const mockGroupTransactionsList = addedGroupTransactions.transactions_list;
@@ -108,6 +110,7 @@ describe('async actions addGroupTransactions', () => {
       'ビックカメラ',
       'コーヒーメーカー',
       17000,
+      payment_user_id,
       3,
       17,
       null
@@ -160,6 +163,8 @@ describe('async actions editGroupTransactions', () => {
     const groupId = 1;
     const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${id}`;
 
+    const payment_user_id = 'suzuki';
+
     const mockResponse = editGroupTransaction;
 
     const mockGroupTransactionsList = editedGroupTransaction.transactions_list;
@@ -180,6 +185,7 @@ describe('async actions editGroupTransactions', () => {
       '虎視淡々',
       'お疲れ会',
       25000,
+      payment_user_id,
       5,
       29,
       null

--- a/test/group-transactions-test/addGroupTransactions.json
+++ b/test/group-transactions-test/addGroupTransactions.json
@@ -1,11 +1,15 @@
 {
   "id": 16,
   "transaction_type": "expense",
+  "posted_date":"2020-10-24T19:00:50Z",
   "updated_date": "2020-10-25T15:50:50Z",
   "transaction_date": "010/23(金)",
   "shop": "ビックカメラ",
   "memo": "コーヒーメーカー",
   "amount": 17000,
+  "posted_user_id": "kawasaki",
+  "updated_user_id": "tanaka",
+  "payment_user_id": "suzuki",
   "big_category_name": "日用品",
   "medium_category_name": "家電",
   "custom_category_name": null

--- a/test/group-transactions-test/addedGroupTransactions.json
+++ b/test/group-transactions-test/addedGroupTransactions.json
@@ -3,11 +3,15 @@
     {
       "id": 16,
       "transaction_type": "expense",
+      "posted_date":"2020-10-24T19:00:50Z",
       "updated_date": "2020-10-25T15:50:50Z",
       "transaction_date": "010/23(金)",
       "shop": "ビックカメラ",
       "memo": "コーヒーメーカー",
       "amount": 17000,
+      "posted_user_id": "kawasaki",
+      "updated_user_id": "tanaka",
+      "payment_user_id": "suzuki",
       "big_category_name": "日用品",
       "medium_category_name": "家電",
       "custom_category_name": null
@@ -15,11 +19,15 @@
     {
       "id": 14,
       "transaction_type": "expense",
+      "posted_date": "2020-10-25T15:48:21Z",
       "updated_date": "2020-10-25T15:50:50Z",
       "transaction_date": "010/23(金)",
       "shop": "クリエイト",
       "memo": "シャンプー",
       "amount": 900,
+      "posted_user_id": "kawasaki",
+      "updated_user_id": null,
+      "payment_user_id": "honda",
       "big_category_name": "日用品",
       "medium_category_name": "消耗品",
       "custom_category_name": null
@@ -27,11 +35,15 @@
     {
       "id": 1,
       "transaction_type": "expense",
+      "posted_date": "2020-10-24T14:48:51Z",
       "updated_date": "2020-10-20T00:08:23Z",
       "transaction_date": "10/08(木)",
       "shop": "青唐辛子",
       "memo": "みんなで焼肉",
       "amount": 28000,
+      "posted_user_id": "kawasaki",
+      "updated_user_id": "suzuki",
+      "payment_user_id": "honda",
       "big_category_name": "食費",
       "medium_category_name": "外食",
       "custom_category_name": null

--- a/test/group-transactions-test/editGroupTransactionResponse.json
+++ b/test/group-transactions-test/editGroupTransactionResponse.json
@@ -1,11 +1,15 @@
 {
   "id": 16,
   "transaction_type": "expense",
+  "posted_date":"2020-10-24T22:30:50Z",
   "updated_date": "2020-10-25T17:50:50Z",
   "transaction_date": "10/24(土)",
   "shop": "虎視淡々",
   "memo": "お疲れ会",
   "amount": 25000,
+  "posted_user_id": "kawasaki",
+  "updated_user_id": "honda",
+  "payment_user_id": "suzuki",
   "big_category_name": "交際費",
   "medium_category_name": "飲み会",
   "custom_category_name": null

--- a/test/group-transactions-test/editedGroupTransactions.json
+++ b/test/group-transactions-test/editedGroupTransactions.json
@@ -3,11 +3,15 @@
     {
       "id": 16,
       "transaction_type": "expense",
+      "posted_date":"2020-10-24T22:30:50Z",
       "updated_date": "2020-10-25T17:50:50Z",
       "transaction_date": "10/24(土)",
       "shop": "虎視淡々",
       "memo": "お疲れ会",
       "amount": 25000,
+      "posted_user_id": "kawasaki",
+      "updated_user_id": "honda",
+      "payment_user_id": "suzuki",
       "big_category_name": "交際費",
       "medium_category_name": "飲み会",
       "custom_category_name": null
@@ -15,11 +19,15 @@
     {
       "id": 14,
       "transaction_type": "expense",
+      "posted_date": "2020-10-25T15:48:21Z",
       "updated_date": "2020-10-25T15:50:50Z",
       "transaction_date": "010/23(金)",
       "shop": "クリエイト",
       "memo": "シャンプー",
       "amount": 900,
+      "posted_user_id": "kawasaki",
+      "updated_user_id": null,
+      "payment_user_id": "honda",
       "big_category_name": "日用品",
       "medium_category_name": "消耗品",
       "custom_category_name": null
@@ -27,11 +35,15 @@
     {
       "id": 1,
       "transaction_type": "expense",
+      "posted_date": "2020-10-24T14:48:51Z",
       "updated_date": "2020-10-20T00:08:23Z",
       "transaction_date": "10/08(木)",
       "shop": "青唐辛子",
       "memo": "みんなで焼肉",
       "amount": 28000,
+      "posted_user_id": "kawasaki",
+      "updated_user_id": "suzuki",
+      "payment_user_id": "honda",
       "big_category_name": "食費",
       "medium_category_name": "外食",
       "custom_category_name": null

--- a/test/group-transactions-test/groupTransactions.json
+++ b/test/group-transactions-test/groupTransactions.json
@@ -3,11 +3,15 @@
     {
       "id": 14,
       "transaction_type": "expense",
+      "posted_date": "2020-10-25T15:48:21Z",
       "updated_date": "2020-10-25T15:50:50Z",
       "transaction_date": "010/23(金)",
       "shop": "クリエイト",
       "memo": "シャンプー",
       "amount": 900,
+      "posted_user_id": "kawasaki",
+      "updated_user_id": null,
+      "payment_user_id": "honda",
       "big_category_name": "日用品",
       "medium_category_name": "消耗品",
       "custom_category_name": null
@@ -15,11 +19,15 @@
     {
       "id": 1,
       "transaction_type": "expense",
+      "posted_date": "2020-10-24T14:48:51Z",
       "updated_date": "2020-10-20T00:08:23Z",
       "transaction_date": "10/08(木)",
       "shop": "青唐辛子",
       "memo": "みんなで焼肉",
       "amount": 28000,
+      "posted_user_id": "kawasaki",
+      "updated_user_id": "suzuki",
+      "payment_user_id": "honda",
       "big_category_name": "食費",
       "medium_category_name": "外食",
       "custom_category_name": null


### PR DESCRIPTION
- transactionsに追加した日が格納される`posted_date`を追加しました。

- groupTransactionsに追加、編集、支払を行なった人を表示するための`posted_user_id` `updated_user_id` `payment_user_id`
   を追加しました。

-上記の追加に伴い、テストを修正しました。 

確認よろしくお願いします。