### PR TITLE
Modify transaction operations and add a view of the group weekly history

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -23,7 +23,7 @@ const Router = (): JSX.Element => {
       <Route exact path={'/big-categories'} component={SelectBigCategory} />
       <Route exact path={'/custom/budgets/:year/:month'} component={CustomBudgets} />
       <Route exact path={'/custom-categories/:id'} component={InputCustomCategory} />
-      <Route exact path={'/history-week'} component={WeeklyHistory} />
+      <Route exact path={'/history/week'} component={WeeklyHistory} />
       <Route exact path={'/login'} component={LogIn} />
       <Route exact path={'/signup'} component={SignUp} />
       <Route exact path={'/standard/budgets'} component={StandardBudgets} />
@@ -31,6 +31,8 @@ const Router = (): JSX.Element => {
       <Route exact path={'/todo'} component={Todo} />
       <Route exact path={'/todo/monthly'} component={MonthlyTodo} />
       <Route exact path={'/yearly/budgets'} component={YearlyBudgets} />
+      <Route exact path={'/group/:id'} component={Home} />
+      <Route exact path={'/group/:id/history/week'} component={WeeklyHistory} />
       <Route exact path={'/group/:id/standard/budgets'} component={StandardBudgets} />
       <Route exact path={'/group/:id/custom/budgets/:year/:month'} component={CustomBudgets} />
       <Route exact path={'/group/:id/yearly/budgets'} component={YearlyBudgets} />
@@ -39,7 +41,6 @@ const Router = (): JSX.Element => {
         path={'/group/:id/standard/budgets/:year/:month'}
         component={EditStandardBudgets}
       />
-      <Route exact path={'/group/:id'} component={Home} />
       <Route exact path={'/group/:id/task'} component={Task} />
       <Route exact path={'/group/:id/todo'} component={Todo} />
       <Route exact path={'/group/:id/todo/monthly'} component={MonthlyTodo} />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -162,7 +162,7 @@ const Header = () => {
               size="large"
               className={classes.button}
               startIcon={<HistoryIcon />}
-              onClick={() => dispatch(push('/history-week'))}
+              onClick={() => existsGroupWhenRouting('/history/week')}
             >
               履歴
             </Button>

--- a/src/components/home/GroupMothlyHistory.tsx
+++ b/src/components/home/GroupMothlyHistory.tsx
@@ -179,8 +179,9 @@ const GroupMonthlyHistory = () => {
   };
 
   return (
-    <>
+    <div className="box__monthlyExpense">
       <table className="monthly-history-table">
+        <h2>{month}月の支出</h2>
         <tbody className="monthly-history-table__tbody">
           <tr className="monthly-history-table__thead">{rows().headerRow}</tr>
           <tr className="monthly-history-table__trow">{rows().historyRow}</tr>
@@ -191,7 +192,7 @@ const GroupMonthlyHistory = () => {
       <div className="monthly-history-table__box-total">
         合計： ¥ {totalAmount().toLocaleString()}
       </div>
-    </>
+    </div>
   );
 };
 export default GroupMonthlyHistory;

--- a/src/components/home/InputForm.tsx
+++ b/src/components/home/InputForm.tsx
@@ -5,6 +5,7 @@ import { addTransactions, addLatestTransactions } from '../../reducks/transactio
 import { push } from 'connected-react-router';
 import { makeStyles } from '@material-ui/core/styles';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
+import { TransactionsReq } from '../../reducks/transactions/types';
 
 const useStyles = makeStyles({
   link: {
@@ -18,7 +19,9 @@ const InputForm = (): JSX.Element => {
   const dispatch = useDispatch();
   const [amount, setAmount] = useState<string>('');
   const [memo, setMemo] = useState<string>('');
+  const emptyMemo = memo === '' ? null : memo;
   const [shop, setShop] = useState<string>('');
+  const emptyShop = shop === '' ? null : shop;
   const [category, setCategory] = useState<string>('');
   const [transactionDate, setTransactionDate] = useState<Date | null>(new Date());
   const [transactionsType, setTransactionType] = useState<string>('');
@@ -103,20 +106,20 @@ const InputForm = (): JSX.Element => {
 
   const unInput = amount === '' || category === '' || transactionsType === '';
 
+  const requestData: TransactionsReq = {
+    transaction_type: transactionsType,
+    transaction_date: transactionDate,
+    shop: emptyShop,
+    memo: emptyMemo,
+    amount: Number(amount),
+    big_category_id: bigCategoryId,
+    medium_category_id: mediumCategoryId,
+    custom_category_id: customCategoryId,
+  };
+
   const addTransaction = () => {
     async function addedTransaction() {
-      await dispatch(
-        addLatestTransactions(
-          transactionsType,
-          transactionDate,
-          shop,
-          memo,
-          amount,
-          bigCategoryId,
-          mediumCategoryId,
-          customCategoryId
-        )
-      );
+      await dispatch(addLatestTransactions(requestData));
       dispatch(addTransactions());
       resetInputForm();
     }
@@ -170,7 +173,7 @@ const InputForm = (): JSX.Element => {
       />
       <GenericButton
         startIcon={<AddCircleOutlineIcon />}
-        onClick={() => addTransaction()}
+        onClick={addTransaction}
         label={'入力する'}
         disabled={unInput}
       />

--- a/src/components/home/MonthlyHistory.tsx
+++ b/src/components/home/MonthlyHistory.tsx
@@ -20,7 +20,7 @@ const MonthlyHistory = () => {
   const [openId, setOpenId] = useState<number | undefined>(undefined);
 
   useEffect(() => {
-    if (pathName !== 'group') {
+    if (pathName !== 'group' && !transactionsList.length) {
       dispatch(fetchTransactionsList(String(year), customMonth));
     }
   }, []);
@@ -183,12 +183,12 @@ const MonthlyHistory = () => {
   };
 
   return (
-    <div className="box__monthlyExpense">
-      <h2>{month}月の支出</h2>
+    <>
       {(() => {
         if (pathName !== 'group') {
           return (
-            <>
+            <div className="box__monthlyExpense">
+              <h2>{month}月の支出</h2>
               <table className="monthly-history-table">
                 <tbody className="monthly-history-table__tbody">
                   <tr className="monthly-history-table__thead">{rows().headerRow}</tr>
@@ -200,13 +200,13 @@ const MonthlyHistory = () => {
               <div className="monthly-history-table__box-total">
                 合計： ¥ {totalAmount().toLocaleString()}
               </div>
-            </>
+            </div>
           );
         } else {
           return <GroupMonthlyHistory />;
         }
       })()}
-    </div>
+    </>
   );
 };
 

--- a/src/components/home/RecentInput.tsx
+++ b/src/components/home/RecentInput.tsx
@@ -2,18 +2,24 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { State } from '../../reducks/store/types';
 import { getLatestTransactions } from '../../reducks/transactions/selectors';
+import { getGroupLatestTransactions } from '../../reducks/groupTransactions/selectors';
 import RecentInputBody from './RecentInputBody';
 import '../../assets/recent-input.scss';
 import { fetchLatestTransactionsList } from '../../reducks/transactions/operations';
 import { guidanceMessage } from '../../lib/constant';
+import { getPathTemplateName } from '../../lib/path';
 
 const RecentInput = () => {
   const dispatch = useDispatch();
   const selector = useSelector((state: State) => state);
   const latestTransactionsList = getLatestTransactions(selector);
+  const groupLatestTransactionList = getGroupLatestTransactions(selector);
+  const pathName = getPathTemplateName(window.location.pathname);
 
   useEffect(() => {
-    dispatch(fetchLatestTransactionsList());
+    if (pathName !== 'group' && !latestTransactionsList.length) {
+      dispatch(fetchLatestTransactionsList());
+    }
   }, []);
 
   return (
@@ -21,10 +27,16 @@ const RecentInput = () => {
       <h3>最近の入力</h3>
       <div />
       {(() => {
-        if (latestTransactionsList.length === 0) {
-          return <dt>{guidanceMessage}</dt>;
+        if (pathName !== 'group') {
+          if (!latestTransactionsList.length) {
+            return <dt>{guidanceMessage}</dt>;
+          } else {
+            return <RecentInputBody latestTransactionsList={latestTransactionsList} />;
+          }
         } else {
-          return <RecentInputBody latestTransactionsList={latestTransactionsList} />;
+          if (!groupLatestTransactionList.length) {
+            return <dt>{guidanceMessage}</dt>;
+          }
         }
       })()}
     </div>

--- a/src/components/uikit/AddTransactionModal.tsx
+++ b/src/components/uikit/AddTransactionModal.tsx
@@ -5,6 +5,7 @@ import Modal from '@material-ui/core/Modal';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import { addTransactions, addLatestTransactions } from '../../reducks/transactions/operations';
+import { TransactionsReq } from '../../reducks/transactions/types';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -45,7 +46,9 @@ const AddTransactionModal = (props: AddTransactionModalProps) => {
   const dispatch = useDispatch();
   const [amount, setAmount] = useState<string>('');
   const [memo, setMemo] = useState<string>('');
+  const emptyMemo = memo === '' ? null : memo;
   const [shop, setShop] = useState<string>('');
+  const emptyShop = shop === '' ? null : shop;
   const [category, setCategory] = useState<string>('');
   const [transactionDate, setTransactionDate] = useState<Date | null>(props.selectDate);
   const [transactionsType, setTransactionType] = useState<string>('');
@@ -127,20 +130,20 @@ const AddTransactionModal = (props: AddTransactionModalProps) => {
 
   const unInput = amount === '' || category === '' || transactionsType === '';
 
+  const requestData: TransactionsReq = {
+    transaction_type: transactionsType,
+    transaction_date: transactionDate,
+    shop: emptyShop,
+    memo: emptyMemo,
+    amount: Number(amount),
+    big_category_id: bigCategoryId,
+    medium_category_id: mediumCategoryId,
+    custom_category_id: customCategoryId,
+  };
+
   const clicked = () => {
     async function addTransaction() {
-      await dispatch(
-        addLatestTransactions(
-          transactionsType,
-          transactionDate,
-          shop,
-          memo,
-          amount,
-          bigCategoryId,
-          mediumCategoryId,
-          customCategoryId
-        )
-      );
+      await dispatch(addLatestTransactions(requestData));
       dispatch(addTransactions());
       props.onClose();
     }

--- a/src/components/uikit/EditTransactionModal.tsx
+++ b/src/components/uikit/EditTransactionModal.tsx
@@ -22,6 +22,7 @@ import { CategoryId, CategoryName } from '../../reducks/categories/types';
 import { expenseTransactionType, incomeTransactionType } from '../../lib/constant';
 import { IconButton } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
+import { TransactionsReq } from '../../reducks/transactions/types';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -77,7 +78,9 @@ const EditTransactionModal = (props: InputModalProps) => {
   const expenseCategories = getExpenseCategories(selector);
   const [amount, setAmount] = useState<string>(String(props.amount));
   const [memo, setMemo] = useState<string | null>(props.memo);
+  const emptyMemo = memo === '' ? null : memo;
   const [shop, setShop] = useState<string | null>(props.shop);
+  const emptyShop = shop === '' ? null : shop;
   const [transactionsType, setTransactionType] = useState<string>(props.transactionsType);
   const id = props.id;
 
@@ -242,6 +245,16 @@ const EditTransactionModal = (props: InputModalProps) => {
     [setBigCategoryId, setMediumCategoryId, setCustomCategoryId]
   );
 
+  const editRequestData: TransactionsReq = {
+    transaction_date: transactionDate,
+    transaction_type: transactionsType,
+    big_category_id: bigCategoryId,
+    medium_category_id: mediumCategoryId,
+    custom_category_id: customCategoryId,
+    amount: Number(amount),
+    memo: emptyMemo,
+    shop: emptyShop,
+  };
   const deleteTransaction = (): void => {
     async function deletedTransaction() {
       await dispatch(deleteLatestTransactions(id));
@@ -307,32 +320,8 @@ const EditTransactionModal = (props: InputModalProps) => {
         <GenericButton
           label={'更新する'}
           onClick={() =>
-            dispatch(
-              editTransactions(
-                id,
-                transactionsType,
-                transactionDate,
-                shop,
-                memo,
-                amount,
-                bigCategoryId,
-                mediumCategoryId,
-                customCategoryId
-              )
-            ) &&
-            dispatch(
-              editLatestTransactions(
-                id,
-                transactionsType,
-                transactionDate,
-                shop,
-                memo,
-                amount,
-                bigCategoryId,
-                mediumCategoryId,
-                customCategoryId
-              )
-            ) &&
+            dispatch(editTransactions(id, editRequestData)) &&
+            dispatch(editLatestTransactions(id, editRequestData)) &&
             props.onClose()
           }
           disabled={false}

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -11,7 +11,6 @@ import {
   TransactionsList,
   FetchTransactionsRes,
   FetchLatestTransactionsRes,
-  TransactionsReq,
   TransactionsRes,
   DeleteTransactionRes,
 } from './types';
@@ -68,43 +67,24 @@ export const fetchLatestTransactionsList = () => {
   };
 };
 
-export const addLatestTransactions = (
-  transaction_type: string,
-  transaction_date: Date | null,
-  shop: string | null,
-  memo: string | null,
-  amount: string | number,
-  big_category_id: number,
-  medium_category_id: number | null,
-  custom_category_id: number | null
-) => {
+export const addLatestTransactions = (requestData: {
+  transaction_type: string;
+  transaction_date: Date | null;
+  shop: string | null;
+  memo: string | null;
+  amount: string | number;
+  big_category_id: number;
+  medium_category_id: number | null;
+  custom_category_id: number | null;
+}) => {
   return async (dispatch: Dispatch<Action>, getState: () => State) => {
-    if (shop === '') {
-      shop = null;
-    }
-
-    if (memo === '') {
-      memo = null;
-    }
-
-    if (!isValidAmountFormat(amount as string)) {
+    if (!isValidAmountFormat(requestData.amount as string)) {
       alert('金額は数字で入力してください。');
     }
-
-    const data: TransactionsReq = {
-      transaction_type: transaction_type,
-      transaction_date: transaction_date,
-      shop: shop,
-      memo: memo,
-      amount: Number(amount),
-      big_category_id: big_category_id,
-      medium_category_id: medium_category_id,
-      custom_category_id: custom_category_id,
-    };
     try {
       const result = await axios.post<TransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions`,
-        JSON.stringify(data, function (key, value) {
+        JSON.stringify(requestData, function (key, value) {
           if (key === 'transaction_date') {
             return moment(new Date(value)).format();
           }
@@ -176,43 +156,26 @@ export const addTransactions = () => {
 
 export const editTransactions = (
   id: number,
-  transaction_type: string,
-  transaction_date: Date | null,
-  shop: string | null,
-  memo: string | null,
-  amount: string | number,
-  big_category_id: number,
-  medium_category_id: number | null,
-  custom_category_id: number | null
+  editRequestData: {
+    transaction_type: string;
+    transaction_date: Date | null;
+    shop: string | null;
+    memo: string | null;
+    amount: string | number;
+    big_category_id: number;
+    medium_category_id: number | null;
+    custom_category_id: number | null;
+  }
 ) => {
   return async (dispatch: Dispatch<Action>, getState: () => State) => {
-    if (shop === '') {
-      shop = null;
-    }
-
-    if (memo === '') {
-      memo = null;
-    }
-
-    if (!isValidAmountFormat(amount as string)) {
+    if (!isValidAmountFormat(editRequestData.amount as string)) {
       alert('金額は数字で入力してください。');
     }
-
-    const data: TransactionsReq = {
-      transaction_type: transaction_type,
-      transaction_date: transaction_date,
-      shop: shop,
-      memo: memo,
-      amount: Number(amount),
-      big_category_id: big_category_id,
-      medium_category_id: medium_category_id,
-      custom_category_id: custom_category_id,
-    };
 
     try {
       const result = await axios.put<TransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${id}`,
-        JSON.stringify(data, function (key, value) {
+        JSON.stringify(editRequestData, function (key, value) {
           if (key === 'transaction_date') {
             return moment(new Date(value)).format();
           }
@@ -264,43 +227,26 @@ export const editTransactions = (
 
 export const editLatestTransactions = (
   id: number,
-  transaction_type: string,
-  transaction_date: Date | null,
-  shop: string | null,
-  memo: string | null,
-  amount: string | number,
-  big_category_id: number,
-  medium_category_id: number | null,
-  custom_category_id: number | null
+  editRequestData: {
+    transaction_type: string;
+    transaction_date: Date | null;
+    shop: string | null;
+    memo: string | null;
+    amount: string | number;
+    big_category_id: number;
+    medium_category_id: number | null;
+    custom_category_id: number | null;
+  }
 ) => {
   return async (dispatch: Dispatch<Action>, getState: () => State) => {
-    if (shop === '') {
-      shop = null;
-    }
-
-    if (memo === '') {
-      memo = null;
-    }
-
-    if (!isValidAmountFormat(amount as string)) {
+    if (!isValidAmountFormat(editRequestData.amount as string)) {
       alert('金額は数字で入力してください。');
     }
-
-    const data: TransactionsReq = {
-      transaction_type: transaction_type,
-      transaction_date: transaction_date,
-      shop: shop,
-      memo: memo,
-      amount: Number(amount),
-      big_category_id: big_category_id,
-      medium_category_id: medium_category_id,
-      custom_category_id: custom_category_id,
-    };
 
     try {
       const result = await axios.put<TransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${id}`,
-        JSON.stringify(data, function (key, value) {
+        JSON.stringify(editRequestData, function (key, value) {
           if (key === 'transaction_date') {
             return moment(new Date(value)).format();
           }

--- a/src/templates/WeeklyHistory.tsx
+++ b/src/templates/WeeklyHistory.tsx
@@ -5,6 +5,8 @@ import Button from '@material-ui/core/Button';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import MonthlyHistory from '../components/home/MonthlyHistory';
+import GroupMonthlyHistory from '../components/home/GroupMothlyHistory';
+import { getPathTemplateName, getPathGroupId } from '../lib/path';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -32,6 +34,9 @@ const useStyles = makeStyles((theme: Theme) =>
 const WeeklyHistory = () => {
   const classes = useStyles();
   const dispatch = useDispatch();
+  const pathName = getPathTemplateName(window.location.pathname);
+  const groupId = getPathGroupId(window.location.pathname);
+  console.log(pathName);
 
   return (
     <>
@@ -42,14 +47,23 @@ const WeeklyHistory = () => {
           aria-label="small outlined button group"
         >
           <Button className={classes.topButton}>日ごと</Button>
-          <Button className={classes.topButton} onClick={() => dispatch(push('/history-week'))}>
+          <Button
+            className={classes.topButton}
+            onClick={() => {
+              if (pathName !== 'group') {
+                dispatch(push('/history-week'));
+              } else {
+                dispatch(push(`/group/${groupId}/history-week`));
+              }
+            }}
+          >
             週ごと
           </Button>
           <Button className={classes.topButton}>月ごと</Button>
         </ButtonGroup>
       </div>
       <div className={classes.tableSize}>
-        <MonthlyHistory />
+        {pathName !== 'group' ? <MonthlyHistory /> : <GroupMonthlyHistory />}
       </div>
     </>
   );

--- a/test/transactions-test/Transactions.test.tsx
+++ b/test/transactions-test/Transactions.test.tsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import axiosMockAdapter from 'axios-mock-adapter';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
+import { TransactionsReq } from '../../src/reducks/transactions/types';
 import {
   fetchTransactionsList,
   fetchLatestTransactionsList,
@@ -127,6 +128,17 @@ describe('async actions addTransactions', () => {
       };
     };
 
+    const requestData: TransactionsReq = {
+      transaction_type: 'expense',
+      transaction_date: actual,
+      shop: 'ニトリ',
+      memo: '椅子',
+      amount: 9000,
+      big_category_id: 3,
+      medium_category_id: 16,
+      custom_category_id: null,
+    };
+
     const mockResponse = addResTransaction;
 
     const addedLatestTransactionsList = addLatestTransaction;
@@ -140,16 +152,7 @@ describe('async actions addTransactions', () => {
 
     axiosMock.onPost(url).reply(201, mockResponse);
 
-    await addLatestTransactions(
-      'expense',
-      actual,
-      'ニトリ',
-      '椅子',
-      9000,
-      3,
-      16,
-      null
-    )(
+    await addLatestTransactions(requestData)(
       store.dispatch,
       // @ts-ignore
       getState
@@ -241,6 +244,17 @@ describe('async actions editTransactions', () => {
 
     const editedTransactionsList = editTransactionsList;
 
+    const requestData: TransactionsReq = {
+      transaction_type: 'expense',
+      transaction_date: actual,
+      shop: 'ビッグカメラ',
+      memo: 'コーヒーメーカー',
+      amount: 25000,
+      big_category_id: 3,
+      medium_category_id: 17,
+      custom_category_id: null,
+    };
+
     const expectedEditActions = [
       {
         type: actionTypes.UPDATE_TRANSACTIONS,
@@ -250,17 +264,7 @@ describe('async actions editTransactions', () => {
 
     axiosMock.onPut(url).reply(200, mockResTransaction);
 
-    await editTransactions(
-      130,
-      'expense',
-      actual,
-      'ビッグカメラ',
-      'コーヒーメーカー',
-      25000,
-      3,
-      17,
-      null
-    )(
+    await editTransactions(130, requestData)(
       store.dispatch,
       // @ts-ignore
       getState
@@ -314,6 +318,17 @@ describe('async actions editLatestTransactions', () => {
 
     const editedLatestTransactions = editLatestTransaction;
 
+    const requestData: TransactionsReq = {
+      transaction_type: 'expense',
+      transaction_date: actual,
+      shop: 'ビッグカメラ',
+      memo: 'コーヒーメーカー',
+      amount: 25000,
+      big_category_id: 3,
+      medium_category_id: 17,
+      custom_category_id: null,
+    };
+
     const expectedEditActions = [
       {
         type: actionTypes.UPDATE_LATEST_TRANSACTIONS,
@@ -323,17 +338,7 @@ describe('async actions editLatestTransactions', () => {
 
     axiosMock.onPut(url).reply(200, mockResponse);
 
-    await editLatestTransactions(
-      130,
-      'expense',
-      actual,
-      'ビッグカメラ',
-      'コーヒーメーカー',
-      25000,
-      3,
-      17,
-      null
-    )(
+    await editLatestTransactions(130, requestData)(
       store.dispatch,
       // @ts-ignore
       getState
@@ -416,11 +421,9 @@ describe('async actions deleteLatestTransactions', () => {
     ];
 
     axiosMock.onDelete(url).reply(200, mockResponseMessage);
-    // window.alert = jest.fn(() => mockResponseMessage);
 
     // @ts-ignore
     await deleteLatestTransactions(130)(store.dispatch, getState);
     expect(store.getActions()).toEqual(expectedDeleteActions);
-    // expect(window.alert).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- `transactions / operations`の`addLatestTransactions, editTransactions, editLatestTransactions` の引数をオブジェクトで
   受け取る形に修正し関数内で代入する処理を行わない形に修正しました。

-引数をオブジェクトで受け取る修正に伴い、テストの修正をしました。

- `addLatestTransactions, editTransactions, editLatestTransactions`の関数内で引数を書き換える処理を行なってしましたが、
  呼び出し側から予期しない動きになるのを避けるために呼び出し側で行う形に修正しました。

- 履歴が画面でグループの週ごとの履歴、`WeeklyHistory`を表示する処理を追加しました。

確認よろしくお願いします。