### PR TITLE
Modify the display of groupTransaction and modify the way the budget …

### DIFF
--- a/src/components/budget/EditGroupStandardBudgets.tsx
+++ b/src/components/budget/EditGroupStandardBudgets.tsx
@@ -108,7 +108,7 @@ const EditGroupStandardBudgets = () => {
             {groupCustomBudgets.map((groupCustomBudget, index) => {
               const onChangeBudget = (event: { target: { value: string } }) => {
                 const newBudgets = [...groupCustomBudgets];
-                newBudgets[index].budget = Number(event.target.value);
+                newBudgets[index].budget = (event.target.value as unknown) as number;
                 setGroupCustomBudgets(newBudgets);
               };
               return (
@@ -144,7 +144,11 @@ const EditGroupStandardBudgets = () => {
                 groupInMonth,
                 groupId,
                 groupCustomBudgets.map((groupCustomBudget) => {
-                  const { big_category_name, ...rest } = groupCustomBudget; // eslint-disable-line
+                  let { big_category_name, ...rest } = groupCustomBudget; // eslint-disable-line
+                  rest = {
+                    big_category_id: rest.big_category_id,
+                    budget: Number(rest.budget),
+                  };
                   return rest;
                 })
               )

--- a/src/components/budget/GroupCustomBudgets.tsx
+++ b/src/components/budget/GroupCustomBudgets.tsx
@@ -103,7 +103,7 @@ const GroupCustomBudgets = () => {
             {groupCustomBudgets.map((groupCustomBudget, index) => {
               const onChangeBudget = (event: { target: { value: string } }) => {
                 const newBudgets = [...groupCustomBudgets];
-                newBudgets[index].budget = Number(event.target.value);
+                newBudgets[index].budget = (event.target.value as unknown) as number;
                 setGroupCustomBudgets(newBudgets);
               };
               return (
@@ -139,7 +139,11 @@ const GroupCustomBudgets = () => {
                 groupInMonth,
                 groupId,
                 groupCustomBudgets.map((groupBudget) => {
-                  const { big_category_name, ...rest } = groupBudget; // eslint-disable-line
+                  let { big_category_name, ...rest } = groupBudget; // eslint-disable-line
+                  rest = {
+                    big_category_id: rest.big_category_id,
+                    budget: Number(rest.budget),
+                  };
                   return rest;
                 })
               )

--- a/src/components/budget/GroupStandardBudgets.tsx
+++ b/src/components/budget/GroupStandardBudgets.tsx
@@ -103,7 +103,7 @@ const GroupStandardBudgets = () => {
             {groupStandardBudgets.map((groupBudget, index) => {
               const onChangeBudget = (event: { target: { value: string } }) => {
                 const newBudgets = [...groupStandardBudgets];
-                newBudgets[index].budget = Number(event.target.value);
+                newBudgets[index].budget = (event.target.value as unknown) as number;
                 setGroupStandardBudgets(newBudgets);
               };
               return (
@@ -136,7 +136,11 @@ const GroupStandardBudgets = () => {
             dispatch(
               editGroupStandardBudgets(
                 groupStandardBudgets.map((groupBudget) => {
-                  const { big_category_name, ...rest } = groupBudget; // eslint-disable-line
+                  let { big_category_name, ...rest } = groupBudget; // eslint-disable-line
+                  rest = {
+                    big_category_id: rest.big_category_id,
+                    budget: Number(rest.budget),
+                  };
                   return rest;
                 })
               )

--- a/src/components/budget/GroupYearlyBudgetsRow.tsx
+++ b/src/components/budget/GroupYearlyBudgetsRow.tsx
@@ -45,10 +45,10 @@ const GroupYearlyBudgetsRow = (props: GroupYearlyBudgetsRowProps) => {
   });
 
   useEffect(() => {
-    if (pathName === 'group' && !groupYearlyBudgetsList.monthly_budgets.length) {
+    if (pathName === 'group') {
       dispatch(fetchGroupYearlyBudgets(groupId, year));
     }
-  }, [year]);
+  }, [year, groupId]);
 
   useEffect(() => {
     setGroupYearlyBudgets(groupYearlyBudgetsList);
@@ -100,8 +100,6 @@ const GroupYearlyBudgetsRow = (props: GroupYearlyBudgetsRowProps) => {
                     onClick={() => {
                       if (window.confirm('カスタム予算を削除しても良いですか？ ')) {
                         dispatch(deleteGroupCustomBudgets(selectYear, selectMonth, groupId));
-                      } else {
-                        alert('削除を中止しました');
                       }
                     }}
                   >

--- a/src/components/budget/YearlyBudgetsRow.tsx
+++ b/src/components/budget/YearlyBudgetsRow.tsx
@@ -92,8 +92,6 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
                     onClick={() => {
                       if (window.confirm('カスタム予算を削除しても良いですか？ ')) {
                         dispatch(deleteCustomBudgets(selectYear, selectMonth));
-                      } else {
-                        alert('削除を中止しました');
                       }
                     }}
                   >

--- a/src/components/home/GroupMothlyHistory.tsx
+++ b/src/components/home/GroupMothlyHistory.tsx
@@ -20,10 +20,10 @@ const GroupMonthlyHistory = () => {
   const [openId, setOpenId] = useState<number | undefined>(undefined);
 
   useEffect(() => {
-    if (pathName === 'group' && !groupTransactionsList.length) {
+    if (pathName === 'group') {
       dispatch(fetchGroupTransactionsList(year, customMonth, groupId));
     }
-  }, [pathName]);
+  }, [pathName, groupId]);
 
   const handleOpen = (transactionId: number) => {
     setOpen(true);

--- a/src/components/home/RecentInput.tsx
+++ b/src/components/home/RecentInput.tsx
@@ -22,10 +22,10 @@ const RecentInput = () => {
   useEffect(() => {
     if (pathName !== 'group' && !latestTransactionsList.length) {
       dispatch(fetchLatestTransactionsList());
-    } else if (pathName === 'group' && !groupLatestTransactionList.length) {
+    } else if (pathName === 'group') {
       dispatch(fetchLatestGroupTransactionsList(groupId));
     }
-  }, [pathName]);
+  }, [pathName, groupId]);
 
   return (
     <div className="recent-input box__recent ">

--- a/src/components/uikit/CategoryInput.tsx
+++ b/src/components/uikit/CategoryInput.tsx
@@ -8,7 +8,9 @@ import Select from '@material-ui/core/Select';
 import { State } from '../../reducks/store/types';
 import { getIncomeCategories, getExpenseCategories } from '../../reducks/categories/selectors';
 import { fetchCategories } from '../../reducks/categories/operations';
+import { fetchGroupCategories } from '../../reducks/groupCategories/operations';
 import { Categories } from '../../reducks/categories/types';
+import { getPathTemplateName, getPathGroupId } from '../../lib/path';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -54,12 +56,16 @@ const CategoryInput = (props: CategoryProps): JSX.Element => {
   const selector = useSelector((state: State) => state);
   const incomeCategories = getIncomeCategories(selector);
   const expenseCategories = getExpenseCategories(selector);
+  const groupId = getPathGroupId(window.location.pathname);
+  const pathName = getPathTemplateName(window.location.pathname);
 
   useEffect(() => {
-    if (incomeCategories.length === 0 || expenseCategories.length === 0) {
+    if (pathName !== 'group' && !incomeCategories.length && !expenseCategories.length) {
       dispatch(fetchCategories());
+    } else if (pathName === 'group') {
+      dispatch(fetchGroupCategories(groupId));
     }
-  }, []);
+  }, [pathName, groupId]);
 
   const categories = useMemo(() => {
     let tmpCategories: ReactElement<Categories>[] = [];

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -54,7 +54,12 @@ export const fetchLatestGroupTransactionsList = (groupId: number) => {
       );
       const latestGroupTransactionsList = result.data.transactions_list;
 
-      dispatch(updateGroupLatestTransactionsAction(latestGroupTransactionsList));
+      if (latestGroupTransactionsList !== undefined) {
+        dispatch(updateGroupLatestTransactionsAction(latestGroupTransactionsList));
+      } else {
+        const emptyGroupLatestTransactionsList: GroupTransactionsList = [];
+        dispatch(updateGroupLatestTransactionsAction(emptyGroupLatestTransactionsList));
+      }
     } catch (error) {
       errorHandling(dispatch, error);
     }

--- a/src/templates/CustomBudgets.tsx
+++ b/src/templates/CustomBudgets.tsx
@@ -148,7 +148,7 @@ const CustomBudgets = () => {
                     {customBudgets.map((customBudget, index) => {
                       const onChangeBudget = (event: { target: { value: string } }) => {
                         const newBudgets = [...customBudgets];
-                        newBudgets[index].budget = Number(event.target.value);
+                        newBudgets[index].budget = (event.target.value as unknown) as number;
                         setCustomBudgets(newBudgets);
                       };
                       return (
@@ -183,7 +183,11 @@ const CustomBudgets = () => {
                         selectYear,
                         selectMonth,
                         customBudgets.map((budget) => {
-                          const { big_category_name, ...rest } = budget; // eslint-disable-line
+                          let { big_category_name, ...rest } = budget; // eslint-disable-line
+                          rest = {
+                            big_category_id: rest.big_category_id,
+                            budget: Number(rest.budget),
+                          };
                           return rest;
                         })
                       )

--- a/src/templates/EditStandardBudgets.tsx
+++ b/src/templates/EditStandardBudgets.tsx
@@ -156,7 +156,7 @@ const EditStandardBudgets = () => {
                     {customBudgets.map((customBudget, index) => {
                       const onChangeBudget = (event: { target: { value: string } }) => {
                         const newBudgets = [...customBudgets];
-                        newBudgets[index].budget = Number(event.target.value);
+                        newBudgets[index].budget = (event.target.value as unknown) as number;
                         setCustomBudgets(newBudgets);
                       };
                       return (
@@ -191,7 +191,11 @@ const EditStandardBudgets = () => {
                         selectYear,
                         selectMonth,
                         customBudgets.map((budget) => {
-                          const { big_category_name, ...rest } = budget; // eslint-disable-line
+                          let { big_category_name, ...rest } = budget; // eslint-disable-line
+                          rest = {
+                            big_category_id: rest.big_category_id,
+                            budget: Number(rest.budget),
+                          };
                           return rest;
                         })
                       )

--- a/src/templates/StandardBudgets.tsx
+++ b/src/templates/StandardBudgets.tsx
@@ -134,7 +134,7 @@ const StandardBudgets = () => {
                     {budgets.map((budget, index) => {
                       const onChangeBudget = (event: { target: { value: string } }) => {
                         const newBudgets = [...budgets];
-                        newBudgets[index].budget = Number(event.target.value);
+                        newBudgets[index].budget = (event.target.value as unknown) as number;
                         setBudgets(newBudgets);
                       };
                       return (
@@ -167,7 +167,11 @@ const StandardBudgets = () => {
                     dispatch(
                       editStandardBudgets(
                         budgets.map((budget) => {
-                          const { big_category_name, ...rest } = budget; // eslint-disable-line
+                          let { big_category_name, ...rest } = budget; // eslint-disable-line
+                          rest = {
+                            big_category_id: rest.big_category_id,
+                            budget: Number(rest.budget),
+                          };
                           return rest;
                         })
                       )


### PR DESCRIPTION
- `RecentInput`にグループを切り替えた際に変更された`grupId`によって各グループのtransactionListを取得するように
  useEffectの第二引数に`groupId`を追加しました。

- `RecentInput`同様に`CategoryInput`のuseEffectの第二引数に`groupId, pathName`を追加しました。

- `StandardBudgets, CustomBudgets, YearlyBudgets`それぞれの画面で初期値に設定されている0を消すことができませんでしたが
  入力の際に0を消して行えるように修正しました。

確認よろしくお願いします。