### PR TITLE
Add budgets display when switching to group screen

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -26,11 +26,13 @@ const Router = (): JSX.Element => {
       <Route exact path={'/history-week'} component={WeeklyHistory} />
       <Route exact path={'/login'} component={LogIn} />
       <Route exact path={'/signup'} component={SignUp} />
-      <Route exact path={'/standard-budgets'} component={StandardBudgets} />
+      <Route exact path={'/standard/budgets'} component={StandardBudgets} />
       <Route exact path={'/standard-budgets/:year:month'} component={SelectStandardBudgets} />
       <Route exact path={'/todo'} component={Todo} />
       <Route exact path={'/todo/monthly'} component={MonthlyTodo} />
-      <Route exact path={'/yearly-budgets'} component={YearlyBudgets} />
+      <Route exact path={'/yearly/budgets'} component={YearlyBudgets} />
+      <Route exact path={'/group/:id/standard/budgets'} component={StandardBudgets} />
+      <Route exact path={'/group/:id/yearly/budgets'} component={YearlyBudgets} />
       <Route exact path={'/group/:id'} component={Home} />
       <Route exact path={'/group/:id/task'} component={Task} />
       <Route exact path={'/group/:id/todo'} component={Todo} />

--- a/src/components/budget/GroupYearlyBudgetsRow.tsx
+++ b/src/components/budget/GroupYearlyBudgetsRow.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  fetchYearlyBudgets,
-  fetchStandardBudgets,
-  deleteCustomBudgets,
-} from '../../reducks/budgets/operations';
-import { YearlyBudgetsList } from '../../reducks/budgets/types';
+  fetchGroupYearlyBudgets,
+  fetchGroupStandardBudgets,
+  deleteGroupCustomBudgets,
+} from '../../reducks/groupBudgets/operations';
+import { GroupYearlyBudgetsList } from '../../reducks/groupBudgets/types';
 import { State } from '../../reducks/store/types';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
@@ -15,8 +15,11 @@ import CreateIcon from '@material-ui/icons/Create';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { standardBudgetType } from '../../lib/constant';
-import { getStandardBudgets, getYearlyBudgets } from '../../reducks/budgets/selectors';
-import { getPathTemplateName } from '../../lib/path';
+import {
+  getGroupYearlyBudgets,
+  getGroupStandardBudgets,
+} from '../../reducks/groupBudgets/selectors';
+import { getPathGroupId, getPathTemplateName } from '../../lib/path';
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -27,52 +30,53 @@ const useStyles = makeStyles(() =>
   })
 );
 
-interface YearlyBudgetsRowProps {
+interface GroupYearlyBudgetsRowProps {
   years: number;
 }
 
-const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
+const GroupYearlyBudgetsRow = (props: GroupYearlyBudgetsRowProps) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const year = props.years;
+  const groupId = getPathGroupId(window.location.pathname);
   const pathName = getPathTemplateName(window.location.pathname);
   const selector = useSelector((state: State) => state);
-  const yearlyBudgets = getYearlyBudgets(selector);
-  const standardBudgets = getStandardBudgets(selector);
-  const [yearBudget, setYearBudget] = useState<YearlyBudgetsList>({
+  const groupYearlyBudgetsList = getGroupYearlyBudgets(selector);
+  const groupStandardBudgetsList = getGroupStandardBudgets(selector);
+  const [groupYearlyBudgets, setGroupYearlyBudgets] = useState<GroupYearlyBudgetsList>({
     year: '',
     yearly_total_budget: 0,
     monthly_budgets: [],
   });
 
   useEffect(() => {
-    if (pathName !== 'group' && !yearlyBudgets.monthly_budgets.length) {
-      dispatch(fetchYearlyBudgets(year));
+    if (pathName === 'group' && !groupYearlyBudgetsList.monthly_budgets.length) {
+      dispatch(fetchGroupYearlyBudgets(groupId, year));
     }
   }, [year]);
 
   useEffect(() => {
-    if (pathName !== 'group' && !standardBudgets.length) {
-      dispatch(fetchStandardBudgets());
+    if (pathName === 'group' && !groupStandardBudgetsList.length) {
+      dispatch(fetchGroupStandardBudgets(groupId));
     }
   }, []);
 
   useEffect(() => {
-    setYearBudget(yearlyBudgets);
-  }, [yearlyBudgets]);
+    setGroupYearlyBudgets(groupYearlyBudgetsList);
+  }, [groupYearlyBudgetsList]);
 
-  const customBudgetsTable = (): JSX.Element[] => {
-    return yearBudget.monthly_budgets.map((budget, index) => {
+  const groupCustomBudgetsTable = (): JSX.Element[] => {
+    return groupYearlyBudgets.monthly_budgets.map((groupYearlyBudget, index) => {
       const transitingBasePath =
-        budget.budget_type === 'CustomBudget' ? `/custom-budgets` : `standard-budgets`;
+        groupYearlyBudget.budget_type === 'CustomBudget' ? `/custom/budgets` : `standard/budgets`;
       const budgetsType = () => {
-        if (budget.budget_type === standardBudgetType) {
+        if (groupYearlyBudget.budget_type === standardBudgetType) {
           return '標準';
         }
         return 'カスタム';
       };
-      const selectYear = budget.month.slice(0, 4);
-      const selectMonth = budget.month.slice(5, 7);
+      const selectYear = groupYearlyBudget.month.slice(0, 4);
+      const selectMonth = groupYearlyBudget.month.slice(5, 7);
       const lastDate = new Date(year, Number(selectMonth), 0).getDate();
       return (
         <TableRow key={index}>
@@ -81,12 +85,12 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
           </TableCell>
           <TableCell className={classes.tableSize}>{budgetsType()}</TableCell>
           <TableCell className={classes.tableSize} align="center">
-            {budget.month}
-            {'01'}日〜{budget.month}
+            {groupYearlyBudget.month}
+            {'01'}日〜{groupYearlyBudget.month}
             {lastDate}日
           </TableCell>
           <TableCell className={classes.tableSize} align="center">
-            ¥{budget.monthly_total_budget}
+            ¥{groupYearlyBudget.monthly_total_budget}
           </TableCell>
           <TableCell className={classes.tableSize} align="center">
             <IconButton
@@ -104,7 +108,7 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
                     size={'small'}
                     onClick={() => {
                       if (window.confirm('カスタム予算を削除しても良いですか？ ')) {
-                        dispatch(deleteCustomBudgets(selectYear, selectMonth));
+                        dispatch(deleteGroupCustomBudgets(selectYear, selectMonth, groupId));
                       } else {
                         alert('削除を中止しました');
                       }
@@ -120,6 +124,6 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
       );
     });
   };
-  return <>{customBudgetsTable()}</>;
+  return <>{groupCustomBudgetsTable()}</>;
 };
-export default YearlyBudgetsRow;
+export default GroupYearlyBudgetsRow;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -170,7 +170,7 @@ const Header = () => {
               size="large"
               className={classes.button}
               startIcon={<MoneyIcon />}
-              onClick={() => dispatch(push('/standard-budgets'))}
+              onClick={() => existsGroupWhenRouting('/standard/budgets')}
             >
               予算
             </Button>

--- a/src/reducks/groupBudgets/operations.ts
+++ b/src/reducks/groupBudgets/operations.ts
@@ -20,11 +20,11 @@ import { errorHandling, isValidBudgetFormat } from '../../lib/validation';
 import { State } from '../store/types';
 import { standardBudgetType } from '../../lib/constant';
 
-export const fetchGroupStandardBudgets = () => {
+export const fetchGroupStandardBudgets = (groupId: number) => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {
     await axios
       .get<GroupStandardBudgetsListRes>(
-        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/1/standard-budgets`,
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`,
         {
           withCredentials: true,
         }
@@ -83,11 +83,11 @@ export const editGroupStandardBudgets = (groupBudgets: GroupBudgetsReq) => {
   };
 };
 
-export const fetchGroupYearlyBudgets = () => {
+export const fetchGroupYearlyBudgets = (groupId: number, year: number) => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {
     await axios
       .get<GroupYearlyBudgetsList>(
-        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/1/budgets/2020`,
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${year}`,
         {
           withCredentials: true,
         }
@@ -226,11 +226,15 @@ export const editGroupCustomBudgets = (
   };
 };
 
-export const deleteGroupCustomBudgets = (selectYear: string, selectMonth: string) => {
+export const deleteGroupCustomBudgets = (
+  selectYear: string,
+  selectMonth: string,
+  groupId: number
+) => {
   return async (dispatch: Dispatch<Action>, getState: () => State): Promise<void> => {
     await axios
       .delete<DeleteGroupCustomBudgetsRes>(
-        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/1/custom-budgets/${selectYear}-${selectMonth}`,
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`,
         {
           withCredentials: true,
         }

--- a/src/templates/GroupStandardBudgets.tsx
+++ b/src/templates/GroupStandardBudgets.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { getGroupStandardBudgets } from '../reducks/groupBudgets/selectors';
+import {
+  editGroupStandardBudgets,
+  fetchGroupStandardBudgets,
+} from '../reducks/groupBudgets/operations';
+import { GroupStandardBudgetsList } from '../reducks/groupBudgets/types';
+import { State } from '../reducks/store/types';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import TableBody from '@material-ui/core/TableBody';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableCell from '@material-ui/core/TableCell';
+import TextField from '@material-ui/core/TextField';
+import GenericButton from '../components/uikit/GenericButton';
+import { getPathGroupId, getPathTemplateName } from '../lib/path';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      margin: '0 auto',
+      flexDirection: 'column',
+      alignItems: 'center',
+      '& > *': {
+        margin: theme.spacing(1),
+      },
+    },
+    tablePosition: {
+      margin: '0 auto',
+      marginTop: 40,
+      alignItems: 'center',
+      tableLayout: 'fixed',
+      width: '100%',
+    },
+    tableSize: {
+      width: 250,
+      textAlign: 'center',
+    },
+    buttonSize: {
+      width: 360,
+      marginTop: 40,
+      backgroundColor: '#fff',
+      margin: '0 auto',
+    },
+    buttonGroupPosition: {
+      margin: '0 auto',
+      marginLeft: '7%',
+    },
+    centerPosition: {
+      textAlign: 'center',
+    },
+    tableTop: {
+      backgroundColor: '#4db5fa',
+    },
+    tableMain: {
+      border: 'solid 1px #e1e3e3',
+    },
+  })
+);
+
+const GroupStandardBudgets = () => {
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const selector = useSelector((state: State) => state);
+  const groupStandardBudgetsList = getGroupStandardBudgets(selector);
+  const [groupStandardBudgets, setGroupStandardBudgets] = useState<GroupStandardBudgetsList>([]);
+  const pathName = getPathTemplateName(window.location.pathname);
+  const groupId = getPathGroupId(window.location.pathname);
+  const unEditBudgets = groupStandardBudgets === groupStandardBudgetsList;
+
+  useEffect(() => {
+    if (pathName === 'group') {
+      dispatch(fetchGroupStandardBudgets(groupId));
+    }
+  }, []);
+
+  useEffect(() => {
+    setGroupStandardBudgets(groupStandardBudgetsList);
+  }, [groupStandardBudgetsList]);
+
+  return (
+    <>
+      <TableContainer className={classes.tablePosition} component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell className={classes.tableTop} align="center">
+                カテゴリー
+              </TableCell>
+              <TableCell className={classes.tableTop} align="center">
+                先月の支出
+              </TableCell>
+              <TableCell className={classes.tableTop} align="center">
+                予算
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {groupStandardBudgets.map((groupBudget, index) => {
+              const onChangeBudget = (event: { target: { value: string } }) => {
+                const newBudgets = [...groupStandardBudgets];
+                newBudgets[index].budget = Number(event.target.value);
+                setGroupStandardBudgets(newBudgets);
+              };
+              return (
+                <TableRow key={groupBudget.big_category_id}>
+                  <TableCell className={classes.tableSize} component="th" scope="row">
+                    {groupBudget.big_category_name}
+                  </TableCell>
+                  <TableCell className={classes.tableSize}>￥10,000</TableCell>
+                  <TableCell className={classes.tableSize} align="center">
+                    <TextField
+                      size={'small'}
+                      id={'budgets'}
+                      variant="outlined"
+                      type={'number'}
+                      value={groupBudget.budget}
+                      onChange={onChangeBudget}
+                    />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <div className={classes.centerPosition}>
+        <GenericButton
+          label={'更新する'}
+          disabled={unEditBudgets}
+          onClick={() =>
+            dispatch(
+              editGroupStandardBudgets(
+                groupStandardBudgets.map((groupBudget) => {
+                  const { big_category_name, ...rest } = groupBudget; // eslint-disable-line
+                  return rest;
+                })
+              )
+            )
+          }
+        />
+      </div>
+    </>
+  );
+};
+export default GroupStandardBudgets;

--- a/src/templates/YearlyBudgets.tsx
+++ b/src/templates/YearlyBudgets.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'connected-react-router';
+import { getYearlyBudgets } from '../reducks/budgets/selectors';
+import { getGroupYearlyBudgets } from '../reducks/groupBudgets/selectors';
 import YearlyBudgetsRow from '../components/budget/YearlyBudgetsRow';
+import GroupYearlyBudgetsRow from '../components/budget/GroupYearlyBudgetsRow';
 import Button from '@material-ui/core/Button';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
@@ -17,6 +20,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import { State } from '../reducks/store/types';
+import { getPathTemplateName, getPathGroupId } from '../lib/path';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -67,8 +71,11 @@ const YearlyBudgets = () => {
   const dispatch = useDispatch();
   const date = new Date();
   const selector = useSelector((state: State) => state);
-  const totalBudge = selector.budgets.yearly_budgets_list.yearly_total_budget;
+  const totalBudget = getYearlyBudgets(selector).yearly_total_budget;
+  const totalGroupBudget = getGroupYearlyBudgets(selector).yearly_total_budget;
   const [years, setYears] = useState<number>(date.getFullYear());
+  const pathName = getPathTemplateName(window.location.pathname);
+  const groupId = getPathGroupId(window.location.pathname);
 
   const handleDateChange = useCallback(
     (event: React.ChangeEvent<{ value: unknown }>) => {
@@ -80,10 +87,26 @@ const YearlyBudgets = () => {
   return (
     <div className={classes.mainPosition}>
       <ButtonGroup className={classes.buttonPosition} size="large" aria-label="budgets-kind">
-        <Button className={classes.buttonSize} onClick={() => dispatch(push('/standard-budgets'))}>
+        <Button
+          className={classes.buttonSize}
+          onClick={() => {
+            {
+              pathName !== 'group'
+                ? dispatch(push('/standard/budgets'))
+                : dispatch(push(`/group/${groupId}/standard/budgets`));
+            }
+          }}
+        >
           標準予算
         </Button>
-        <Button className={classes.buttonSize} onClick={() => dispatch(push('/yearly-budgets'))}>
+        <Button
+          className={classes.buttonSize}
+          onClick={() => {
+            pathName !== 'group'
+              ? dispatch(push('/yearly/budgets'))
+              : dispatch(push(`/group/${groupId}/yearly/budgets`));
+          }}
+        >
           月別カスタム予算
         </Button>
       </ButtonGroup>
@@ -95,7 +118,7 @@ const YearlyBudgets = () => {
           <MenuItem value={years - 1}>{years - 1}</MenuItem>
         </Select>
       </FormControl>
-      <h1>総額 ¥ {totalBudge}</h1>
+      <h1>総額 ¥ {pathName !== 'group' ? totalBudget : totalGroupBudget}</h1>
       <TableContainer className={classes.tablePosition} component={Paper}>
         <Table>
           <TableHead>
@@ -118,7 +141,11 @@ const YearlyBudgets = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            <YearlyBudgetsRow years={years} />
+            {pathName !== 'group' ? (
+              <YearlyBudgetsRow years={years} />
+            ) : (
+              <GroupYearlyBudgetsRow years={years} />
+            )}
           </TableBody>
         </Table>
       </TableContainer>

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -11,3 +11,4 @@ export { default as Task } from './Task';
 export { default as Todo } from './Todo';
 export { default as WeeklyHistory } from './WeeklyHistory';
 export { default as YearlyBudgets } from './YearlyBudgets';
+export { default as GroupStandardBudgets } from './GroupStandardBudgets';

--- a/test/group-budgets-test/GroupBudgets.test.tsx
+++ b/test/group-budgets-test/GroupBudgets.test.tsx
@@ -47,7 +47,7 @@ describe('async actions fetchGroupStandardBudgets', () => {
 
     axiosMock.onGet(url).reply(200, mockResponse);
 
-    await fetchGroupStandardBudgets()(store.dispatch);
+    await fetchGroupStandardBudgets(groupId)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -182,7 +182,7 @@ describe('async actions getGroupYearlyBudgets', () => {
 
     axiosMock.onGet(url).reply(200, mockResponse);
 
-    await fetchGroupYearlyBudgets()(store.dispatch);
+    await fetchGroupYearlyBudgets(groupId, year)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -526,7 +526,7 @@ describe('async actions deleteGroupCustomBudgets', () => {
     window.alert = jest.fn(() => mockResponse);
 
     // @ts-ignore
-    await deleteGroupCustomBudgets(selectYear, selectMonth)(store.dispatch, getState);
+    await deleteGroupCustomBudgets(selectYear, selectMonth, groupId)(store.dispatch, getState);
     expect(store.getActions()).toEqual(expectedActions);
     expect(window.alert).toHaveBeenCalled();
   });


### PR DESCRIPTION
- グループに変更した際に予算画面での表示をグループの標準予算と年間予算を表示する処理を追加しました。

- グループに変更した際に表示する`GroupStandardBudgets, GroupYearlyBudgets`を追加しました。

- グループの`fetchGroupStandardBudgets, fetchGroupYearlyBudgets, deleteGroupCustomBudgets`のurlに仮のgroupIdを
  設定していましたが、現在のgroupIdをリクエストで送る形に修正しました。

- groupIdの修正に伴い、テストの修正を行いました。

確認よろしくお願いします。

