### PR TITLE
Add SearchTransaction in transaction

### DIFF
--- a/src/components/uikit/SearchTransaction.tsx
+++ b/src/components/uikit/SearchTransaction.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
+import { searchTransactions } from '../../reducks/transactions/operations';
 import '../../assets/history/daily-history.scss';
 import { DatePicker, CategoryInput, TextInput, KindSelectBox, GenericButton } from './index';
 
@@ -7,10 +9,12 @@ interface SearchTransactionProps {
   openSearchFiled: boolean;
   openSearch: () => void;
   closeSearch: () => void;
-  selectDateChange: (selectDate: Date | null) => void;
+  selectStartDateChange: (selectStartDate: Date | null) => void;
+  selectEndDateChange: (selectEndDate: Date | null) => void;
   selectTransactionsType: (event: React.ChangeEvent<{ value: unknown }>) => void;
   inputMemo: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  inputAmount: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  inputLowAmount: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  inputHighAmount: (event: React.ChangeEvent<HTMLInputElement>) => void;
   inputShop: (event: React.ChangeEvent<HTMLInputElement>) => void;
   changeCategory: (event: React.ChangeEvent<{ value: unknown }>) => void;
   selectCategory: (
@@ -18,8 +22,10 @@ interface SearchTransactionProps {
     associatedCategoryId: number | null,
     category_type: string
   ) => void;
-  selectDate: Date | null;
-  amount: string;
+  selectStartDate: Date | null;
+  selectEndDate: Date | null;
+  lowAmount: string;
+  highAmount: string;
   memo: string;
   shop: string;
   category: string;
@@ -30,6 +36,17 @@ interface SearchTransactionProps {
 }
 
 const SearchTransaction = (props: SearchTransactionProps) => {
+  const dispatch = useDispatch();
+
+  const searchRequestData = {
+    transaction_type: props.transactionType,
+    low_amount: props.lowAmount,
+    high_amount: props.highAmount,
+    big_category_id: 2,
+    memo: props.memo,
+    shop: props.shop,
+  };
+
   return (
     <>
       <button className="daily-history__search-btn" onClick={props.openSearch}>
@@ -78,22 +95,22 @@ const SearchTransaction = (props: SearchTransactionProps) => {
           </div>
           <div>
             <TextInput
-              value={props.shop}
+              value={props.lowAmount}
               fullWidth={true}
               id={'amount'}
               label={'最低金額'}
-              onChange={props.inputAmount}
+              onChange={props.inputLowAmount}
               required={false}
               type={'text'}
             />
           </div>
           <div className="daily-history__input-form">
             <TextInput
-              value={props.shop}
+              value={props.highAmount}
               fullWidth={true}
               id={'amount'}
               label={'最高金額'}
-              onChange={props.inputAmount}
+              onChange={props.inputHighAmount}
               required={false}
               type={'text'}
             />
@@ -102,25 +119,25 @@ const SearchTransaction = (props: SearchTransactionProps) => {
             <DatePicker
               id={'startDate'}
               label={'開始日'}
-              onChange={props.selectDateChange}
+              onChange={props.selectStartDateChange}
               required={false}
-              value={props.selectDate}
+              value={props.selectStartDate}
             />
           </div>
           <div>
             <DatePicker
               id={'endDate'}
               label={'終了日'}
-              onChange={props.selectDateChange}
+              onChange={props.selectEndDateChange}
               required={false}
-              value={props.selectDate}
+              value={props.selectEndDate}
             />
           </div>
           <div className="daily-history__search-btn-position">
             <GenericButton
               disabled={false}
               label={'この条件で絞り込む'}
-              onClick={props.closeSearch}
+              onClick={() => dispatch(searchTransactions(searchRequestData)) && props.closeSearch()}
             />
           </div>
         </div>

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -10,6 +10,7 @@ const initialState = {
   transactions: {
     latestTransactionsList: [],
     transactionsList: [],
+    searchTransactionsList: [],
     noTransactionsMessage: '',
   },
   groupTransactions: {

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -25,6 +25,7 @@ export interface State {
   transactions: {
     latestTransactionsList: TransactionsList;
     transactionsList: TransactionsList;
+    searchTransactionsList: TransactionsList;
     noTransactionsMessage: string;
   };
   groupTransactions: {

--- a/src/reducks/transactions/actions.ts
+++ b/src/reducks/transactions/actions.ts
@@ -3,6 +3,7 @@ export type transactionActions = ReturnType<
   | typeof updateTransactionsAction
   | typeof fetchTransactionsActions
   | typeof updateLatestTransactionsActions
+  | typeof searchTransactionsActions
 >;
 
 export const FETCH_TRANSACTIONS = 'FETCH_TRANSACTIONS';
@@ -32,5 +33,13 @@ export const updateTransactionsAction = (transactionsList: TransactionsList) => 
   return {
     type: UPDATE_TRANSACTIONS,
     payload: transactionsList,
+  };
+};
+
+export const SEARCH_TRANSACTIONS = 'SEARCH_TRANSACTIONS';
+export const searchTransactionsActions = (searchTransactionsList: TransactionsList) => {
+  return {
+    type: SEARCH_TRANSACTIONS,
+    payload: searchTransactionsList,
   };
 };

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -2,6 +2,7 @@ import {
   fetchTransactionsActions,
   updateTransactionsAction,
   updateLatestTransactionsActions,
+  searchTransactionsActions,
 } from './actions';
 import axios from 'axios';
 import { Dispatch, Action } from 'redux';
@@ -338,6 +339,49 @@ export const deleteLatestTransactions = (id: number) => {
       );
 
       dispatch(updateLatestTransactionsActions(nextLatestTransactionsList));
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
+  };
+};
+
+export const searchTransactions = (searchRequestData: {
+  transaction_type?: string;
+  start_transaction_date?: Date | null;
+  end_transaction_date?: Date | null;
+  shop?: string | null;
+  memo?: string | null;
+  low_amount?: string | number;
+  high_amount?: string | number;
+  big_category_id?: number;
+  sort?: string;
+  sort_type?: string;
+  limit?: number;
+}) => {
+  return async (dispatch: Dispatch<Action>) => {
+    try {
+      const result = await axios.get<TransactionsList>(
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/search?`,
+        {
+          withCredentials: true,
+          params: {
+            start_date: searchRequestData.start_transaction_date,
+            end_date: searchRequestData.end_transaction_date,
+            transaction_type: searchRequestData.transaction_type,
+            low_amount: searchRequestData.low_amount,
+            high_amount: searchRequestData.high_amount,
+            shop: searchRequestData.shop,
+            memo: searchRequestData.memo,
+            big_category_id: searchRequestData.big_category_id,
+            sort: searchRequestData.sort,
+            sort_type: searchRequestData.sort_type,
+            limit: searchRequestData.limit,
+          },
+        }
+      );
+      const searchTransactionsList = result.data;
+
+      dispatch(searchTransactionsActions(searchTransactionsList));
     } catch (error) {
       errorHandling(dispatch, error);
     }

--- a/src/reducks/transactions/reducers.ts
+++ b/src/reducks/transactions/reducers.ts
@@ -22,6 +22,11 @@ export const transactionsReducer = (
         ...state,
         transactionsList: [...action.payload],
       };
+    case Actions.SEARCH_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
     default:
       return state;
   }

--- a/src/templates/DailyHistory.tsx
+++ b/src/templates/DailyHistory.tsx
@@ -27,10 +27,12 @@ const DailyHistory = (props: DailyHistoryProps) => {
   const pathName = getPathTemplateName(window.location.pathname);
   const groupId = getPathGroupId(window.location.pathname);
   const [openSearchField, setOpenSearchField] = useState<boolean>(false);
-  const [selectDate, setSelectDate] = useState<Date | null>(new Date());
+  const [selectStartDate, setStartSelectDate] = useState<Date | null>(new Date());
+  const [selectEndDate, setEndSelectDate] = useState<Date | null>(new Date());
   const [memo, setMemo] = useState<string>('');
   const [shop, setShop] = useState<string>('');
-  const [amount, setAmount] = useState<string>('');
+  const [lowAmount, setLowAmount] = useState<string>('');
+  const [highAmount, setHighAmount] = useState<string>('');
   const [category, setCategory] = useState<string>('');
   const [bigCategoryId, setBigCategoryId] = useState<number>(0);
   const [mediumCategoryId, setMediumCategoryId] = useState<number | null>(null);
@@ -61,8 +63,12 @@ const DailyHistory = (props: DailyHistoryProps) => {
     setOpenSearchField(false);
   }, [setOpenSearchField]);
 
-  const selectDateChange = useCallback((selectDate: Date | null) => {
-    setSelectDate(selectDate as Date);
+  const selectStartDateChange = useCallback((selectStartDate: Date | null) => {
+    setStartSelectDate(selectStartDate as Date);
+  }, []);
+
+  const selectEndDateChange = useCallback((selectEndDate: Date | null) => {
+    setEndSelectDate(selectEndDate as Date);
   }, []);
 
   const inputMemo = useCallback(
@@ -79,11 +85,18 @@ const DailyHistory = (props: DailyHistoryProps) => {
     [setShop]
   );
 
-  const inputAmount = useCallback(
+  const inputLowAmount = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setAmount(event.target.value);
+      setLowAmount(event.target.value);
     },
-    [setAmount]
+    [setLowAmount]
+  );
+
+  const inputHighAmount = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setHighAmount(event.target.value);
+    },
+    [setHighAmount]
   );
 
   const changeCategory = useCallback(
@@ -126,13 +139,9 @@ const DailyHistory = (props: DailyHistoryProps) => {
           openSearch={openSearch}
           openSearchFiled={openSearchField}
           pathName={pathName}
-          selectDate={selectDate}
-          selectDateChange={selectDateChange}
-          inputAmount={inputAmount}
           inputMemo={inputMemo}
           inputShop={inputShop}
           selectTransactionsType={selectTransactionType}
-          amount={amount}
           memo={memo}
           shop={shop}
           transactionType={transactionType}
@@ -140,6 +149,14 @@ const DailyHistory = (props: DailyHistoryProps) => {
           selectCategory={selectCategory}
           changeCategory={changeCategory}
           bigCategoryId={bigCategoryId}
+          selectStartDate={selectStartDate}
+          selectEndDate={selectEndDate}
+          highAmount={highAmount}
+          lowAmount={lowAmount}
+          selectStartDateChange={selectStartDateChange}
+          selectEndDateChange={selectEndDateChange}
+          inputHighAmount={inputHighAmount}
+          inputLowAmount={inputLowAmount}
           customCategoryId={customCategoryId}
           mediumCategoryId={mediumCategoryId}
         />

--- a/test/transactions-test/Transactions.test.tsx
+++ b/test/transactions-test/Transactions.test.tsx
@@ -14,6 +14,7 @@ import {
   editLatestTransactions,
   deleteTransactions,
   deleteLatestTransactions,
+  searchTransactions,
 } from '../../src/reducks/transactions/operations';
 import transactionsList from './transactions.json';
 import latestTransactionsList from './latestTransactions.json';
@@ -25,6 +26,7 @@ import deleteResTransaction from './deleteReponse.json';
 import addLatestTransaction from './addLatestTransactions.json';
 import editLatestTransaction from './editLatestTransactions.json';
 import deleteTransaction from './deleteLatestTransactions.json';
+import fetchResSearchTransaction from './fetchSearchTransactionsRes.json';
 
 const axiosMock = new axiosMockAdapter(axios);
 const middlewares = [thunk];
@@ -426,4 +428,47 @@ describe('async actions deleteLatestTransactions', () => {
     await deleteLatestTransactions(130)(store.dispatch, getState);
     expect(store.getActions()).toEqual(expectedDeleteActions);
   });
+});
+
+it('Get transactionsList  search criteria match in  if fetch succeeds', async () => {
+  const store = mockStore({
+    transactions: {
+      searchTransactionsList: [],
+    },
+  });
+  beforeEach(() => {
+    store.clearActions();
+  });
+
+  const args = {
+    transaction_type: 'expense',
+    low_amount: 2000,
+    high_amount: 10000,
+    big_category_id: 2,
+    sort: 'transaction_date',
+  };
+
+  // const params = {
+  //   transaction_type: 'expense',
+  //   low_amount: 2000,
+  //   high_amount: 10000,
+  //   big_category_id: 2,
+  //   sort: 'transaction_date',
+  // };
+
+  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/search?`;
+
+  const mockResponse = fetchResSearchTransaction;
+
+  const expectSearchActions = [
+    {
+      type: actionTypes.SEARCH_TRANSACTIONS,
+      payload: mockResponse,
+    },
+  ];
+
+  axiosMock.onGet(url).reply(200, mockResponse);
+
+  await searchTransactions(args)(store.dispatch);
+  expect(store.getActions()).toEqual(expectSearchActions);
 });

--- a/test/transactions-test/fetchSearchTransactionsRes.json
+++ b/test/transactions-test/fetchSearchTransactionsRes.json
@@ -1,0 +1,56 @@
+{
+  "transactions_list": [
+    {
+      "id": 29,
+      "transaction_type": "expense",
+      "posted_date": "2020-11-21T15:55:11Z",
+      "updated_date": "2020-11-21T15:55:11Z",
+      "transaction_date": "2020/11/21(土)",
+      "shop": "コストコ",
+      "memo": "牛肉ブロック購入",
+      "amount": 5000,
+      "big_category_name": "食費",
+      "medium_category_name": "食料品",
+      "custom_category_name": null
+    },
+    {
+      "id": 28,
+      "transaction_type": "expense",
+      "posted_date": "2020-11-20T14:23:37Z",
+      "updated_date": "2020-11-20T14:23:37Z",
+      "transaction_date": "2020/11/20(金)",
+      "shop": null,
+      "memo": null,
+      "amount": 3000,
+      "big_category_name": "食費",
+      "medium_category_name": "昼食",
+      "custom_category_name": null
+    },
+    {
+      "id": 30,
+      "transaction_type": "expense",
+      "posted_date": "2020-11-21T15:56:08Z",
+      "updated_date": "2020-11-21T15:56:08Z",
+      "transaction_date": "2020/11/10(火)",
+      "shop": "ビッグヨーサン",
+      "memo": "鍋食材",
+      "amount": 3000,
+      "big_category_name": "食費",
+      "medium_category_name": "食料品",
+      "custom_category_name": null
+    },
+    {
+      "id": 1,
+      "transaction_type": "expense",
+      "posted_date": "2020-11-17T13:32:16Z",
+      "updated_date": "2020-11-17T13:32:16Z",
+      "transaction_date": "2020/07/01(水)",
+      "shop": "コストコ",
+      "memo": "セールで牛肉購入",
+      "amount": 4500,
+      "big_category_name": "食費",
+      "medium_category_name": "食料品",
+      "custom_category_name": null
+    }
+  ]
+}


### PR DESCRIPTION
- transactions検索処理のaction、`SEARCH_TRANSACTIONS`を`transaction / actions`に追加しました。

- `SEARCH_TRANSACTIONS`のケースを`transactions / reducers`に追加しました。

- 検索条件に一致した家計簿データーを取得する処理を行う`SearchTransaction`を`transactions/ operations`に追加しました。

確認よろしくお願いします。
