### PR TITLE
Add the group accounting acquisition process to groupTransactions

### DIFF
--- a/src/reducks/groupTransactions/actions.ts
+++ b/src/reducks/groupTransactions/actions.ts
@@ -1,7 +1,9 @@
-import { GroupTransactionsList } from './types';
+import { GroupTransactionsList, GroupAccountList } from './types';
 
 export type groupTransactionsAction = ReturnType<
-  typeof updateGroupTransactionsAction | typeof updateGroupLatestTransactionsAction
+  | typeof updateGroupTransactionsAction
+  | typeof updateGroupLatestTransactionsAction
+  | typeof fetchGroupAccountAction
 >;
 
 export const UPDATE_GROUP_TRANSACTIONS = 'UPDATE_GROUP_TRANSACTIONS';
@@ -19,5 +21,13 @@ export const updateGroupLatestTransactionsAction = (
   return {
     type: UPDATE_GROUP_LATEST_TRANSACTIONS,
     payload: groupLatestTransactionsList,
+  };
+};
+
+export const FETCH_GROUP_ACCOUNT = 'FETCH_GROUP_ACCOUNT';
+export const fetchGroupAccountAction = (groupAccountList: GroupAccountList) => {
+  return {
+    type: FETCH_GROUP_ACCOUNT,
+    payload: groupAccountList,
   };
 };

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -1,4 +1,8 @@
-import { updateGroupTransactionsAction, updateGroupLatestTransactionsAction } from './actions';
+import {
+  updateGroupTransactionsAction,
+  updateGroupLatestTransactionsAction,
+  fetchGroupAccountAction,
+} from './actions';
 import axios from 'axios';
 import { Dispatch, Action } from 'redux';
 import {
@@ -7,6 +11,7 @@ import {
   FetchGroupTransactionsRes,
   GroupLatestTransactionsListRes,
   deleteGroupTransactionRes,
+  GroupAccountList,
 } from './types';
 import { State } from '../store/types';
 import { push } from 'connected-react-router';
@@ -346,6 +351,24 @@ export const deleteGroupLatestTransactions = (id: number, groupId: number) => {
       );
 
       dispatch(updateGroupLatestTransactionsAction(nextGroupLatestTransactionsList));
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
+  };
+};
+
+export const fetchGroupAccount = (groupId: number, year: number, customMont: string) => {
+  return async (dispatch: Dispatch<Action>) => {
+    try {
+      const result = await axios.get<GroupAccountList>(
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMont}/account`,
+        {
+          withCredentials: true,
+        }
+      );
+      const groupAccountList = result.data;
+
+      dispatch(fetchGroupAccountAction(groupAccountList));
     } catch (error) {
       errorHandling(dispatch, error);
     }

--- a/src/reducks/groupTransactions/reducers.ts
+++ b/src/reducks/groupTransactions/reducers.ts
@@ -17,6 +17,11 @@ export const groupTransactionsReducer = (
         ...state,
         groupLatestTransactionsList: [...action.payload],
       };
+    case Actions.FETCH_GROUP_ACCOUNT:
+      return {
+        ...state,
+        groupAccountList: action.payload,
+      };
     default:
       return state;
   }

--- a/src/reducks/groupTransactions/selectors.ts
+++ b/src/reducks/groupTransactions/selectors.ts
@@ -12,3 +12,8 @@ export const getGroupLatestTransactions = createSelector(
   [groupTransactionsSelector],
   (state) => state.groupLatestTransactionsList
 );
+
+export const getGroupAccountList = createSelector(
+  [groupTransactionsSelector],
+  (state) => state.groupAccountList
+);

--- a/src/reducks/groupTransactions/types.ts
+++ b/src/reducks/groupTransactions/types.ts
@@ -41,3 +41,25 @@ export interface FetchGroupTransactionsRes {
 export interface deleteGroupTransactionRes {
   message: string;
 }
+
+export interface GroupAccount {
+  id: number;
+  group_id: number;
+  month: string;
+  payer_user_id: string;
+  recipient_user_id: string;
+  payment_amount: number;
+  payment_confirmation: boolean;
+  receipt_confirmation: boolean;
+}
+
+export interface GroupAccounts extends Array<GroupAccount> {}
+
+export interface GroupAccountList {
+  group_id: number;
+  month: string;
+  group_total_payment_amount: number;
+  group_average_payment_amount: number;
+  group_remaining_amount: number;
+  group_accounts_list: GroupAccounts;
+}

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -15,6 +15,14 @@ const initialState = {
   groupTransactions: {
     groupLatestTransactionsList: [],
     groupTransactionsList: [],
+    groupAccountList: {
+      group_id: 0,
+      month: '',
+      group_total_payment_amount: 0,
+      group_average_payment_amount: 0,
+      group_remaining_amount: 0,
+      group_accounts_list: [],
+    },
   },
   budgets: {
     standard_budgets_list: [],

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -2,7 +2,7 @@ import { Categories } from '../categories/types';
 import { GroupCategories } from '../groupCategories/types';
 import { Groups } from '../groups/types';
 import { TransactionsList } from '../transactions/types';
-import { GroupTransactionsList } from '../groupTransactions/types';
+import { GroupTransactionsList, GroupAccountList } from '../groupTransactions/types';
 import { StandardBudgetsList, YearlyBudgetsList, CustomBudgetsList } from '../budgets/types';
 import {
   GroupStandardBudgetsList,
@@ -30,6 +30,7 @@ export interface State {
   groupTransactions: {
     groupLatestTransactionsList: GroupTransactionsList;
     groupTransactionsList: GroupTransactionsList;
+    groupAccountList: GroupAccountList;
   };
   budgets: {
     standard_budgets_list: StandardBudgetsList;

--- a/test/group-transactions-test/GroupTransactions.test.tsx
+++ b/test/group-transactions-test/GroupTransactions.test.tsx
@@ -14,6 +14,7 @@ import {
   addGroupLatestTransactions,
   editGroupLatestTransactionsList,
   deleteGroupLatestTransactions,
+  fetchGroupAccount,
 } from '../../src/reducks/groupTransactions/operations';
 import groupTransactions from './groupTransactions.json';
 import groupLatestTransactions from './groupLatestTransactions.json';
@@ -25,6 +26,7 @@ import editedGroupTransaction from './editedGroupTransactions.json';
 import editedGroupLatestTransactions from './editedGroupLatestTransactions.json';
 import deleteResponse from './deleteResponse.json';
 import deletedGroupLatestTransaction from './deletedGroupLatestTransactions.json';
+import groupAccountList from './groupAccountList.json';
 import { year, customMonth } from '../../src/lib/constant';
 
 const axiosMock = new axiosMockAdapter(axios);
@@ -427,6 +429,33 @@ describe('async actions groupTransactions', () => {
 
     // @ts-ignore
     await deleteGroupLatestTransactions(id, groupId)(store.dispatch, getState);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('Get groupAccountList  if fetch succeeds', async () => {
+    beforeEach(() => {
+      store.clearActions();
+    });
+
+    const store = mockStore({ groupLatestTransactionsList: { groupAccountList: [] } });
+
+    const groupId = 1;
+    const year = 2020;
+    const customMonth = '11';
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMonth}/account`;
+
+    const mockResponse = groupAccountList;
+
+    const expectedActions = [
+      {
+        type: actionTypes.FETCH_GROUP_ACCOUNT,
+        payload: mockResponse,
+      },
+    ];
+
+    axiosMock.onGet(url).reply(200, mockResponse);
+
+    await fetchGroupAccount(groupId, year, customMonth)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });

--- a/test/group-transactions-test/groupAccountList.json
+++ b/test/group-transactions-test/groupAccountList.json
@@ -1,0 +1,49 @@
+{
+  "group_id": 1,
+  "month": "2020-11-01T00:00:00Z",
+  "group_total_payment_amount": 156000,
+  "group_average_payment_amount": 26000,
+  "group_remaining_amount": 0,
+  "group_accounts_list": [
+    {
+      "id": 14,
+      "group_id": 1,
+      "month": "2020-11-01T00:00:00Z",
+      "payer_user_id": "test4",
+      "recipient_user_id": "anraku",
+      "payment_amount": 19000,
+      "payment_confirmation": false,
+      "receipt_confirmation": false
+    },
+    {
+      "id": 15,
+      "group_id": 1,
+      "month": "2020-11-01T00:00:00Z",
+      "payer_user_id": "test5",
+      "recipient_user_id": "taira",
+      "payment_amount": 20000,
+      "payment_confirmation": false,
+      "receipt_confirmation": false
+    },
+    {
+      "id": 16,
+      "group_id": 1,
+      "month": "2020-11-01T00:00:00Z",
+      "payer_user_id": "furusawa",
+      "recipient_user_id": "taira",
+      "payment_amount": 14000,
+      "payment_confirmation": false,
+      "receipt_confirmation": false
+    },
+    {
+      "id": 17,
+      "group_id": 1,
+      "month": "2020-11-01T00:00:00Z",
+      "payer_user_id": "furusawa",
+      "recipient_user_id": "ito",
+      "payment_amount": 4000,
+      "payment_confirmation": false,
+      "receipt_confirmation": false
+    }
+  ]
+}


### PR DESCRIPTION
- グループの会計データを取得する処理の`actions, reducers, selectors, types, initialState`を追加しました。

- グループの会計データを取得する処理を行う`fetchGroupAccount`を追加しました。

- `fetchGroupAccount`のテストを追加しました。

確認よろしくお願いします。