### PR TITLE
Modify the operations of budgets

### DIFF
--- a/src/components/budget/EditGroupStandardBudgets.tsx
+++ b/src/components/budget/EditGroupStandardBudgets.tsx
@@ -4,10 +4,10 @@ import {
   fetchGroupStandardBudgets,
   addGroupCustomBudgets,
   copyGroupStandardBudgets,
-} from '../reducks/groupBudgets/operations';
-import { State } from '../reducks/store/types';
-import { GroupCustomBudgetsList } from '../reducks/groupBudgets/types';
-import { getGroupCustomBudgets } from '../reducks/groupBudgets/selectors';
+} from '../../reducks/groupBudgets/operations';
+import { State } from '../../reducks/store/types';
+import { GroupCustomBudgetsList } from '../../reducks/groupBudgets/types';
+import { getGroupCustomBudgets } from '../../reducks/groupBudgets/selectors';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
@@ -18,8 +18,8 @@ import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
-import GenericButton from '../components/uikit/GenericButton';
-import { getPathGroupId, getGroupPathYear, getGroupPathMonth } from '../lib/path';
+import GenericButton from '../uikit/GenericButton';
+import { getPathGroupId, getGroupPathYear, getGroupPathMonth } from '../../lib/path';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/components/budget/GroupCustomBudgets.tsx
+++ b/src/components/budget/GroupCustomBudgets.tsx
@@ -4,21 +4,21 @@ import { push } from 'connected-react-router';
 import {
   fetchGroupCustomBudgets,
   editGroupCustomBudgets,
-} from '../reducks/groupBudgets/operations';
-import { getGroupCustomBudgets } from '../reducks/groupBudgets/selectors';
-import { GroupCustomBudgetsList } from '../reducks/groupBudgets/types';
-import { State } from '../reducks/store/types';
+} from '../../reducks/groupBudgets/operations';
+import { getGroupCustomBudgets } from '../../reducks/groupBudgets/selectors';
+import { GroupCustomBudgetsList } from '../../reducks/groupBudgets/types';
+import { State } from '../../reducks/store/types';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import TableRow from '@material-ui/core/TableRow';
 import TableBody from '@material-ui/core/TableBody';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableCell from '@material-ui/core/TableCell';
 import TextField from '@material-ui/core/TextField';
-import GenericButton from '../components/uikit/GenericButton';
+import GenericButton from '../uikit/GenericButton';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
-import { getGroupPathYear, getGroupPathMonth, getPathGroupId } from '../lib/path';
+import { getGroupPathYear, getGroupPathMonth, getPathGroupId } from '../../lib/path';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/components/budget/GroupStandardBudgets.tsx
+++ b/src/components/budget/GroupStandardBudgets.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getGroupStandardBudgets } from '../reducks/groupBudgets/selectors';
+import { getGroupStandardBudgets } from '../../reducks/groupBudgets/selectors';
 import {
   editGroupStandardBudgets,
   fetchGroupStandardBudgets,
-} from '../reducks/groupBudgets/operations';
-import { GroupStandardBudgetsList } from '../reducks/groupBudgets/types';
-import { State } from '../reducks/store/types';
+} from '../../reducks/groupBudgets/operations';
+import { GroupStandardBudgetsList } from '../../reducks/groupBudgets/types';
+import { State } from '../../reducks/store/types';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
@@ -16,8 +16,8 @@ import TableBody from '@material-ui/core/TableBody';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableCell from '@material-ui/core/TableCell';
 import TextField from '@material-ui/core/TextField';
-import GenericButton from '../components/uikit/GenericButton';
-import { getPathGroupId, getPathTemplateName } from '../lib/path';
+import GenericButton from '../uikit/GenericButton';
+import { getPathGroupId, getPathTemplateName } from '../../lib/path';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/components/budget/GroupYearlyBudgetsRow.tsx
+++ b/src/components/budget/GroupYearlyBudgetsRow.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   fetchGroupYearlyBudgets,
-  fetchGroupStandardBudgets,
   deleteGroupCustomBudgets,
 } from '../../reducks/groupBudgets/operations';
 import { GroupYearlyBudgetsList } from '../../reducks/groupBudgets/types';
@@ -15,10 +14,7 @@ import CreateIcon from '@material-ui/icons/Create';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { standardBudgetType } from '../../lib/constant';
-import {
-  getGroupYearlyBudgets,
-  getGroupStandardBudgets,
-} from '../../reducks/groupBudgets/selectors';
+import { getGroupYearlyBudgets } from '../../reducks/groupBudgets/selectors';
 import { getPathGroupId, getPathTemplateName } from '../../lib/path';
 
 const useStyles = makeStyles(() =>
@@ -42,7 +38,6 @@ const GroupYearlyBudgetsRow = (props: GroupYearlyBudgetsRowProps) => {
   const pathName = getPathTemplateName(window.location.pathname);
   const selector = useSelector((state: State) => state);
   const groupYearlyBudgetsList = getGroupYearlyBudgets(selector);
-  const groupStandardBudgetsList = getGroupStandardBudgets(selector);
   const [groupYearlyBudgets, setGroupYearlyBudgets] = useState<GroupYearlyBudgetsList>({
     year: '',
     yearly_total_budget: 0,
@@ -54,12 +49,6 @@ const GroupYearlyBudgetsRow = (props: GroupYearlyBudgetsRowProps) => {
       dispatch(fetchGroupYearlyBudgets(groupId, year));
     }
   }, [year]);
-
-  useEffect(() => {
-    if (pathName === 'group' && !groupStandardBudgetsList.length) {
-      dispatch(fetchGroupStandardBudgets(groupId));
-    }
-  }, []);
 
   useEffect(() => {
     setGroupYearlyBudgets(groupYearlyBudgetsList);

--- a/src/components/budget/YearlyBudgetsRow.tsx
+++ b/src/components/budget/YearlyBudgetsRow.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  fetchYearlyBudgets,
-  fetchStandardBudgets,
-  deleteCustomBudgets,
-} from '../../reducks/budgets/operations';
+import { fetchYearlyBudgets, deleteCustomBudgets } from '../../reducks/budgets/operations';
 import { YearlyBudgetsList } from '../../reducks/budgets/types';
 import { State } from '../../reducks/store/types';
 import TableRow from '@material-ui/core/TableRow';
@@ -15,7 +11,7 @@ import CreateIcon from '@material-ui/icons/Create';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { standardBudgetType } from '../../lib/constant';
-import { getStandardBudgets, getYearlyBudgets } from '../../reducks/budgets/selectors';
+import { getYearlyBudgets } from '../../reducks/budgets/selectors';
 import { getPathTemplateName } from '../../lib/path';
 
 const useStyles = makeStyles(() =>
@@ -38,7 +34,6 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
   const pathName = getPathTemplateName(window.location.pathname);
   const selector = useSelector((state: State) => state);
   const yearlyBudgets = getYearlyBudgets(selector);
-  const standardBudgets = getStandardBudgets(selector);
   const [yearBudget, setYearBudget] = useState<YearlyBudgetsList>({
     year: '',
     yearly_total_budget: 0,
@@ -46,16 +41,10 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
   });
 
   useEffect(() => {
-    if (pathName !== 'group' && !yearlyBudgets.monthly_budgets.length) {
+    if (pathName !== 'group') {
       dispatch(fetchYearlyBudgets(year));
     }
   }, [year]);
-
-  useEffect(() => {
-    if (pathName !== 'group' && !standardBudgets.length) {
-      dispatch(fetchStandardBudgets());
-    }
-  }, []);
 
   useEffect(() => {
     setYearBudget(yearlyBudgets);

--- a/src/lib/constant.ts
+++ b/src/lib/constant.ts
@@ -1,4 +1,5 @@
 export const standardBudgetType = 'StandardBudget';
+export const customBudgetType = 'CustomBudget';
 export const expenseTransactionType = 'expense';
 export const incomeTransactionType = 'income';
 export const date = new Date();

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -36,3 +36,22 @@ export const errorHandling = (
     alert(error);
   }
 };
+
+export const totalStandardBudget = (standardBudget: number[]): number => {
+  let total = 0;
+  for (let i = 0; i < standardBudget.length; i++) {
+    total += standardBudget[i];
+  }
+
+  return total;
+};
+
+export const totalCustomBudgets = (budgetList: number[]): number => {
+  let total = 0;
+
+  for (let i = 0; i < budgetList.length; i++) {
+    total += budgetList[i];
+  }
+
+  return total;
+};

--- a/src/reducks/budgets/actions.ts
+++ b/src/reducks/budgets/actions.ts
@@ -1,10 +1,9 @@
 import { StandardBudgetsList, YearlyBudgetsList, CustomBudgetsList } from './types';
 export type budgetsActions = ReturnType<
   | typeof updateStandardBudgetsActions
-  | typeof fetchYearlyBudgetsActions
   | typeof updateCustomBudgetsActions
   | typeof copyStandardBudgetsActions
-  | typeof deleteCustomBudgetsActions
+  | typeof updateYearlyBudgetsActions
 >;
 
 export const UPDATE_STANDARD_BUDGETS = 'UPDATE_STANDARD_BUDGETS';
@@ -14,16 +13,6 @@ export const updateStandardBudgetsActions = (
   return {
     type: UPDATE_STANDARD_BUDGETS,
     payload: standard_budgets_list,
-  };
-};
-
-export const FETCH_YEARLY_BUDGETS = 'FETCH_YEARLY_BUDGETS';
-export const fetchYearlyBudgetsActions = (
-  yearly_budgets_list: YearlyBudgetsList
-): { type: string; payload: YearlyBudgetsList } => {
-  return {
-    type: FETCH_YEARLY_BUDGETS,
-    payload: yearly_budgets_list,
   };
 };
 
@@ -47,12 +36,12 @@ export const copyStandardBudgetsActions = (
   };
 };
 
-export const DELETE_CUSTOM_BUDGETS = 'DELETE_CUSTOM_BUDGETS';
-export const deleteCustomBudgetsActions = (
+export const UPDATE_YEARLY_BUDGETS = 'UPDATE_YEARLY_BUDGETS';
+export const updateYearlyBudgetsActions = (
   yearly_budgets_list: YearlyBudgetsList
 ): { type: string; payload: YearlyBudgetsList } => {
   return {
-    type: DELETE_CUSTOM_BUDGETS,
+    type: UPDATE_YEARLY_BUDGETS,
     payload: yearly_budgets_list,
   };
 };

--- a/src/reducks/budgets/reducers.ts
+++ b/src/reducks/budgets/reducers.ts
@@ -9,11 +9,6 @@ export const budgetsReducer = (state = initialState.budgets, action: budgetsActi
         ...state,
         standard_budgets_list: [...action.payload],
       };
-    case Actions.FETCH_YEARLY_BUDGETS:
-      return {
-        ...state,
-        yearly_budgets_list: action.payload,
-      };
     case Actions.UPDATE_CUSTOM_BUDGETS:
       return {
         ...state,
@@ -24,7 +19,7 @@ export const budgetsReducer = (state = initialState.budgets, action: budgetsActi
         ...state,
         custom_budgets_list: [...action.payload],
       };
-    case Actions.DELETE_CUSTOM_BUDGETS:
+    case Actions.UPDATE_YEARLY_BUDGETS:
       return {
         ...state,
         yearly_budgets_list: action.payload,

--- a/src/templates/CustomBudgets.tsx
+++ b/src/templates/CustomBudgets.tsx
@@ -25,7 +25,7 @@ import {
   getGroupPathYear,
   getGroupPathMonth,
 } from '../lib/path';
-import GroupCustomBudgets from './GroupCustomBudgets';
+import GroupCustomBudgets from '../components/budget/GroupCustomBudgets';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -87,7 +87,7 @@ const CustomBudgets = () => {
   const unInput = customBudgets === customBudgetsList;
 
   useEffect(() => {
-    if (pathName !== 'group' && !customBudgetsList) {
+    if (pathName !== 'group') {
       dispatch(fetchCustomBudgets(selectYear, selectMonth));
     }
   }, []);

--- a/src/templates/EditStandardBudgets.tsx
+++ b/src/templates/EditStandardBudgets.tsx
@@ -29,7 +29,7 @@ import {
   getPathYear,
   getPathMonth,
 } from '../lib/path';
-import EditGroupStandardBudgets from './EditGroupStandardBudgets';
+import EditGroupStandardBudgets from '../components/budget/EditGroupStandardBudgets';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/templates/StandardBudgets.tsx
+++ b/src/templates/StandardBudgets.tsx
@@ -18,7 +18,7 @@ import TableCell from '@material-ui/core/TableCell';
 import TextField from '@material-ui/core/TextField';
 import GenericButton from '../components/uikit/GenericButton';
 import { getPathTemplateName, getPathGroupId } from '../lib/path';
-import GroupStandardBudgets from './GroupStandardBudgets';
+import GroupStandardBudgets from '../components/budget/GroupStandardBudgets';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/templates/YearlyBudgets.tsx
+++ b/src/templates/YearlyBudgets.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'connected-react-router';
+import { fetchStandardBudgets } from '../reducks/budgets/operations';
 import { getYearlyBudgets } from '../reducks/budgets/selectors';
 import { getGroupYearlyBudgets } from '../reducks/groupBudgets/selectors';
 import YearlyBudgetsRow from '../components/budget/YearlyBudgetsRow';
@@ -76,6 +77,10 @@ const YearlyBudgets = () => {
   const [years, setYears] = useState<number>(date.getFullYear());
   const pathName = getPathTemplateName(window.location.pathname);
   const groupId = getPathGroupId(window.location.pathname);
+
+  useEffect(() => {
+    dispatch(fetchStandardBudgets());
+  }, []);
 
   const handleDateChange = useCallback(
     (event: React.ChangeEvent<{ value: unknown }>) => {

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -11,6 +11,3 @@ export { default as Task } from './Task';
 export { default as Todo } from './Todo';
 export { default as WeeklyHistory } from './WeeklyHistory';
 export { default as YearlyBudgets } from './YearlyBudgets';
-export { default as GroupStandardBudgets } from './GroupStandardBudgets';
-export { default as EditGroupStandardBudgets } from './EditGroupStandardBudgets';
-export { default as GroupCustomBudgets } from './GroupCustomBudgets';

--- a/test/budgets-test/Budgets.test.tsx
+++ b/test/budgets-test/Budgets.test.tsx
@@ -20,7 +20,8 @@ import editBudgets from './editBudgetsResponse.json';
 import addCustomBudget from './addCustomBudgetsResponse.json';
 import editCustomBudget from './editCustomBudgetsResponse.json';
 import deleteCustomBudget from './deleteCustomBudgetsResponse.json';
-
+import addCustomBudgetsPayload from './addCustomBudgetsPayload.json';
+import editCustomBudgetsPayload from './editCustomBudgetsPayload.json';
 const axiosMock = new axiosMockAdapter(axios);
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -165,7 +166,7 @@ describe('async actions getYearlyBudgets', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.FETCH_YEARLY_BUDGETS,
+        type: actionTypes.UPDATE_YEARLY_BUDGETS,
         payload: mockYearlyBudgets,
       },
     ];
@@ -208,11 +209,25 @@ describe('async actions addCustomBudgets', () => {
     store.clearActions();
   });
   const selectYear = '2020';
-  const selectMonth = '07';
-  const store = mockStore({ customBudgets });
+  const selectMonth = '06';
+  const store = mockStore({
+    budgets: {
+      yearly_budgets_list: yearlyBudgets,
+      standard_budgets_list: editBudgets.standard_budgets,
+    },
+  });
   const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`;
 
   it('Add custom_budgets if fetch succeeds', async () => {
+    const getState = () => {
+      return {
+        budgets: {
+          yearly_budgets_list: yearlyBudgets,
+          standard_budgets_list: editBudgets.standard_budgets,
+        },
+      };
+    };
+
     const mockCustomBudgets = addCustomBudget;
 
     const nextCustomBudgets = {
@@ -239,7 +254,7 @@ describe('async actions addCustomBudgets', () => {
         },
         {
           big_category_id: 7,
-          budget: 0,
+          budget: 2000,
         },
         {
           big_category_id: 8,
@@ -286,8 +301,8 @@ describe('async actions addCustomBudgets', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.UPDATE_CUSTOM_BUDGETS,
-        payload: mockCustomBudgets.custom_budgets,
+        type: actionTypes.UPDATE_YEARLY_BUDGETS,
+        payload: addCustomBudgetsPayload,
       },
     ];
 
@@ -297,7 +312,8 @@ describe('async actions addCustomBudgets', () => {
       selectYear,
       selectMonth,
       nextCustomBudgets.custom_budgets
-    )(store.dispatch);
+      // @ts-ignore
+    )(store.dispatch, getState);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -307,15 +323,19 @@ describe('async actions editCustomBudgets', () => {
     store.clearActions();
   });
   const selectYear = '2020';
-  const selectMonth = '07';
-  const store = mockStore({ addCustomBudget });
+  const selectMonth = '06';
+  const store = mockStore({
+    budgets: {
+      yearly_budgets_list: addCustomBudgetsPayload,
+    },
+  });
   const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`;
 
   it('Edit custom_budgets if fetch succeeds', async () => {
     const getState = () => {
       return {
         budgets: {
-          custom_budgets_list: customBudgets.custom_budgets,
+          yearly_budgets_list: addCustomBudgetsPayload,
         },
       };
     };
@@ -393,8 +413,8 @@ describe('async actions editCustomBudgets', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.UPDATE_CUSTOM_BUDGETS,
-        payload: mockCustomBudgets.custom_budgets,
+        type: actionTypes.UPDATE_YEARLY_BUDGETS,
+        payload: editCustomBudgetsPayload,
       },
     ];
 
@@ -416,14 +436,14 @@ describe('async actions deleteCustomBudgets', () => {
   });
   const selectYear = '2020';
   const selectMonth = '07';
-  const store = mockStore({ yearlyBudgets });
+  const store = mockStore({ budgets: { yearly_budgets_list: editCustomBudgetsPayload } });
   const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`;
   it('Delete custom_budgets if fetch succeeds', async () => {
     const getState = () => {
       return {
         budgets: {
           standard_budgets_list: editBudgets.standard_budgets,
-          yearly_budgets_list: yearlyBudgets,
+          yearly_budgets_list: editCustomBudgetsPayload,
         },
       };
     };
@@ -432,7 +452,7 @@ describe('async actions deleteCustomBudgets', () => {
 
     const mockCustomBudgets = {
       year: '2020-01-01T00:00:00Z',
-      yearly_total_budget: 1008200,
+      yearly_total_budget: 1028600,
       monthly_budgets: [
         {
           month: '2020年01月',
@@ -461,8 +481,8 @@ describe('async actions deleteCustomBudgets', () => {
         },
         {
           month: '2020年06月',
-          budget_type: 'StandardBudget',
-          monthly_total_budget: 83600,
+          budget_type: 'CustomBudget',
+          monthly_total_budget: 92600,
         },
         {
           month: '2020年07月',
@@ -499,7 +519,7 @@ describe('async actions deleteCustomBudgets', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.DELETE_CUSTOM_BUDGETS,
+        type: actionTypes.UPDATE_YEARLY_BUDGETS,
         payload: mockCustomBudgets,
       },
     ];

--- a/test/budgets-test/addCustomBudgetsPayload.json
+++ b/test/budgets-test/addCustomBudgetsPayload.json
@@ -1,6 +1,6 @@
 {
   "year": "2020-01-01T00:00:00Z",
-  "yearly_total_budget": 1036000,
+  "yearly_total_budget": 1038000,
   "monthly_budgets": [
     {
       "month": "2020年01月",
@@ -29,8 +29,8 @@
     },
     {
       "month": "2020年06月",
-      "budget_type": "StandardBudget",
-      "monthly_total_budget": 83600
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 85600
     },
     {
       "month": "2020年07月",

--- a/test/budgets-test/addCustomBudgetsResponse.json
+++ b/test/budgets-test/addCustomBudgetsResponse.json
@@ -28,7 +28,7 @@
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 2000
     },
     {
       "big_category_id": 8,

--- a/test/budgets-test/editCustomBudgetsPayload.json
+++ b/test/budgets-test/editCustomBudgetsPayload.json
@@ -1,6 +1,6 @@
 {
   "year": "2020-01-01T00:00:00Z",
-  "yearly_total_budget": 1036000,
+  "yearly_total_budget": 1045000,
   "monthly_budgets": [
     {
       "month": "2020年01月",
@@ -29,8 +29,8 @@
     },
     {
       "month": "2020年06月",
-      "budget_type": "StandardBudget",
-      "monthly_total_budget": 83600
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 92600
     },
     {
       "month": "2020年07月",


### PR DESCRIPTION
- budgetsのoperationsの関数を`.then`を使用しない`async await`の形に修正しました。

- カスタム予算の追加, 編集の処理が実行された後に年間予算画面にルーティングする形に修正したのに伴い、追加と同時にカスタム予算を 
  年間予算に反映させるため`yearlyBudgetsList`をdispatch する形に修正しました。

-カスタム予算の追加, 編集の変更に伴いテストの修正を行いました。

- グループ時に表示させる`GroupStandardBudgets, GroupCustomBudgets, EditGroupStandardBudgets`を`component / budget` 
  に移動しました。

- 予算の合計値を求める`totalStandardBudget, totalCustomBudget`を`validation.ts`に追加しました。

確認よろしくお願いします。
