### PR TITLE
Add display of MonthlyHistory for groups

### DIFF
--- a/src/components/home/GroupMothlyHistory.tsx
+++ b/src/components/home/GroupMothlyHistory.tsx
@@ -1,48 +1,44 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { fetchTransactionsList } from '../../reducks/transactions/operations';
+import { fetchGroupTransactionsList } from '../../reducks/groupTransactions/operations';
 import { State } from '../../reducks/store/types';
-import { getTransactions } from '../../reducks/transactions/selectors';
+import { getGroupTransactions } from '../../reducks/groupTransactions/selectors';
+import { incomeTransactionType } from '../../lib/constant';
+import { getPathGroupId } from '../../lib/path';
 import { year, month, customMonth } from '../../lib/constant';
-import '../../assets/monthly-history.scss';
 import { displayWeeks, WeeklyInfo } from '../../lib/date';
 import { EditTransactionModal, SelectMenu } from '../uikit';
-import { incomeTransactionType } from '../../lib/constant';
-import { getPathTemplateName } from '../../lib/path';
-import GroupMonthlyHistory from './GroupMothlyHistory';
 
-const MonthlyHistory = () => {
+const GroupMonthlyHistory = () => {
   const dispatch = useDispatch();
   const selector = useSelector((state: State) => state);
-  const pathName = getPathTemplateName(window.location.pathname);
-  const transactionsList = getTransactions(selector);
+  const groupId = getPathGroupId(window.location.pathname);
+  const groupTransactionsList = getGroupTransactions(selector);
   const [open, setOpen] = useState<boolean>(false);
   const [openId, setOpenId] = useState<number | undefined>(undefined);
 
   useEffect(() => {
-    if (pathName !== 'group') {
-      dispatch(fetchTransactionsList(String(year), customMonth));
-    }
+    dispatch(fetchGroupTransactionsList(year, customMonth, groupId));
   }, []);
 
   const handleOpen = (transactionId: number) => {
-    setOpenId(transactionId);
     setOpen(true);
+    setOpenId(transactionId);
   };
 
   const handleClose = () => {
-    setOpenId(undefined);
     setOpen(false);
+    setOpenId(undefined);
   };
 
   const subTotalAmounts = (startDate: number, endDate: number) => {
     let oneWeekSubTotal = 0;
 
-    for (const transaction of transactionsList) {
-      if (transaction.transaction_type !== incomeTransactionType) {
-        const transactionDay = Number(transaction.transaction_date.slice(8, 10));
+    for (const groupTransaction of groupTransactionsList) {
+      if (groupTransaction.transaction_type !== incomeTransactionType) {
+        const transactionDay = Number(groupTransaction.transaction_date.slice(8, 10));
         if (startDate <= transactionDay && transactionDay <= endDate) {
-          oneWeekSubTotal += transaction.amount;
+          oneWeekSubTotal += groupTransaction.amount;
         }
       }
     }
@@ -74,7 +70,7 @@ const MonthlyHistory = () => {
             let items: ReactElement[] = [];
             let prevTransactionDate = '';
 
-            transactionsList.map((transaction, index) => {
+            groupTransactionsList.map((groupTransaction, index) => {
               const {
                 id,
                 transaction_date,
@@ -82,10 +78,10 @@ const MonthlyHistory = () => {
                 medium_category_name,
                 custom_category_name,
                 shop,
-                amount,
                 memo,
-              } = transaction;
-              const transactionDay = Number(transaction.transaction_date.slice(8, 10));
+                amount,
+              } = groupTransaction;
+              const transactionDay = Number(transaction_date.slice(8, 10));
 
               const categoryName = {
                 mediumCategory: medium_category_name !== null ? medium_category_name : '',
@@ -119,7 +115,7 @@ const MonthlyHistory = () => {
                           }
                         })()}
                         {(() => {
-                          if (medium_category_name != null) {
+                          if (groupTransaction.medium_category_name != null) {
                             return medium_category_name;
                           }
 
@@ -174,40 +170,28 @@ const MonthlyHistory = () => {
   const totalAmount = () => {
     let amount = 0;
 
-    for (const transaction of transactionsList) {
-      if (transaction.transaction_type !== incomeTransactionType) {
-        amount += transaction.amount;
+    for (const groupTransaction of groupTransactionsList) {
+      if (groupTransaction.transaction_type !== incomeTransactionType) {
+        amount += groupTransaction.amount;
       }
     }
     return amount;
   };
 
   return (
-    <div className="box__monthlyExpense">
-      <h2>{month}月の支出</h2>
-      {(() => {
-        if (pathName !== 'group') {
-          return (
-            <>
-              <table className="monthly-history-table">
-                <tbody className="monthly-history-table__tbody">
-                  <tr className="monthly-history-table__thead">{rows().headerRow}</tr>
-                  <tr className="monthly-history-table__trow">{rows().historyRow}</tr>
-                  <tr className="monthly-history-table__trow">{rows().operationRow}</tr>
-                  <tr className="monthly-history-table__trow">{rows().totalAmountRow}</tr>
-                </tbody>
-              </table>
-              <div className="monthly-history-table__box-total">
-                合計： ¥ {totalAmount().toLocaleString()}
-              </div>
-            </>
-          );
-        } else {
-          return <GroupMonthlyHistory />;
-        }
-      })()}
-    </div>
+    <>
+      <table className="monthly-history-table">
+        <tbody className="monthly-history-table__tbody">
+          <tr className="monthly-history-table__thead">{rows().headerRow}</tr>
+          <tr className="monthly-history-table__trow">{rows().historyRow}</tr>
+          <tr className="monthly-history-table__trow">{rows().operationRow}</tr>
+          <tr className="monthly-history-table__trow">{rows().totalAmountRow}</tr>
+        </tbody>
+      </table>
+      <div className="monthly-history-table__box-total">
+        合計： ¥ {totalAmount().toLocaleString()}
+      </div>
+    </>
   );
 };
-
-export default MonthlyHistory;
+export default GroupMonthlyHistory;

--- a/src/components/home/RecentInput.tsx
+++ b/src/components/home/RecentInput.tsx
@@ -5,12 +5,12 @@ import { getLatestTransactions } from '../../reducks/transactions/selectors';
 import RecentInputBody from './RecentInputBody';
 import '../../assets/recent-input.scss';
 import { fetchLatestTransactionsList } from '../../reducks/transactions/operations';
+import { guidanceMessage } from '../../lib/constant';
 
 const RecentInput = () => {
   const dispatch = useDispatch();
   const selector = useSelector((state: State) => state);
   const latestTransactionsList = getLatestTransactions(selector);
-  const guidanceMessage = '「入力フォーム」から家計簿の追加を行ってください';
 
   useEffect(() => {
     dispatch(fetchLatestTransactionsList());

--- a/src/components/home/RecentInputBody.tsx
+++ b/src/components/home/RecentInputBody.tsx
@@ -9,54 +9,58 @@ interface RecentInputBodyProps {
 
 const RecentInputBody = (props: RecentInputBodyProps) => {
   const [open, setOpen] = useState<boolean>(false);
-  const [id, setId] = useState<number | undefined>(undefined);
+  const [openId, setOpenId] = useState<number | undefined>(undefined);
 
   const handleOpen = (transactionId: number) => {
     setOpen(true);
-    setId(transactionId);
+    setOpenId(transactionId);
   };
 
   const handleClose = () => {
     setOpen(false);
-    setId(undefined);
+    setOpenId(undefined);
   };
 
   const latestTransaction = () => {
     return props.latestTransactionsList.map((transaction, index) => {
+      const {
+        id,
+        transaction_type,
+        transaction_date,
+        medium_category_name,
+        custom_category_name,
+        amount,
+        memo,
+        shop,
+      } = transaction;
+
       const categoryName = {
-        mediumCategory:
-          transaction.medium_category_name !== null ? transaction.medium_category_name : '',
-        customCategory:
-          transaction.custom_category_name !== null ? transaction.custom_category_name : '',
+        mediumCategory: medium_category_name !== null ? medium_category_name : '',
+        customCategory: custom_category_name !== null ? custom_category_name : '',
       };
 
       return (
         <div key={index}>
-          <dl
-            className="recent-input__recent_delimiterLine"
-            onClick={() => handleOpen(transaction.id)}
-          >
-            <dt className="recent-input__recent-text">{transaction.transaction_date}</dt>
-            <dt className="recent-input__recent-text">￥ {transaction.amount.toLocaleString()}</dt>
+          <dl className="recent-input__recent_delimiterLine" onClick={() => handleOpen(id)}>
+            <dt className="recent-input__recent-text">{transaction_date}</dt>
+            <dt className="recent-input__recent-text">￥ {amount.toLocaleString()}</dt>
             <dt className="recent-input__recent-text">
-              {transaction.medium_category_name !== null
-                ? transaction.medium_category_name
-                : transaction.custom_category_name}
+              {medium_category_name || custom_category_name}
             </dt>
-            <dt>{transaction.shop}</dt>
-            <dt>{transaction.memo}</dt>
+            <dt>{shop}</dt>
+            <dt>{memo}</dt>
           </dl>
           <EditTransactionModal
             key={index}
-            amount={transaction.amount}
+            amount={amount}
             categoryName={categoryName}
-            id={transaction.id}
-            memo={transaction.memo !== null ? transaction.memo : ''}
-            shop={transaction.shop !== null ? transaction.shop : ''}
-            open={id === transaction.id && open}
+            id={id}
+            memo={transaction.memo !== null ? memo : ''}
+            shop={transaction.shop !== null ? shop : ''}
+            open={openId === transaction.id && open}
             onClose={handleClose}
-            transactionDate={transaction.transaction_date}
-            transactionsType={transaction.transaction_type}
+            transactionDate={transaction_date}
+            transactionsType={transaction_type}
           />
         </div>
       );

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -2,3 +2,4 @@ export { default as InputForm } from './InputForm';
 export { default as RecentInput } from './RecentInput';
 export { default as MonthlyHistory } from './MonthlyHistory';
 export { default as HistoryPieChart } from './HistoryPieChart';
+export { default as GroupMonthlyHistory } from './GroupMothlyHistory';

--- a/src/lib/constant.ts
+++ b/src/lib/constant.ts
@@ -6,3 +6,4 @@ export const date = new Date();
 export const year = date.getFullYear();
 export const month = date.getMonth() + 1;
 export const customMonth = ('0' + month).slice(-2);
+export const guidanceMessage = '「入力フォーム」から家計簿の追加を行ってください';

--- a/src/reducks/groupTransactions/actions.ts
+++ b/src/reducks/groupTransactions/actions.ts
@@ -1,13 +1,23 @@
 import { GroupTransactionsList } from './types';
 
-export type groupTransactionsAction = ReturnType<typeof updateGroupTransactionsAction>;
+export type groupTransactionsAction = ReturnType<
+  typeof updateGroupTransactionsAction | typeof updateGroupLatestTransactionsAction
+>;
 
 export const UPDATE_GROUP_TRANSACTIONS = 'UPDATE_GROUP_TRANSACTIONS';
-export const updateGroupTransactionsAction = (
-  groupTransactionsList: GroupTransactionsList
-): { type: string; payload: GroupTransactionsList } => {
+export const updateGroupTransactionsAction = (groupTransactionsList: GroupTransactionsList) => {
   return {
     type: UPDATE_GROUP_TRANSACTIONS,
+    payload: groupTransactionsList,
+  };
+};
+
+export const UPDATE_GROUP_LATEST_TRANSACTIONS = 'UPDATE_GROUP_LATEST_TRANSACTIONS';
+export const updateGroupLatestTransactionsAction = (
+  groupTransactionsList: GroupTransactionsList
+) => {
+  return {
+    type: UPDATE_GROUP_LATEST_TRANSACTIONS,
     payload: groupTransactionsList,
   };
 };

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -12,11 +12,11 @@ import { push } from 'connected-react-router';
 import { isValidAmountFormat, errorHandling } from '../../lib/validation';
 import moment from 'moment';
 
-export const fetchGroupTransactionsList = (year: number, customMonth: string) => {
+export const fetchGroupTransactionsList = (year: number, customMonth: string, groupId: number) => {
   return async (dispatch: Dispatch<Action>) => {
     try {
       const result = await axios.get<FetchGroupTransactionsRes>(
-        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/1/transactions/${year}-${customMonth}`,
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMonth}`,
         {
           withCredentials: true,
         }

--- a/src/reducks/groupTransactions/reducers.ts
+++ b/src/reducks/groupTransactions/reducers.ts
@@ -12,6 +12,11 @@ export const groupTransactionsReducer = (
         ...state,
         groupTransactionsList: [...action.payload],
       };
+    case Actions.UPDATE_GROUP_LATEST_TRANSACTIONS:
+      return {
+        ...state,
+        groupLatestTransactionsList: [...action.payload],
+      };
     default:
       return state;
   }

--- a/src/reducks/groupTransactions/selectors.ts
+++ b/src/reducks/groupTransactions/selectors.ts
@@ -7,3 +7,8 @@ export const getGroupTransactions = createSelector(
   [groupTransactionsSelector],
   (state) => state.groupTransactionsList
 );
+
+export const getGroupLatestTransactions = createSelector(
+  [groupTransactionsSelector],
+  (state) => state.groupLatestTransactionsList
+);

--- a/src/reducks/groupTransactions/types.ts
+++ b/src/reducks/groupTransactions/types.ts
@@ -4,18 +4,22 @@ export interface GroupTransactions {
   posted_date: Date;
   updated_date: Date;
   transaction_date: string;
-  shop?: string | null;
-  memo?: string | null;
+  shop: string | null;
+  memo: string | null;
   amount: number;
   posted_user_id: string;
   updated_user_id: string;
   payment_user_id: string;
   big_category_name: string;
-  medium_category_name?: string | null;
-  custom_category_name?: string | null;
+  medium_category_name: string | null;
+  custom_category_name: string | null;
 }
 
 export interface GroupTransactionsList extends Array<GroupTransactions> {}
+
+export interface GroupLatestTransactionsListRes {
+  transactions_list: GroupTransactionsList;
+}
 
 export interface GroupTransactionsReq {
   transaction_type: string;

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -13,6 +13,7 @@ const initialState = {
     noTransactionsMessage: '',
   },
   groupTransactions: {
+    groupLatestTransactionsList: [],
     groupTransactionsList: [],
   },
   budgets: {

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -28,6 +28,7 @@ export interface State {
     noTransactionsMessage: string;
   };
   groupTransactions: {
+    groupLatestTransactionsList: GroupTransactionsList;
     groupTransactionsList: GroupTransactionsList;
   };
   budgets: {

--- a/test/group-transactions-test/GroupTransactions.test.tsx
+++ b/test/group-transactions-test/GroupTransactions.test.tsx
@@ -45,7 +45,7 @@ describe('async actions fetchGroupTransactionsList', () => {
 
     axiosMock.onGet(url).reply(200, mockResponse);
 
-    await fetchGroupTransactionsList(year, customMonth)(store.dispatch);
+    await fetchGroupTransactionsList(year, customMonth, groupId)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAddActions);
   });
 });


### PR DESCRIPTION
- グループに切り替えた際にHome画面と履歴画面で表示している月の履歴をグループの履歴`GroupMonthlyHistory`に切り替える処理を
  追加しました。

- `RecentInput`で`transactionList`がない場合に表示させていたメッセージを`constant.ts`からimport する形に修正しました。

- `RecentInputBody, MonthlyHistory`の`transaction.`で参照している部分が冗長になっていたので分割代入を使用して参照する形に修正 
  しました。

- グループの最新10件を取得するfetchGroupLatestTransactionsのactions, reducers, initialState, typesを追加しました。

確認よろしくお願いします。
