### PR TITLE
Add addGroupAccount to groupTransactions and modify fetchGroupAccount

### DIFF
--- a/src/reducks/groupTransactions/actions.ts
+++ b/src/reducks/groupTransactions/actions.ts
@@ -4,6 +4,7 @@ export type groupTransactionsAction = ReturnType<
   | typeof updateGroupTransactionsAction
   | typeof updateGroupLatestTransactionsAction
   | typeof fetchGroupAccountAction
+  | typeof addGroupAccountAction
 >;
 
 export const UPDATE_GROUP_TRANSACTIONS = 'UPDATE_GROUP_TRANSACTIONS';
@@ -25,9 +26,23 @@ export const updateGroupLatestTransactionsAction = (
 };
 
 export const FETCH_GROUP_ACCOUNT = 'FETCH_GROUP_ACCOUNT';
-export const fetchGroupAccountAction = (groupAccountList: GroupAccountList) => {
+export const fetchGroupAccountAction = (
+  groupAccountList: GroupAccountList,
+  notAccountMessage: string
+) => {
   return {
     type: FETCH_GROUP_ACCOUNT,
+    payload: {
+      groupAccountList,
+      notAccountMessage,
+    },
+  };
+};
+
+export const ADD_GROUP_ACCOUNT = 'ADD_GROUP_ACCOUNT';
+export const addGroupAccountAction = (groupAccountList: GroupAccountList) => {
+  return {
+    type: ADD_GROUP_ACCOUNT,
     payload: groupAccountList,
   };
 };

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -2,6 +2,7 @@ import {
   updateGroupTransactionsAction,
   updateGroupLatestTransactionsAction,
   fetchGroupAccountAction,
+  addGroupAccountAction,
 } from './actions';
 import axios from 'axios';
 import { Dispatch, Action } from 'redux';
@@ -12,6 +13,7 @@ import {
   GroupLatestTransactionsListRes,
   deleteGroupTransactionRes,
   GroupAccountList,
+  GroupAccountListRes,
 } from './types';
 import { State } from '../store/types';
 import { push } from 'connected-react-router';
@@ -360,7 +362,7 @@ export const deleteGroupLatestTransactions = (id: number, groupId: number) => {
 export const fetchGroupAccount = (groupId: number, year: number, customMont: string) => {
   return async (dispatch: Dispatch<Action>) => {
     try {
-      const result = await axios.get<GroupAccountList>(
+      const result = await axios.get<GroupAccountListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMont}/account`,
         {
           withCredentials: true,
@@ -368,7 +370,35 @@ export const fetchGroupAccount = (groupId: number, year: number, customMont: str
       );
       const groupAccountList = result.data;
 
-      dispatch(fetchGroupAccountAction(groupAccountList));
+      if (groupAccountList !== undefined) {
+        const message = '';
+
+        dispatch(fetchGroupAccountAction(groupAccountList, message));
+      } else {
+        const message = result.data.message;
+        const emptyGroupAccountList = {} as GroupAccountList;
+
+        dispatch(fetchGroupAccountAction(emptyGroupAccountList, message));
+      }
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
+  };
+};
+
+export const addGroupAccount = (groupId: number, year: number, customMonth: string) => {
+  return async (dispatch: Dispatch<Action>) => {
+    try {
+      const result = await axios.post<GroupAccountList>(
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMonth}/account`,
+        null,
+        {
+          withCredentials: true,
+        }
+      );
+      const groupAccountList = result.data;
+
+      dispatch(addGroupAccountAction(groupAccountList));
     } catch (error) {
       errorHandling(dispatch, error);
     }

--- a/src/reducks/groupTransactions/reducers.ts
+++ b/src/reducks/groupTransactions/reducers.ts
@@ -20,6 +20,11 @@ export const groupTransactionsReducer = (
     case Actions.FETCH_GROUP_ACCOUNT:
       return {
         ...state,
+        ...action.payload,
+      };
+    case Actions.ADD_GROUP_ACCOUNT:
+      return {
+        ...state,
         groupAccountList: action.payload,
       };
     default:

--- a/src/reducks/groupTransactions/selectors.ts
+++ b/src/reducks/groupTransactions/selectors.ts
@@ -17,3 +17,8 @@ export const getGroupAccountList = createSelector(
   [groupTransactionsSelector],
   (state) => state.groupAccountList
 );
+
+export const getNotGroupAccountMessage = createSelector(
+  [groupTransactionsSelector],
+  (state) => state.notAccountMessage
+);

--- a/src/reducks/groupTransactions/types.ts
+++ b/src/reducks/groupTransactions/types.ts
@@ -63,3 +63,13 @@ export interface GroupAccountList {
   group_remaining_amount: number;
   group_accounts_list: GroupAccounts;
 }
+
+export interface GroupAccountListRes {
+  message: string;
+  group_id: number;
+  month: string;
+  group_total_payment_amount: number;
+  group_average_payment_amount: number;
+  group_remaining_amount: number;
+  group_accounts_list: GroupAccounts;
+}

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -15,6 +15,7 @@ const initialState = {
   groupTransactions: {
     groupLatestTransactionsList: [],
     groupTransactionsList: [],
+    notAccountMessage: '',
     groupAccountList: {
       group_id: 0,
       month: '',

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -31,6 +31,7 @@ export interface State {
     groupLatestTransactionsList: GroupTransactionsList;
     groupTransactionsList: GroupTransactionsList;
     groupAccountList: GroupAccountList;
+    notAccountMessage: string;
   };
   budgets: {
     standard_budgets_list: StandardBudgetsList;

--- a/test/group-transactions-test/GroupTransactions.test.tsx
+++ b/test/group-transactions-test/GroupTransactions.test.tsx
@@ -15,6 +15,7 @@ import {
   editGroupLatestTransactionsList,
   deleteGroupLatestTransactions,
   fetchGroupAccount,
+  addGroupAccount,
 } from '../../src/reducks/groupTransactions/operations';
 import groupTransactions from './groupTransactions.json';
 import groupLatestTransactions from './groupLatestTransactions.json';
@@ -449,13 +450,45 @@ describe('async actions groupTransactions', () => {
     const expectedActions = [
       {
         type: actionTypes.FETCH_GROUP_ACCOUNT,
-        payload: mockResponse,
+        payload: {
+          groupAccountList: mockResponse,
+          notAccountMessage: '',
+        },
       },
     ];
 
     axiosMock.onGet(url).reply(200, mockResponse);
 
     await fetchGroupAccount(groupId, year, customMonth)(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('Post groupAccountList  if fetch succeeds', async () => {
+    const store = mockStore({
+      groupLatestTransactionsList: { groupAccountList: groupAccountList },
+    });
+
+    beforeEach(() => {
+      store.clearActions();
+    });
+
+    const groupId = 1;
+    const year = 2020;
+    const customMonth = '11';
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMonth}/account`;
+
+    const mockResponse = groupAccountList;
+
+    const expectedActions = [
+      {
+        type: actionTypes.ADD_GROUP_ACCOUNT,
+        payload: mockResponse,
+      },
+    ];
+
+    axiosMock.onPost(url).reply(201, mockResponse);
+
+    await addGroupAccount(groupId, year, customMonth)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });


### PR DESCRIPTION
- グループの会計データを追加する処理の`actions, reducers`を追加しました。

- グループの会計データを追加する処理を行う`addGroupAccount`を追加しました。

- `addGroupAccount`のテストを追加しました。

- グループの会計データを取得する`fetchGroupAccount`に、会計データがない場合のレスポンスメッセージを表示させるために
  メッセージをactionのpayloadに追加しました。

- `groupTransactions / selector`にグループの会計データがない場合に表示する`notAccountMessage`を追加しました。

- メッセージ追加の変更に伴い、`fetchGroupAccount`のテストを修正しました。

確認よろしくお願いします。
