### PR TITLE
Add SearchGroupTransaction in groupTransaction and modify searchTrans…

### DIFF
--- a/src/components/uikit/SearchTransaction.tsx
+++ b/src/components/uikit/SearchTransaction.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { searchTransactions } from '../../reducks/transactions/operations';
+import { searchGroupTransactions } from '../../reducks/groupTransactions/operations';
 import '../../assets/history/daily-history.scss';
 import { DatePicker, CategoryInput, TextInput, KindSelectBox, GenericButton } from './index';
 
 interface SearchTransactionProps {
   pathName: string;
+  groupId: number;
   openSearchFiled: boolean;
   openSearch: () => void;
   closeSearch: () => void;
@@ -26,8 +28,8 @@ interface SearchTransactionProps {
   selectEndDate: Date | null;
   lowAmount: string;
   highAmount: string;
-  memo: string;
-  shop: string;
+  memo: string | null;
+  shop: string | null;
   category: string;
   bigCategoryId: number;
   mediumCategoryId: number | null;
@@ -39,12 +41,25 @@ const SearchTransaction = (props: SearchTransactionProps) => {
   const dispatch = useDispatch();
 
   const searchRequestData = {
-    transaction_type: props.transactionType,
-    low_amount: props.lowAmount,
-    high_amount: props.highAmount,
+    transaction_type: props.transactionType !== '' ? props.transactionType : null,
+    start_date: props.selectStartDate,
+    end_date: props.selectEndDate,
+    low_amount: props.lowAmount !== '' ? props.lowAmount : null,
+    high_amount: props.highAmount !== '' ? props.highAmount : null,
+    memo: props.memo !== '' ? props.memo : null,
+    shop: props.shop !== '' ? props.shop : null,
     big_category_id: 2,
-    memo: props.memo,
-    shop: props.shop,
+  };
+
+  const groupSearchRequestData = {
+    transaction_type: props.transactionType !== '' ? props.transactionType : null,
+    start_date: props.selectStartDate,
+    end_date: props.selectEndDate,
+    low_amount: props.lowAmount !== '' ? props.lowAmount : null,
+    high_amount: props.highAmount !== '' ? props.highAmount : null,
+    memo: props.memo !== '' ? props.memo : null,
+    shop: props.shop !== '' ? props.shop : null,
+    big_category_id: 2,
   };
 
   return (
@@ -137,7 +152,14 @@ const SearchTransaction = (props: SearchTransactionProps) => {
             <GenericButton
               disabled={false}
               label={'この条件で絞り込む'}
-              onClick={() => dispatch(searchTransactions(searchRequestData)) && props.closeSearch()}
+              onClick={() => {
+                if (props.pathName !== 'group') {
+                  dispatch(searchTransactions(searchRequestData)) && props.closeSearch();
+                } else {
+                  dispatch(searchGroupTransactions(props.groupId, groupSearchRequestData)) &&
+                    props.closeSearch();
+                }
+              }}
             />
           </div>
         </div>

--- a/src/reducks/groupTransactions/actions.ts
+++ b/src/reducks/groupTransactions/actions.ts
@@ -7,6 +7,7 @@ export type groupTransactionsAction = ReturnType<
   | typeof addGroupAccountAction
   | typeof editGroupAccountAction
   | typeof deleteGroupAccountAction
+  | typeof searchGroupTransactionsAction
 >;
 
 export const UPDATE_GROUP_TRANSACTIONS = 'UPDATE_GROUP_TRANSACTIONS';
@@ -67,6 +68,20 @@ export const deleteGroupAccountAction = (
     payload: {
       deletedMessage,
       groupAccountList,
+    },
+  };
+};
+
+export const SEARCH_GROUP_TRANSACTIONS = 'SEARCH_GROUP_TRANSACTIONS';
+export const searchGroupTransactionsAction = (
+  groupSearchTransactionsList: GroupTransactionsList,
+  notHistoryMessage: string
+) => {
+  return {
+    type: SEARCH_GROUP_TRANSACTIONS,
+    payload: {
+      groupSearchTransactionsList,
+      notHistoryMessage,
     },
   };
 };

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -5,6 +5,7 @@ import {
   addGroupAccountAction,
   editGroupAccountAction,
   deleteGroupAccountAction,
+  searchGroupTransactionsAction,
 } from './actions';
 import axios from 'axios';
 import { Dispatch, Action } from 'redux';
@@ -457,6 +458,65 @@ export const deleteGroupAccount = (groupId: number, year: number, customMonth: s
         dispatch(deleteGroupAccountAction(emptyGroupAccountList, deletedMessage));
       } else {
         return prevGroupAccountList;
+      }
+    } catch (error) {
+      errorHandling(dispatch, error);
+    }
+  };
+};
+
+export const searchGroupTransactions = (
+  groupId: number,
+  searchRequest: {
+    transaction_type?: string | null;
+    start_date?: Date | null;
+    end_date?: Date | null;
+    shop?: string | null;
+    memo?: string | null;
+    low_amount?: string | number | null;
+    high_amount?: string | number | null;
+    payment_user_id?: string;
+    big_category_id?: number;
+    limit?: number;
+    sort?: string;
+    sort_type?: string;
+  }
+) => {
+  return async (dispatch: Dispatch<Action>) => {
+    try {
+      const result = await axios.get<FetchGroupTransactionsRes>(
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/search?`,
+        {
+          withCredentials: true,
+          params: {
+            start_date:
+              searchRequest.start_date !== null ? moment(searchRequest.start_date).format() : null,
+            end_date:
+              searchRequest.end_date !== null ? moment(searchRequest.end_date).format() : null,
+            transaction_type: searchRequest.transaction_type,
+            shop: searchRequest.shop,
+            memo: searchRequest.memo,
+            low_amount: searchRequest.low_amount,
+            high_amount: searchRequest.high_amount,
+            payment_user_id: searchRequest.payment_user_id,
+            limit: searchRequest.limit,
+            sort: searchRequest.sort,
+            big_category_id: searchRequest.big_category_id,
+            sort_type: searchRequest.sort_type,
+          },
+        }
+      );
+      const searchGroupTransactionsList: GroupTransactionsList = result.data.transactions_list;
+      const notHistoryMessage = result.data.message;
+
+      if (searchGroupTransactionsList !== undefined) {
+        const emptyMessage = '';
+        dispatch(searchGroupTransactionsAction(searchGroupTransactionsList, emptyMessage));
+      } else {
+        const emptySearchGroupTransactionsList: GroupTransactionsList = [];
+        dispatch(
+          searchGroupTransactionsAction(emptySearchGroupTransactionsList, notHistoryMessage)
+        );
       }
     } catch (error) {
       errorHandling(dispatch, error);

--- a/src/reducks/groupTransactions/reducers.ts
+++ b/src/reducks/groupTransactions/reducers.ts
@@ -37,6 +37,11 @@ export const groupTransactionsReducer = (
         ...state,
         ...action.payload,
       };
+    case Actions.SEARCH_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
     default:
       return state;
   }

--- a/src/reducks/groupTransactions/selectors.ts
+++ b/src/reducks/groupTransactions/selectors.ts
@@ -22,3 +22,13 @@ export const getNotGroupAccountMessage = createSelector(
   [groupTransactionsSelector],
   (state) => state.notAccountMessage
 );
+
+export const getSearchGroupTransactions = createSelector(
+  [groupTransactionsSelector],
+  (state) => state.groupSearchTransactionsList
+);
+
+export const getNotHistoryMessage = createSelector(
+  [groupTransactionsSelector],
+  (state) => state.notAccountMessage
+);

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -12,11 +12,14 @@ const initialState = {
     transactionsList: [],
     searchTransactionsList: [],
     noTransactionsMessage: '',
+    notHistoryMessage: '',
   },
   groupTransactions: {
     groupLatestTransactionsList: [],
     groupTransactionsList: [],
+    groupSearchTransactionsList: [],
     notAccountMessage: '',
+    notHistoryMessage: '',
     deletedMessage: '',
     groupAccountList: {
       group_id: 0,

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -27,10 +27,12 @@ export interface State {
     transactionsList: TransactionsList;
     searchTransactionsList: TransactionsList;
     noTransactionsMessage: string;
+    notHistoryMessage: string;
   };
   groupTransactions: {
     groupLatestTransactionsList: GroupTransactionsList;
     groupTransactionsList: GroupTransactionsList;
+    groupSearchTransactionsList: GroupTransactionsList;
     groupAccountList: GroupAccountList;
     notAccountMessage: string;
     deletedMessage: string;

--- a/src/reducks/transactions/actions.ts
+++ b/src/reducks/transactions/actions.ts
@@ -37,9 +37,15 @@ export const updateTransactionsAction = (transactionsList: TransactionsList) => 
 };
 
 export const SEARCH_TRANSACTIONS = 'SEARCH_TRANSACTIONS';
-export const searchTransactionsActions = (searchTransactionsList: TransactionsList) => {
+export const searchTransactionsActions = (
+  searchTransactionsList: TransactionsList,
+  notHistoryMessage: string
+) => {
   return {
     type: SEARCH_TRANSACTIONS,
-    payload: searchTransactionsList,
+    payload: {
+      searchTransactionsList,
+      notHistoryMessage,
+    },
   };
 };

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -346,13 +346,13 @@ export const deleteLatestTransactions = (id: number) => {
 };
 
 export const searchTransactions = (searchRequestData: {
-  transaction_type?: string;
-  start_transaction_date?: Date | null;
-  end_transaction_date?: Date | null;
+  transaction_type?: string | null;
+  start_date?: Date | null;
+  end_date?: Date | null;
   shop?: string | null;
   memo?: string | null;
-  low_amount?: string | number;
-  high_amount?: string | number;
+  low_amount?: string | number | null;
+  high_amount?: string | number | null;
   big_category_id?: number;
   sort?: string;
   sort_type?: string;
@@ -360,13 +360,19 @@ export const searchTransactions = (searchRequestData: {
 }) => {
   return async (dispatch: Dispatch<Action>) => {
     try {
-      const result = await axios.get<TransactionsList>(
+      const result = await axios.get<FetchTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/search?`,
         {
           withCredentials: true,
           params: {
-            start_date: searchRequestData.start_transaction_date,
-            end_date: searchRequestData.end_transaction_date,
+            start_date:
+              searchRequestData.start_date !== null
+                ? moment(searchRequestData.start_date).format()
+                : null,
+            end_date:
+              searchRequestData.end_date !== null
+                ? moment(searchRequestData.end_date).format()
+                : null,
             transaction_type: searchRequestData.transaction_type,
             low_amount: searchRequestData.low_amount,
             high_amount: searchRequestData.high_amount,
@@ -379,9 +385,16 @@ export const searchTransactions = (searchRequestData: {
           },
         }
       );
-      const searchTransactionsList = result.data;
+      const message = result.data.message;
+      const searchTransactionsList: TransactionsList = result.data.transactions_list;
 
-      dispatch(searchTransactionsActions(searchTransactionsList));
+      if (searchTransactionsList !== undefined) {
+        const emptyMessage = '';
+        dispatch(searchTransactionsActions(searchTransactionsList, emptyMessage));
+      } else {
+        const emptySearchTransactionsList: TransactionsList = [];
+        dispatch(searchTransactionsActions(emptySearchTransactionsList, message));
+      }
     } catch (error) {
       errorHandling(dispatch, error);
     }

--- a/src/reducks/transactions/selectors.ts
+++ b/src/reducks/transactions/selectors.ts
@@ -17,3 +17,13 @@ export const getTransactionsMessage = createSelector(
   [transactionsSelector],
   (state) => state.noTransactionsMessage
 );
+
+export const getSearchTransactions = createSelector(
+  [transactionsSelector],
+  (state) => state.searchTransactionsList
+);
+
+export const notHistoryMessage = createSelector(
+  [transactionsSelector],
+  (state) => state.notHistoryMessage
+);

--- a/src/templates/DailyHistory.tsx
+++ b/src/templates/DailyHistory.tsx
@@ -27,8 +27,8 @@ const DailyHistory = (props: DailyHistoryProps) => {
   const pathName = getPathTemplateName(window.location.pathname);
   const groupId = getPathGroupId(window.location.pathname);
   const [openSearchField, setOpenSearchField] = useState<boolean>(false);
-  const [selectStartDate, setStartSelectDate] = useState<Date | null>(new Date());
-  const [selectEndDate, setEndSelectDate] = useState<Date | null>(new Date());
+  const [selectStartDate, setStartSelectDate] = useState<Date | null>(null);
+  const [selectEndDate, setEndSelectDate] = useState<Date | null>(null);
   const [memo, setMemo] = useState<string>('');
   const [shop, setShop] = useState<string>('');
   const [lowAmount, setLowAmount] = useState<string>('');
@@ -159,6 +159,7 @@ const DailyHistory = (props: DailyHistoryProps) => {
           inputLowAmount={inputLowAmount}
           customCategoryId={customCategoryId}
           mediumCategoryId={mediumCategoryId}
+          groupId={groupId}
         />
         <div className="daily-history__spacer" />
         {(() => {

--- a/test/group-transactions-test/GroupTransactions.test.tsx
+++ b/test/group-transactions-test/GroupTransactions.test.tsx
@@ -18,6 +18,7 @@ import {
   addGroupAccount,
   editGroupAccount,
   deleteGroupAccount,
+  searchGroupTransactions,
 } from '../../src/reducks/groupTransactions/operations';
 import groupTransactions from './groupTransactions.json';
 import groupLatestTransactions from './groupLatestTransactions.json';
@@ -32,6 +33,7 @@ import deletedGroupLatestTransaction from './deletedGroupLatestTransactions.json
 import groupAccountList from './groupAccountList.json';
 import editGroupAccountList from './editGroupAccoountResponse.json';
 import deleteAccountResponse from './deleteGroupAccountResponse.json';
+import searchGroupTransactionsRes from './fetchSearchGroupTransactionsResponse.json';
 import { year, customMonth } from '../../src/lib/constant';
 
 const axiosMock = new axiosMockAdapter(axios);
@@ -631,6 +633,41 @@ describe('async actions groupTransactions', () => {
 
     // @ts-ignore
     await deleteGroupAccount(groupId, year, customMonth)(store.dispatch, getState);
+    expect(store.getActions()).toEqual(expectActions);
+  });
+
+  it('Get groupTransactionsList search criteria match in  if fetch succeeds', async () => {
+    const store = mockStore({ groupTransactions: { groupSearchTransactionsList: [] } });
+
+    beforeEach(() => {
+      store.clearActions();
+    });
+
+    const groupId = 1;
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/search?`;
+
+    const params = {
+      transaction_type: 'expense',
+      low_amount: 1000,
+      high_amount: 5000,
+      big_category_id: 2,
+    };
+
+    const mockResponse = searchGroupTransactionsRes;
+
+    const expectActions = [
+      {
+        type: actionTypes.SEARCH_GROUP_TRANSACTIONS,
+        payload: {
+          groupSearchTransactionsList: mockResponse.transactions_list,
+          notHistoryMessage: '',
+        },
+      },
+    ];
+
+    axiosMock.onGet(url).reply(200, mockResponse);
+
+    await searchGroupTransactions(groupId, params)(store.dispatch);
     expect(store.getActions()).toEqual(expectActions);
   });
 });

--- a/test/group-transactions-test/fetchSearchGroupTransactionsResponse.json
+++ b/test/group-transactions-test/fetchSearchGroupTransactionsResponse.json
@@ -1,0 +1,68 @@
+{
+  "transactions_list":[
+    {
+      "id": 20,
+      "transaction_type": "expense",
+      "posted_date": "2020-11-20T15:28:54Z",
+      "updated_date": "2020-11-20T15:28:54Z",
+      "transaction_date": "2020/11/20(金)",
+      "shop": null,
+      "memo": null,
+      "amount": 2000,
+      "posted_user_id": "taira",
+      "updated_user_id": null,
+      "payment_user_id": "taira",
+      "big_category_name": "食費",
+      "medium_category_name": "夕食",
+      "custom_category_name": null
+    },
+    {
+      "id": 19,
+      "transaction_type": "expense",
+      "posted_date": "2020-11-20T14:17:01Z",
+      "updated_date": "2020-11-20T14:17:01Z",
+      "transaction_date": "2020/11/20(金)",
+      "shop": "ビッグヨーサン",
+      "memo": "鶏肉",
+      "amount": 3000,
+      "posted_user_id": "taira",
+      "updated_user_id": null,
+      "payment_user_id": "tati1",
+      "big_category_name": "食費",
+      "medium_category_name": "食料品",
+      "custom_category_name": null
+    },
+    {
+      "id": 18,
+      "transaction_type": "expense",
+      "posted_date": "2020-11-17T19:53:53Z",
+      "updated_date": "2020-11-17T19:53:53Z",
+      "transaction_date": "2020/11/17(火)",
+      "shop": "すき家",
+      "memo": null,
+      "amount": 1000,
+      "posted_user_id": "taira",
+      "updated_user_id": null,
+      "payment_user_id": "taira",
+      "big_category_name": "食費",
+      "medium_category_name": "昼食",
+      "custom_category_name": null
+    },
+    {
+      "id": 23,
+      "transaction_type": "expense",
+      "posted_date": "2020-11-21T22:41:25Z",
+      "updated_date": "2020-11-21T22:41:25Z",
+      "transaction_date": "2020/11/06(金)",
+      "shop": "コストコ",
+      "memo": "チーズケーキ",
+      "amount": 1200,
+      "posted_user_id": "taira",
+      "updated_user_id": null,
+      "payment_user_id": "taira",
+      "big_category_name": "食費",
+      "medium_category_name": "食料品",
+      "custom_category_name": null
+    }
+  ]
+}

--- a/test/transactions-test/Transactions.test.tsx
+++ b/test/transactions-test/Transactions.test.tsx
@@ -440,21 +440,13 @@ it('Get transactionsList  search criteria match in  if fetch succeeds', async ()
     store.clearActions();
   });
 
-  const args = {
+  const params = {
     transaction_type: 'expense',
     low_amount: 2000,
     high_amount: 10000,
     big_category_id: 2,
     sort: 'transaction_date',
   };
-
-  // const params = {
-  //   transaction_type: 'expense',
-  //   low_amount: 2000,
-  //   high_amount: 10000,
-  //   big_category_id: 2,
-  //   sort: 'transaction_date',
-  // };
 
   const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/search?`;
 
@@ -463,12 +455,15 @@ it('Get transactionsList  search criteria match in  if fetch succeeds', async ()
   const expectSearchActions = [
     {
       type: actionTypes.SEARCH_TRANSACTIONS,
-      payload: mockResponse,
+      payload: {
+        searchTransactionsList: mockResponse.transactions_list,
+        notHistoryMessage: '',
+      },
     },
   ];
 
   axiosMock.onGet(url).reply(200, mockResponse);
 
-  await searchTransactions(args)(store.dispatch);
+  await searchTransactions(params)(store.dispatch);
   expect(store.getActions()).toEqual(expectSearchActions);
 });


### PR DESCRIPTION
- グループの検索家計簿データ取得のaction、`SEARCH_GROUP_TRANSACTIONS`を`actions, reducers`に追加しました。

- 検索条件に一致した家計簿データを取得する処理を行う`SearchGroupTransaction`を`groupTransactions / operations`に
  追加しました。

- `SearchGroupTransaction`のテストを追加しました。

- `transactions / operations`の `searchTransactions`を開始日と終了日が現在の日付でリクエストされるようにフォーマットを調整し、
  金額やメモを検索条件に含めていない場合は、`query string`に含まれないように修正しました。

確認よろしくお願いします。
