### PR TITLE
Modify the operations for groupBudgets

### DIFF
--- a/src/reducks/groupBudgets/actions.ts
+++ b/src/reducks/groupBudgets/actions.ts
@@ -1,46 +1,69 @@
 import { GroupStandardBudgetsList, GroupYearlyBudgetsList, GroupCustomBudgetsList } from './types';
 
 export type groupBudgetsActions = ReturnType<
-  | typeof updateGroupStandardBudgetsActions
+  | typeof fetchGroupStandardBudgetsActions
+  | typeof editGroupStandardBudgetsActions
   | typeof fetchGroupYearlyBudgetsActions
-  | typeof updateGroupCustomBudgetsActions
+  | typeof fetchGroupCustomBudgetsActions
+  | typeof addGroupCustomBudgetsActions
+  | typeof editGroupCustomBudgetsActions
   | typeof deleteGroupCustomBudgetsActions
 >;
 
-export const UPDATE_GROUP_STANDARD_BUDGETS = 'UPDATE_GROUP_STANDARD_BUDGETS';
-export const updateGroupStandardBudgetsActions = (
+export const FETCH_GROUP_STANDARD_BUDGETS = 'FETCH_GROUP_STANDARD_BUDGETS';
+export const fetchGroupStandardBudgetsActions = (
   groupStandardBudgetsList: GroupStandardBudgetsList
-): { type: string; payload: GroupStandardBudgetsList } => {
+) => {
   return {
-    type: UPDATE_GROUP_STANDARD_BUDGETS,
+    type: FETCH_GROUP_STANDARD_BUDGETS,
+    payload: groupStandardBudgetsList,
+  };
+};
+
+export const EDIT_GROUP_STANDARD_BUDGETS = 'EDIT_GROUP_STANDARD_BUDGETS';
+export const editGroupStandardBudgetsActions = (
+  groupStandardBudgetsList: GroupStandardBudgetsList
+) => {
+  return {
+    type: EDIT_GROUP_STANDARD_BUDGETS,
     payload: groupStandardBudgetsList,
   };
 };
 
 export const FETCH_GROUP_YEARLY_BUDGETS = 'FETCH_GROUP_YEARLY_BUDGETS';
-export const fetchGroupYearlyBudgetsActions = (
-  groupYearlyBudgetsList: GroupYearlyBudgetsList
-): { type: string; payload: GroupYearlyBudgetsList } => {
+export const fetchGroupYearlyBudgetsActions = (groupYearlyBudgetsList: GroupYearlyBudgetsList) => {
   return {
     type: FETCH_GROUP_YEARLY_BUDGETS,
     payload: groupYearlyBudgetsList,
   };
 };
 
-export const UPDATE_GROUP_CUSTOM_BUDGETS = 'UPDATE_GROUP_CUSTOM_BUDGETS';
-export const updateGroupCustomBudgetsActions = (
-  groupCustomBudgetsList: GroupCustomBudgetsList
-): { type: string; payload: GroupCustomBudgetsList } => {
+export const FETCH_GROUP_CUSTOM_BUDGETS = 'FETCH_GROUP_CUSTOM_BUDGETS';
+export const fetchGroupCustomBudgetsActions = (groupCustomBudgetsList: GroupCustomBudgetsList) => {
   return {
-    type: UPDATE_GROUP_CUSTOM_BUDGETS,
+    type: FETCH_GROUP_CUSTOM_BUDGETS,
     payload: groupCustomBudgetsList,
   };
 };
 
+export const ADD_GROUP_CUSTOM_BUDGETS = 'ADD_GROUP_CUSTOM_BUDGETS';
+export const addGroupCustomBudgetsActions = (groupYearlyBudgetsList: GroupYearlyBudgetsList) => {
+  return {
+    type: ADD_GROUP_CUSTOM_BUDGETS,
+    payload: groupYearlyBudgetsList,
+  };
+};
+
+export const EDIT_GROUP_CUSTOM_BUDGETS = 'EDIT_GROUP_CUSTOM_BUDGETS';
+export const editGroupCustomBudgetsActions = (groupYearlyBudgetsList: GroupYearlyBudgetsList) => {
+  return {
+    type: EDIT_GROUP_CUSTOM_BUDGETS,
+    payload: groupYearlyBudgetsList,
+  };
+};
+
 export const COPY_GROUP_STANDARD_BUDGETS = 'COPY_GROUP_STANDARD_BUDGETS';
-export const copyGroupStandardBudgetsActions = (
-  groupCustomBudgetsList: GroupCustomBudgetsList
-): { type: string; payload: GroupCustomBudgetsList } => {
+export const copyGroupStandardBudgetsActions = (groupCustomBudgetsList: GroupCustomBudgetsList) => {
   return {
     type: COPY_GROUP_STANDARD_BUDGETS,
     payload: groupCustomBudgetsList,
@@ -48,9 +71,7 @@ export const copyGroupStandardBudgetsActions = (
 };
 
 export const DELETE_GROUP_CUSTOM_BUDGETS = 'DELETE_GROUP_CUSTOM_BUDGETS';
-export const deleteGroupCustomBudgetsActions = (
-  groupYearlyBudgetsList: GroupYearlyBudgetsList
-): { type: string; payload: GroupYearlyBudgetsList } => {
+export const deleteGroupCustomBudgetsActions = (groupYearlyBudgetsList: GroupYearlyBudgetsList) => {
   return {
     type: DELETE_GROUP_CUSTOM_BUDGETS,
     payload: groupYearlyBudgetsList,

--- a/src/reducks/groupBudgets/operations.ts
+++ b/src/reducks/groupBudgets/operations.ts
@@ -1,8 +1,11 @@
 import {
-  updateGroupStandardBudgetsActions,
+  fetchGroupStandardBudgetsActions,
+  fetchGroupCustomBudgetsActions,
   fetchGroupYearlyBudgetsActions,
+  addGroupCustomBudgetsActions,
+  editGroupStandardBudgetsActions,
+  editGroupCustomBudgetsActions,
   copyGroupStandardBudgetsActions,
-  updateGroupCustomBudgetsActions,
   deleteGroupCustomBudgetsActions,
 } from './actions';
 import axios from 'axios';
@@ -17,88 +20,83 @@ import {
   DeleteGroupCustomBudgetsRes,
 } from './types';
 import { errorHandling, isValidBudgetFormat } from '../../lib/validation';
+import { totalCustomBudgets } from '../../lib/validation';
 import { State } from '../store/types';
-import { standardBudgetType } from '../../lib/constant';
+import { customBudgetType, standardBudgetType } from '../../lib/constant';
 
 export const fetchGroupStandardBudgets = (groupId: number) => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {
-    await axios
-      .get<GroupStandardBudgetsListRes>(
+    try {
+      const result = await axios.get<GroupStandardBudgetsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`,
         {
           withCredentials: true,
         }
-      )
-      .then((res) => {
-        const groupStandardBudgetsList = res.data.standard_budgets;
-        dispatch(updateGroupStandardBudgetsActions(groupStandardBudgetsList));
-      })
-      .catch((error) => {
-        errorHandling(dispatch, error);
-      });
+      );
+      const groupStandardBudgetsList = result.data.standard_budgets;
+      dispatch(fetchGroupStandardBudgetsActions(groupStandardBudgetsList));
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
   };
 };
 
 export const editGroupStandardBudgets = (groupBudgets: GroupBudgetsReq) => {
+  const data = { standard_budgets: groupBudgets };
   return async (dispatch: Dispatch<Action>, getState: () => State): Promise<void> => {
     const validBudgets = groupBudgets.every((groupBudget) =>
       isValidBudgetFormat(groupBudget.budget)
     );
+
     if (!validBudgets) {
       alert('予算は0以上の整数で入力してください。');
       return;
     }
 
-    const data = { standard_budgets: groupBudgets };
-
-    await axios
-      .put<GroupStandardBudgetsListRes>(
+    try {
+      const result = await axios.put<GroupStandardBudgetsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/1/standard-budgets`,
         JSON.stringify(data),
         {
           withCredentials: true,
         }
-      )
-      .then((res) => {
-        const editedGroupStandardBudgetsList: GroupStandardBudgetsList = res.data.standard_budgets;
-        const groupStandardBudgetsList: GroupStandardBudgetsList = getState().groupBudgets
-          .groupStandardBudgetsList;
+      );
+      const editedGroupStandardBudgetsList: GroupStandardBudgetsList = result.data.standard_budgets;
+      const groupStandardBudgetsList: GroupStandardBudgetsList = getState().groupBudgets
+        .groupStandardBudgetsList;
 
-        const nextGroupStandardBudgetsList = groupStandardBudgetsList.map((GroupStandardBudget) => {
-          const editGroupStandardBudget = editedGroupStandardBudgetsList.find(
-            (item: { big_category_id: number }) =>
-              item.big_category_id === GroupStandardBudget.big_category_id
-          );
-          if (editGroupStandardBudget) {
-            return editGroupStandardBudget;
-          }
-          return GroupStandardBudget;
-        });
-
-        dispatch(updateGroupStandardBudgetsActions(nextGroupStandardBudgetsList));
-      })
-      .catch((error) => {
-        errorHandling(dispatch, error);
+      const nextGroupStandardBudgetsList = groupStandardBudgetsList.map((GroupStandardBudget) => {
+        const editGroupStandardBudget = editedGroupStandardBudgetsList.find(
+          (item: { big_category_id: number }) =>
+            item.big_category_id === GroupStandardBudget.big_category_id
+        );
+        if (editGroupStandardBudget) {
+          return editGroupStandardBudget;
+        }
+        return GroupStandardBudget;
       });
+
+      dispatch(editGroupStandardBudgetsActions(nextGroupStandardBudgetsList));
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
   };
 };
 
 export const fetchGroupYearlyBudgets = (groupId: number, year: number) => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {
-    await axios
-      .get<GroupYearlyBudgetsList>(
+    try {
+      const result = await axios.get<GroupYearlyBudgetsList>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${year}`,
         {
           withCredentials: true,
         }
-      )
-      .then((res) => {
-        const groupYearlyBudgetsList = res.data;
-        dispatch(fetchGroupYearlyBudgetsActions(groupYearlyBudgetsList));
-      })
-      .catch((error) => {
-        errorHandling(dispatch, error);
-      });
+      );
+      const groupYearlyBudgetsList = result.data;
+      dispatch(fetchGroupYearlyBudgetsActions(groupYearlyBudgetsList));
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
   };
 };
 
@@ -128,21 +126,19 @@ export const fetchGroupCustomBudgets = (
   groupId: number
 ) => {
   return async (dispatch: Dispatch<Action>): Promise<void> => {
-    await axios
-      .get<GroupCustomBudgetsListRes>(
+    try {
+      const result = await axios.get<GroupCustomBudgetsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`,
         {
           withCredentials: true,
         }
-      )
-      .then((res) => {
-        const groupCustomBudgets = res.data.custom_budgets;
+      );
+      const groupCustomBudgets = result.data.custom_budgets;
 
-        dispatch(updateGroupCustomBudgetsActions(groupCustomBudgets));
-      })
-      .catch((error) => {
-        errorHandling(dispatch, error);
-      });
+      dispatch(fetchGroupCustomBudgetsActions(groupCustomBudgets));
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
   };
 };
 
@@ -153,7 +149,7 @@ export const addGroupCustomBudgets = (
   groupCustomBudgets: GroupBudgetsReq
 ) => {
   const data = { custom_budgets: groupCustomBudgets };
-  return async (dispatch: Dispatch<Action>): Promise<void> => {
+  return async (dispatch: Dispatch<Action>, getState: () => State): Promise<void> => {
     const validBudgets = groupCustomBudgets.every((groupCustomBudget) =>
       isValidBudgetFormat(groupCustomBudget.budget)
     );
@@ -163,22 +159,51 @@ export const addGroupCustomBudgets = (
       return;
     }
 
-    await axios
-      .post<GroupCustomBudgetsListRes>(
+    try {
+      const result = await axios.post<GroupCustomBudgetsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`,
         JSON.stringify(data),
         {
           withCredentials: true,
         }
-      )
-      .then((res) => {
-        const addedGroupCustomBudgetsList: GroupCustomBudgetsList = res.data.custom_budgets;
+      );
+      const addedGroupCustomBudgetsList: GroupCustomBudgetsList = result.data.custom_budgets;
+      const groupYearlyBudgetsList: GroupYearlyBudgetsList = getState().groupBudgets
+        .groupYearlyBudgetsList;
 
-        dispatch(updateGroupCustomBudgetsActions(addedGroupCustomBudgetsList));
-      })
-      .catch((error) => {
-        errorHandling(dispatch, error);
+      const groupCustomBudgets: number[] = addedGroupCustomBudgetsList.map((groupCustomBudget) => {
+        return groupCustomBudget.budget;
       });
+
+      const prevGroupCustomBudgetsTotal =
+        groupYearlyBudgetsList.monthly_budgets[Number(selectMonth) - 1].monthly_total_budget;
+
+      const nreTotalBudget = () => {
+        if (totalCustomBudgets(groupCustomBudgets) < prevGroupCustomBudgetsTotal) {
+          return (
+            groupYearlyBudgetsList.yearly_total_budget -
+            (prevGroupCustomBudgetsTotal - totalCustomBudgets(groupCustomBudgets))
+          );
+        } else {
+          return (
+            groupYearlyBudgetsList.yearly_total_budget +
+            (totalCustomBudgets(groupCustomBudgets) - prevGroupCustomBudgetsTotal)
+          );
+        }
+      };
+
+      groupYearlyBudgetsList.yearly_total_budget = nreTotalBudget();
+
+      groupYearlyBudgetsList.monthly_budgets[Number(selectMonth) - 1] = {
+        month: `${selectYear}年${selectMonth}月`,
+        budget_type: customBudgetType,
+        monthly_total_budget: totalCustomBudgets(groupCustomBudgets),
+      };
+
+      dispatch(addGroupCustomBudgetsActions(groupYearlyBudgetsList));
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
   };
 };
 
@@ -199,36 +224,51 @@ export const editGroupCustomBudgets = (
       return;
     }
 
-    await axios
-      .put<GroupCustomBudgetsListRes>(
+    try {
+      const result = await axios.put<GroupCustomBudgetsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`,
         JSON.stringify(data),
         {
           withCredentials: true,
         }
-      )
-      .then((res) => {
-        const editedGroupCustomBudgetsList: GroupCustomBudgetsList = res.data.custom_budgets;
+      );
+      const editedGroupCustomBudgetsList: GroupCustomBudgetsList = result.data.custom_budgets;
+      const groupYearlyBudgetsLis: GroupYearlyBudgetsList = getState().groupBudgets
+        .groupYearlyBudgetsList;
 
-        const groupCustomBudgetsList: GroupCustomBudgetsList = getState().groupBudgets
-          .groupCustomBudgetsList;
+      const prevGroupCustomBudgetTotal =
+        groupYearlyBudgetsLis.monthly_budgets[Number(selectMonth) - 1].monthly_total_budget;
 
-        const nextGroupCustomBudgetsList = groupCustomBudgetsList.map((groupCustomBudget) => {
-          const editGroupCustomBudget = editedGroupCustomBudgetsList.find(
-            (item: { big_category_id: number }) =>
-              item.big_category_id === groupCustomBudget.big_category_id
-          );
-          if (editGroupCustomBudget) {
-            return editGroupCustomBudget;
-          }
-          return groupCustomBudget;
-        });
-
-        dispatch(updateGroupCustomBudgetsActions(nextGroupCustomBudgetsList));
-      })
-      .catch((error) => {
-        errorHandling(dispatch, error);
+      const groupCustomBudget = editedGroupCustomBudgetsList.map((groupBudget) => {
+        return groupBudget.budget;
       });
+
+      const newTotalBudget = () => {
+        if (totalCustomBudgets(groupCustomBudget) < prevGroupCustomBudgetTotal) {
+          return (
+            groupYearlyBudgetsLis.yearly_total_budget -
+            (prevGroupCustomBudgetTotal - totalCustomBudgets(groupCustomBudget))
+          );
+        } else {
+          return (
+            groupYearlyBudgetsLis.yearly_total_budget +
+            (totalCustomBudgets(groupCustomBudget) - prevGroupCustomBudgetTotal)
+          );
+        }
+      };
+
+      groupYearlyBudgetsLis.yearly_total_budget = newTotalBudget();
+
+      groupYearlyBudgetsLis.monthly_budgets[Number(selectMonth) - 1] = {
+        month: `${selectYear}年${selectMonth}月`,
+        budget_type: customBudgetType,
+        monthly_total_budget: totalCustomBudgets(groupCustomBudget),
+      };
+
+      dispatch(editGroupCustomBudgetsActions(groupYearlyBudgetsLis));
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
   };
 };
 
@@ -238,65 +278,61 @@ export const deleteGroupCustomBudgets = (
   groupId: number
 ) => {
   return async (dispatch: Dispatch<Action>, getState: () => State): Promise<void> => {
-    await axios
-      .delete<DeleteGroupCustomBudgetsRes>(
+    try {
+      const result = await axios.delete<DeleteGroupCustomBudgetsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`,
         {
           withCredentials: true,
         }
-      )
-      .then((res) => {
-        const message = res.data.message;
+      );
+      const message = result.data.message;
 
-        const groupStandardBudgetsList: GroupStandardBudgetsList = getState().groupBudgets
-          .groupStandardBudgetsList;
+      const groupStandardBudgetsList: GroupStandardBudgetsList = getState().groupBudgets
+        .groupStandardBudgetsList;
 
-        const groupYearlyBudgetsList: GroupYearlyBudgetsList = getState().groupBudgets
-          .groupYearlyBudgetsList;
+      const groupYearlyBudgetsList: GroupYearlyBudgetsList = getState().groupBudgets
+        .groupYearlyBudgetsList;
 
-        const groupStandardBudgets = groupStandardBudgetsList.map((groupStandardBudget) => {
-          return groupStandardBudget.budget;
-        });
-
-        const totalGroupStandardBudget = () => {
-          let total = 0;
-
-          for (let i = 0, len = groupStandardBudgets.length; i < len; i++) {
-            total += groupStandardBudgets[i];
-          }
-          return total;
-        };
-
-        const newTotalBudget = () => {
-          const deleteBudget =
-            groupYearlyBudgetsList.monthly_budgets[Number(selectMonth) - 1].monthly_total_budget;
-
-          if (totalGroupStandardBudget() > deleteBudget) {
-            return (
-              groupYearlyBudgetsList.yearly_total_budget +
-              (totalGroupStandardBudget() - deleteBudget)
-            );
-          } else {
-            return (
-              groupYearlyBudgetsList.yearly_total_budget -
-              (deleteBudget - totalGroupStandardBudget())
-            );
-          }
-        };
-
-        groupYearlyBudgetsList.yearly_total_budget = newTotalBudget();
-
-        groupYearlyBudgetsList.monthly_budgets[Number(selectMonth) - 1] = {
-          month: `${selectYear}年${selectMonth}月`,
-          budget_type: standardBudgetType,
-          monthly_total_budget: totalGroupStandardBudget(),
-        };
-
-        dispatch(deleteGroupCustomBudgetsActions(groupYearlyBudgetsList));
-        alert(message);
-      })
-      .catch((error) => {
-        errorHandling(dispatch, error);
+      const groupStandardBudgets = groupStandardBudgetsList.map((groupStandardBudget) => {
+        return groupStandardBudget.budget;
       });
+
+      const totalGroupStandardBudget = () => {
+        let total = 0;
+
+        for (let i = 0, len = groupStandardBudgets.length; i < len; i++) {
+          total += groupStandardBudgets[i];
+        }
+        return total;
+      };
+
+      const newTotalBudget = () => {
+        const deleteBudget =
+          groupYearlyBudgetsList.monthly_budgets[Number(selectMonth) - 1].monthly_total_budget;
+
+        if (totalGroupStandardBudget() > deleteBudget) {
+          return (
+            groupYearlyBudgetsList.yearly_total_budget + (totalGroupStandardBudget() - deleteBudget)
+          );
+        } else {
+          return (
+            groupYearlyBudgetsList.yearly_total_budget - (deleteBudget - totalGroupStandardBudget())
+          );
+        }
+      };
+
+      groupYearlyBudgetsList.yearly_total_budget = newTotalBudget();
+
+      groupYearlyBudgetsList.monthly_budgets[Number(selectMonth) - 1] = {
+        month: `${selectYear}年${selectMonth}月`,
+        budget_type: standardBudgetType,
+        monthly_total_budget: totalGroupStandardBudget(),
+      };
+
+      dispatch(deleteGroupCustomBudgetsActions(groupYearlyBudgetsList));
+      alert(message);
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
   };
 };

--- a/src/reducks/groupBudgets/reducers.ts
+++ b/src/reducks/groupBudgets/reducers.ts
@@ -7,7 +7,12 @@ export const groupBudgetsReducer = (
   action: groupBudgetsActions
 ) => {
   switch (action.type) {
-    case Actions.UPDATE_GROUP_STANDARD_BUDGETS:
+    case Actions.FETCH_GROUP_STANDARD_BUDGETS:
+      return {
+        ...state,
+        groupStandardBudgetsList: [...action.payload],
+      };
+    case Actions.EDIT_GROUP_STANDARD_BUDGETS:
       return {
         ...state,
         groupStandardBudgetsList: [...action.payload],
@@ -17,10 +22,20 @@ export const groupBudgetsReducer = (
         ...state,
         groupYearlyBudgetsList: action.payload,
       };
-    case Actions.UPDATE_GROUP_CUSTOM_BUDGETS:
+    case Actions.FETCH_GROUP_CUSTOM_BUDGETS:
       return {
         ...state,
         groupCustomBudgetsList: [...action.payload],
+      };
+    case Actions.ADD_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        groupYearlyBudgetsList: action.payload,
+      };
+    case Actions.EDIT_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        groupYearlyBudgetsList: action.payload,
       };
     case Actions.COPY_GROUP_STANDARD_BUDGETS:
       return {

--- a/test/group-budgets-test/GroupBudgets.test.tsx
+++ b/test/group-budgets-test/GroupBudgets.test.tsx
@@ -17,7 +17,9 @@ import groupStandardBudgets from './fetchGroupStandardBudgetsResponse.json';
 import groupEditedStandardBudgets from './editGroupStandardBudgetsResponse.json';
 import groupYearlyBudgets from './fetchGroupYearlyBudgetsResponse.json';
 import groupAddedCustomBudgets from './addGroupCustomBudgetsResponse.json';
+import addGroupCustomBudgetPayload from './addGroupCustomBudgetsPayload.json';
 import groupCustomBudgets from './fetchGroupCustomBudgetsResponse.json';
+import editGroupCustomBudgetPayload from './editGroupCustomBudgetsPayload.json';
 import groupEditedCustomBudgets from './editGroupCustomBudgetsResponse.json';
 import groupDeletedCustomBudgets from './deleteGroupCustomBudgetsResponse.json';
 
@@ -40,7 +42,7 @@ describe('async actions fetchGroupStandardBudgets', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.UPDATE_GROUP_STANDARD_BUDGETS,
+        type: actionTypes.FETCH_GROUP_STANDARD_BUDGETS,
         payload: mockResponse.standard_budgets,
       },
     ];
@@ -142,7 +144,7 @@ describe('async actions editGroupStandardBudgets', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.UPDATE_GROUP_STANDARD_BUDGETS,
+        type: actionTypes.EDIT_GROUP_STANDARD_BUDGETS,
         payload: mockResponse.standard_budgets,
       },
     ];
@@ -203,7 +205,7 @@ describe('async actions getGroupCustomBudgets', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.UPDATE_GROUP_CUSTOM_BUDGETS,
+        type: actionTypes.FETCH_GROUP_CUSTOM_BUDGETS,
         payload: mockResponse.custom_budgets,
       },
     ];
@@ -221,9 +223,17 @@ describe('async actions addGroupCustomBudgets', () => {
   });
   const groupId = 1;
   const selectYear = '2020';
-  const selectMonth = '01';
-  const store = mockStore({ groupCustomBudgets });
+  const selectMonth = '02';
+  const store = mockStore({ groupBudgets: { groupYearlyBudgetsList: groupYearlyBudgets } });
   const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+
+  const getState = () => {
+    return {
+      groupBudgets: {
+        groupYearlyBudgetsList: groupYearlyBudgets,
+      },
+    };
+  };
 
   it('Add groupCustomBudgets if fetch succeeds', async () => {
     const mockResponse = groupAddedCustomBudgets;
@@ -299,8 +309,8 @@ describe('async actions addGroupCustomBudgets', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.UPDATE_GROUP_CUSTOM_BUDGETS,
-        payload: mockResponse.custom_budgets,
+        type: actionTypes.ADD_GROUP_CUSTOM_BUDGETS,
+        payload: addGroupCustomBudgetPayload,
       },
     ];
 
@@ -311,7 +321,8 @@ describe('async actions addGroupCustomBudgets', () => {
       selectMonth,
       groupId,
       mockRequest.custom_budgets
-    )(store.dispatch);
+      // @ts-ignore
+    )(store.dispatch, getState);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });
@@ -321,8 +332,10 @@ describe('async actions editGroupCustomBudgets', () => {
     store.clearActions();
   });
   const selectYear = '2020';
-  const selectMonth = '01';
-  const store = mockStore({ groupAddedCustomBudgets });
+  const selectMonth = '02';
+  const store = mockStore({
+    groupBudgets: { groupYearlyBudgetsList: addGroupCustomBudgetPayload },
+  });
 
   const groupId = 1;
   const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
@@ -331,7 +344,7 @@ describe('async actions editGroupCustomBudgets', () => {
     const getState = () => {
       return {
         groupBudgets: {
-          groupCustomBudgetsList: groupAddedCustomBudgets.custom_budgets,
+          groupYearlyBudgetsList: addGroupCustomBudgetPayload,
         },
       };
     };
@@ -409,8 +422,8 @@ describe('async actions editGroupCustomBudgets', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.UPDATE_GROUP_CUSTOM_BUDGETS,
-        payload: mockResponse.custom_budgets,
+        type: actionTypes.EDIT_GROUP_CUSTOM_BUDGETS,
+        payload: editGroupCustomBudgetPayload,
       },
     ];
 
@@ -431,10 +444,15 @@ describe('async actions deleteGroupCustomBudgets', () => {
   beforeEach(() => {
     store.clearActions();
   });
-  const store = mockStore({ groupYearlyBudgets });
+  const store = mockStore({
+    groupBudgets: {
+      groupYearlyBudgetsList: groupYearlyBudgets,
+      groupStandardBudgetsList: groupEditedStandardBudgets.standard_budgets,
+    },
+  });
 
   const selectYear = '2020';
-  const selectMonth = '01';
+  const selectMonth = '02';
   const groupId = 1;
   const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
 
@@ -443,21 +461,21 @@ describe('async actions deleteGroupCustomBudgets', () => {
       return {
         groupBudgets: {
           groupStandardBudgetsList: groupEditedStandardBudgets.standard_budgets,
-          groupYearlyBudgetsList: groupYearlyBudgets,
+          groupYearlyBudgetsList: editGroupCustomBudgetPayload,
         },
       };
     };
 
     const mockResponse = groupDeletedCustomBudgets.message;
 
-    const mockRequest = {
+    const mockPayload = {
       year: '2020-01-01T00:00:00Z',
-      yearly_total_budget: 1775000,
+      yearly_total_budget: 1801500,
       monthly_budgets: [
         {
           month: '2020年01月',
-          budget_type: 'StandardBudget',
-          monthly_total_budget: 143500,
+          budget_type: 'CustomBudget',
+          monthly_total_budget: 170000,
         },
         {
           month: '2020年02月',
@@ -520,7 +538,7 @@ describe('async actions deleteGroupCustomBudgets', () => {
     const expectedActions = [
       {
         type: actionTypes.DELETE_GROUP_CUSTOM_BUDGETS,
-        payload: mockRequest,
+        payload: mockPayload,
       },
     ];
 

--- a/test/group-budgets-test/addGroupCustomBudgetsPayload.json
+++ b/test/group-budgets-test/addGroupCustomBudgetsPayload.json
@@ -1,0 +1,66 @@
+{
+  "year": "2020-01-01T00:00:00Z",
+  "yearly_total_budget": 1813000,
+  "monthly_budgets": [
+    {
+      "month": "2020年01月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 170000
+    },
+    {
+      "month": "2020年02月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 155000
+    },
+    {
+      "month": "2020年03月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年04月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年05月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年06月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年07月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 170000
+    },
+    {
+      "month": "2020年08月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年09月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年10月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年11月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年12月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 170000
+    }
+  ]
+}

--- a/test/group-budgets-test/editGroupCustomBudgetsPayload.json
+++ b/test/group-budgets-test/editGroupCustomBudgetsPayload.json
@@ -1,0 +1,66 @@
+{
+  "year": "2020-01-01T00:00:00Z",
+  "yearly_total_budget": 1822000,
+  "monthly_budgets": [
+    {
+      "month": "2020年01月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 170000
+    },
+    {
+      "month": "2020年02月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 164000
+    },
+    {
+      "month": "2020年03月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年04月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年05月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年06月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年07月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 170000
+    },
+    {
+      "month": "2020年08月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年09月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年10月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年11月",
+      "budget_type": "StandardBudget",
+      "monthly_total_budget": 143500
+    },
+    {
+      "month": "2020年12月",
+      "budget_type": "CustomBudget",
+      "monthly_total_budget": 170000
+    }
+  ]
+}


### PR DESCRIPTION
- actionsでGET, POST, PUT,DELETEをまとめて`UPDATE`というactionでまとめていましたが、それぞれのactionTypeを明確にするため 
 に`StandardBudgets, CustomBudgets`の`FETCH, ADD, EDIT`のactionを追加しました。

- カスタム予算の追加, 編集後に年間予算画面にルーティングを行う形に修正したのに伴い、 追加, 編集と同時にカスタム予算を年間予算に
  反映させるため`groupYearlyBudgets`をdispatchする形に修正しました。

- 上記の変更に伴いテストを修正しました。

確認よろしくお願いします。