### PR TITLE
Add guest user login and modify SignUp and LogIn template

### DIFF
--- a/src/assets/modules/text-area.scss
+++ b/src/assets/modules/text-area.scss
@@ -1,0 +1,16 @@
+@import "../variable";
+
+.text-input {
+
+  &__text-form {
+    border: 1px solid $task-border_color;
+    border-radius: $task-border_radius;
+    font-size: $middle-font-size;
+    height: 40px;
+    width: 400px;
+  }
+
+  &:focus {
+    outline: none;
+  }
+}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -149,98 +149,108 @@ const Header = () => {
   const menuId = 'primary-search-account-menu';
 
   return (
-    <div className={classes.grow}>
-      <AppBar className={classes.header} position="static">
-        <Toolbar>
-          <div className={classes.sectionMobile}>
-            <MobileDrawer />
-          </div>
-          <Typography variant="h6" noWrap>
-            <Button
-              color="inherit"
-              className={classes.title}
-              onClick={() => existsGroupWhenRouting(`/`)}
-            >
-              家計簿App
-            </Button>
-          </Typography>
-          <div className={classes.sectionDesktop}>
-            <Button
-              size="large"
-              className={classes.button}
-              startIcon={<HistoryIcon />}
-              onClick={() => existsGroupWhenRouting('/daily/history')}
-            >
-              履歴
-            </Button>
-            <Button
-              size="large"
-              className={classes.button}
-              startIcon={<MoneyIcon />}
-              onClick={() => existsGroupWhenRouting('/standard/budgets')}
-            >
-              予算
-            </Button>
-            <Button size="large" className={classes.button} startIcon={<CreditCardIcon />}>
-              集計
-            </Button>
-            <Button
-              size="large"
-              className={classes.button}
-              startIcon={<PlaylistAddCheckIcon />}
-              onClick={() => existsGroupWhenRouting('/todo')}
-            >
-              Todo
-            </Button>
-            {entityType === 'group' && (
-              <Button
-                size="large"
-                className={classes.button}
-                startIcon={<EventAvailableIcon />}
-                onClick={() => existsGroupWhenRouting('/task')}
-              >
-                タスク
-              </Button>
-            )}
-          </div>
-          <div className={classes.grow} />
-          <SwitchEntity
-            entityType={entityType}
-            groupId={groupId}
-            name={name}
-            userName={userName}
-            openMenu={openMenu}
-            switchToIndividual={switchToIndividual}
-            switchToGroup={switchToGroup}
-            closeMenu={closeMenu}
-            anchorEl={anchorEl}
-            approvedGroups={approvedGroups}
-          />
-          <InvitationNotifications />
-          <div className={classes.sectionDesktop}>
-            <Button
-              startIcon={<ExitToAppIcon />}
-              className={classes.button}
-              aria-label="logout"
-              aria-controls={menuId}
-              aria-haspopup="true"
-              onClick={() => logOutCheck()}
-            >
-              ログアウト
-            </Button>
-            <Button
-              startIcon={<SettingsIcon />}
-              className={classes.button}
-              aria-label="settings"
-              aria-controls={menuId}
-              aria-haspopup="true"
-            >
-              設定
-            </Button>
-          </div>
-        </Toolbar>
-      </AppBar>
-    </div>
+    <>
+      {(() => {
+        if (entityType !== 'login' && entityType !== 'signup') {
+          return (
+            <div className={classes.grow}>
+              <AppBar className={classes.header} position="static">
+                <Toolbar>
+                  <div className={classes.sectionMobile}>
+                    <MobileDrawer />
+                  </div>
+                  <Typography variant="h6" noWrap>
+                    <Button
+                      color="inherit"
+                      className={classes.title}
+                      onClick={() => existsGroupWhenRouting(`/`)}
+                    >
+                      家計簿App
+                    </Button>
+                  </Typography>
+                  <div className={classes.sectionDesktop}>
+                    <Button
+                      size="large"
+                      className={classes.button}
+                      startIcon={<HistoryIcon />}
+                      onClick={() => existsGroupWhenRouting('/daily/history')}
+                    >
+                      履歴
+                    </Button>
+                    <Button
+                      size="large"
+                      className={classes.button}
+                      startIcon={<MoneyIcon />}
+                      onClick={() => existsGroupWhenRouting('/standard/budgets')}
+                    >
+                      予算
+                    </Button>
+                    <Button size="large" className={classes.button} startIcon={<CreditCardIcon />}>
+                      集計
+                    </Button>
+                    <Button
+                      size="large"
+                      className={classes.button}
+                      startIcon={<PlaylistAddCheckIcon />}
+                      onClick={() => existsGroupWhenRouting('/todo')}
+                    >
+                      Todo
+                    </Button>
+                    {entityType === 'group' && (
+                      <Button
+                        size="large"
+                        className={classes.button}
+                        startIcon={<EventAvailableIcon />}
+                        onClick={() => existsGroupWhenRouting('/task')}
+                      >
+                        タスク
+                      </Button>
+                    )}
+                  </div>
+                  <div className={classes.grow} />
+                  <SwitchEntity
+                    entityType={entityType}
+                    groupId={groupId}
+                    name={name}
+                    userName={userName}
+                    openMenu={openMenu}
+                    switchToIndividual={switchToIndividual}
+                    switchToGroup={switchToGroup}
+                    closeMenu={closeMenu}
+                    anchorEl={anchorEl}
+                    approvedGroups={approvedGroups}
+                  />
+                  <InvitationNotifications />
+                  <div className={classes.sectionDesktop}>
+                    <Button
+                      startIcon={<ExitToAppIcon />}
+                      className={classes.button}
+                      aria-label="logout"
+                      aria-controls={menuId}
+                      aria-haspopup="true"
+                      onClick={() => logOutCheck()}
+                    >
+                      ログアウト
+                    </Button>
+                    <Button
+                      startIcon={<SettingsIcon />}
+                      className={classes.button}
+                      aria-label="settings"
+                      aria-controls={menuId}
+                      aria-haspopup="true"
+                    >
+                      設定
+                    </Button>
+                  </div>
+                </Toolbar>
+              </AppBar>
+            </div>
+          );
+        } else {
+          return null;
+        }
+      })()}
+    </>
   );
 };
 export default Header;

--- a/src/components/uikit/TextArea.tsx
+++ b/src/components/uikit/TextArea.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import '../../assets/modules/text-area.scss';
+
+interface InputFormProps {
+  id: string;
+  value: string;
+  type: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur: ((event: React.FocusEvent<HTMLInputElement>) => void) | undefined;
+}
+
+const TextArea = (props: InputFormProps) => {
+  return (
+    <input
+      className="text-input__text-form"
+      id={props.id}
+      value={props.value}
+      type={props.type}
+      onChange={props.onChange}
+      onBlur={props.onBlur}
+    />
+  );
+};
+export default TextArea;

--- a/src/components/uikit/index.tsx
+++ b/src/components/uikit/index.tsx
@@ -22,3 +22,4 @@ export { default as SelectSort } from './SelectSort';
 export { default as SelectSortType } from './SelectSortType';
 export { default as SelectBigCategory } from './SelectBigCategroy';
 export { default as SelectLimit } from './SelectLimit';
+export { default as TextArea } from './TextArea';

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { push } from 'connected-react-router';
 import { Action, Dispatch } from 'redux';
 
@@ -59,4 +60,79 @@ export const totalCustomBudgets = (budgetList: number[]): number => {
   }
 
   return total;
+};
+
+export const onUserIdFocusOut = (
+  userId: string,
+  setUserIdMessage: React.Dispatch<React.SetStateAction<string>>
+) => {
+  if (!userId.length) {
+    return '';
+  } else if (userId.length > 10) {
+    setUserIdMessage('ユーザーIDは10文字以下で入力してください。');
+  }
+};
+
+export const onUserNameFocusOut = (
+  userName: string,
+  setUserNameMessage: React.Dispatch<React.SetStateAction<string>>
+) => {
+  if (!userName.length) {
+    return '';
+  } else if (userName.length > 50) {
+    setUserNameMessage('ユーザー名は50文字以下で入力してください。');
+  }
+};
+
+export const onEmailFocusOut = (
+  email: string,
+  setEmailMessage: React.Dispatch<React.SetStateAction<string>>
+) => {
+  if (!email.length) {
+    return '';
+  } else if (email.length < 5) {
+    setEmailMessage('メールアドレスは5文字以上で入力してください。');
+  } else if (email.length > 50) {
+    setEmailMessage('メールアドレスは50文字以下で入力してください。');
+  } else if (!isValidEmailFormat(email)) {
+    setEmailMessage('メールアドレス形式に誤りがあります。正しく入力し直してください。');
+  }
+};
+
+export const onPasswordFocusOut = (
+  password: string,
+  setPassWordMessage: React.Dispatch<React.SetStateAction<string>>
+) => {
+  if (!password.length) {
+    return '';
+  } else if (password.length < 8) {
+    setPassWordMessage('パスワードは8文字以上で入力してください。');
+  } else if (password.length > 50) {
+    setPassWordMessage('パスワードは50文字以下で入力してください。');
+  }
+};
+
+export const onConfirmPasswordFocusOut = (
+  password: string,
+  confirmPassword: string,
+  setConfirmPasswordMessage: React.Dispatch<React.SetStateAction<string>>
+) => {
+  if (password !== confirmPassword) {
+    setConfirmPasswordMessage(
+      'パスワードと確認パスワードが一致しません。もう一度入力してください。'
+    );
+  }
+};
+
+export const passWordSubmit = (
+  password: string,
+  setPassWordMessage: React.Dispatch<React.SetStateAction<string>>
+) => {
+  if (!password.length) {
+    return '';
+  } else if (!isValidPasswordFormat(password)) {
+    setPassWordMessage('パスワードを正しく入力してください。');
+  } else {
+    return '';
+  }
 };

--- a/src/reducks/users/operations.ts
+++ b/src/reducks/users/operations.ts
@@ -3,55 +3,10 @@ import { Dispatch, Action } from 'redux';
 import { push } from 'connected-react-router';
 import axios from 'axios';
 import { SignupReq, UserRes, LoginReq, LogoutRes } from './types';
-import { isValidEmailFormat, isValidPasswordFormat, errorHandling } from '../../lib/validation';
+import { isValidPasswordFormat, errorHandling } from '../../lib/validation';
 
-export const signUp = (
-  userId: string,
-  userName: string,
-  email: string,
-  password: string,
-  confirmPassword: string
-) => {
+export const signUp = (userId: string, userName: string, email: string, password: string) => {
   return async (dispatch: Dispatch<Action>) => {
-    const errorMessages: string[] = [];
-
-    if (userId.length > 10) {
-      errorMessages.push('ユーザーIDは10文字以下で入力してください。');
-    }
-
-    if (userName.length > 50) {
-      errorMessages.push('ユーザー名は50文字以下で入力してください。');
-    }
-
-    if (email.length < 5) {
-      errorMessages.push('メールアドレスは5文字以上で入力してください。');
-    }
-
-    if (email.length > 50) {
-      errorMessages.push('メールアドレスは50文字以下で入力してください。');
-    }
-
-    if (!isValidEmailFormat(email)) {
-      errorMessages.push('メールアドレスの形式に誤りがあります。正しく入力し直してください。');
-    }
-
-    if (password.length < 8) {
-      errorMessages.push('パスワードは8文字以上で入力してください。');
-    }
-
-    if (password.length > 50) {
-      errorMessages.push('パスワードは50文字以下で入力してください。');
-    }
-
-    if (password !== confirmPassword) {
-      errorMessages.push('パスワードと確認パスワードが一致しません。もう一度入力してください。');
-    }
-
-    if (errorMessages.length > 0) {
-      alert(errorMessages.join('\n'));
-      return null;
-    }
-
     const data: SignupReq = {
       id: userId,
       name: userName,
@@ -117,16 +72,8 @@ export const signUp = (
 
 export const logIn = (email: string, password: string) => {
   return async (dispatch: Dispatch<Action>) => {
-    if (!isValidEmailFormat(email)) {
-      const alertMessage: string[] = [];
-      alertMessage.push('メールアドレスの形式に誤りがあります。正しく入力し直してください。');
-      if (!isValidPasswordFormat(password)) {
-        alertMessage.push('パスワードを正しく入力してください。');
-      }
-      if (alertMessage.length > 0) {
-        alert(alertMessage.join('\n'));
-        return null;
-      }
+    if (!isValidPasswordFormat(password)) {
+      alert('パスワードを正しく入力してください。');
     }
 
     const data: LoginReq = { email: email, password: password };
@@ -151,10 +98,10 @@ export const logIn = (email: string, password: string) => {
           if (errorMessages) {
             alert(errorMessages.join('\n'));
           }
-        } else if (error && error.response) {
+        }
+
+        if (error.response) {
           alert(error.response.data.error.message);
-        } else {
-          alert(error);
         }
       });
   };

--- a/src/templates/LogIn.tsx
+++ b/src/templates/LogIn.tsx
@@ -7,10 +7,12 @@ import PersonIcon from '@material-ui/icons/Person';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
-import { GenericButton, TextInput } from '../components/uikit/index';
+import { GenericButton, TextArea } from '../components/uikit/index';
 import { useDispatch } from 'react-redux';
 import { logIn } from '../reducks/users/operations';
-
+import { InvalidMessage } from '../components/uikit';
+import { onEmailFocusOut, passWordSubmit } from '../lib/validation';
+import '../assets/modules/text-area.scss';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -35,29 +37,28 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const LogIn = () => {
+  const classes = useStyles();
   const dispatch = useDispatch();
-
   const [email, setEmail] = useState<string>('');
-  const [password, setPassword] = useState<string>('')
-
+  const [password, setPassword] = useState<string>('');
+  const [emailMessage, setEmailMessage] = useState<string>('');
+  const [passwordMessage, setPassWordMessage] = useState<string>('');
 
   const inputEmail = useCallback(
-    (event:React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       setEmail(event.target.value);
     },
     [setEmail]
   );
 
   const inputPassword = useCallback(
-    (event:React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       setPassword(event.target.value);
     },
     [setPassword]
   );
 
-  const unLogIn = email === '' || password === '';
-
-  const classes = useStyles();
+  const unLogIn = email === '' || password === '' || password.length < 8;
 
   return (
     <section className="login__form">
@@ -72,31 +73,29 @@ const LogIn = () => {
           </Typography>
           <div className="module-spacer--small" />
           <form className={classes.form} noValidate>
-            <Grid container spacing={2}>
-              <Grid item xs={12} className="center">
-                <TextInput
-                  value={email}
-                  required={true}
-                  fullWidth={true}
-                  id={'email'}
-                  label={'メールアドレス'}
-                  type={'email'}
-                  onChange={inputEmail}
-                />
-              </Grid>
-              <div className="module-spacer--small" />
-              <Grid item xs={12} className="center">
-                <TextInput
-                  value={password}
-                  required={true}
-                  fullWidth={true}
-                  id={'password'}
-                  label={'パスワード'}
-                  type={'password'}
-                  onChange={inputPassword}
-                />
-              </Grid>
-            </Grid>
+            <div>
+              <label>メールアドレス</label>
+              <TextArea
+                value={email}
+                id={'email'}
+                type={'email'}
+                onChange={inputEmail}
+                onBlur={() => onEmailFocusOut(email, setEmailMessage)}
+              />
+              <InvalidMessage message={emailMessage} />
+            </div>
+            <div className="module-spacer--small" />
+            <div>
+              <label>パスワード</label>
+              <TextArea
+                value={password}
+                id={'password'}
+                type={'password'}
+                onChange={inputPassword}
+                onBlur={() => passWordSubmit(password, setPassWordMessage)}
+              />
+              <InvalidMessage message={passwordMessage} />
+            </div>
             <div className="module-spacer--small" />
             <div className="center">
               <GenericButton
@@ -106,7 +105,13 @@ const LogIn = () => {
               />
             </div>
             <div className="module-spacer--small" />
-
+            <div className="center">
+              <GenericButton
+                label={'ゲストユーザーログイン'}
+                disabled={false}
+                onClick={() => dispatch(logIn('kakeibo@gmail.com', 'kakeibo1'))}
+              />
+            </div>
             <div className="module-spacer--small" />
             <Grid item className="center">
               <a className={classes.link} onClick={() => dispatch(push('/signup'))}>

--- a/src/templates/SignUp.tsx
+++ b/src/templates/SignUp.tsx
@@ -7,9 +7,17 @@ import PersonIcon from '@material-ui/icons/Person';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
-import { GenericButton, TextInput } from '../components/uikit/index';
+import { GenericButton, InvalidMessage, TextArea } from '../components/uikit/index';
 import { useDispatch } from 'react-redux';
 import { signUp } from '../reducks/users/operations';
+import {
+  onUserIdFocusOut,
+  onUserNameFocusOut,
+  onEmailFocusOut,
+  onPasswordFocusOut,
+  onConfirmPasswordFocusOut,
+} from '../lib/validation';
+import '../assets/modules/text-area.scss';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -37,49 +45,58 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const SignUp = (): JSX.Element => {
+  const classes = useStyles();
   const dispatch = useDispatch();
-
   const [userId, setUserId] = useState<string>('');
   const [userName, setUserName] = useState<string>('');
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [confirmPassword, setConfirmPassword] = useState<string>('');
+  const [userIdMessage, setUserIdMessage] = useState<string>('');
+  const [userNameMessage, setUserNameMessage] = useState<string>('');
+  const [emailMessage, setEmailMessage] = useState<string>('');
+  const [passwordMessage, setPassWordMessage] = useState<string>('');
+  const [confirmPasswordMessage, setConfirmPasswordMessage] = useState<string>('');
 
   const inputUserId = useCallback(
-    (event:React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       setUserId(event.target.value);
     },
     [setUserId]
   );
   const inputUserName = useCallback(
-    (event:React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       setUserName(event.target.value);
     },
     [setUserName]
   );
   const inputEmail = useCallback(
-    (event:React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       setEmail(event.target.value);
     },
     [setEmail]
   );
   const inputPassword = useCallback(
-    (event:React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       setPassword(event.target.value);
     },
     [setPassword]
   );
   const inputConfirmPassword = useCallback(
-    (event:React.ChangeEvent<HTMLInputElement>) => {
+    (event: React.ChangeEvent<HTMLInputElement>) => {
       setConfirmPassword(event.target.value);
     },
     [setConfirmPassword]
   );
 
   const unSignUp =
-    userId === '' || userName === '' || email === '' || password === '' || confirmPassword === '';
-
-  const classes = useStyles();
+    userId === '' ||
+    userName === '' ||
+    email === '' ||
+    password === '' ||
+    confirmPassword === '' ||
+    password.length < 8 ||
+    confirmPassword.length < 8;
 
   return (
     <section className="signup__form">
@@ -93,69 +110,73 @@ const SignUp = (): JSX.Element => {
             アカウント登録
           </Typography>
           <form className={classes.form} noValidate>
-            <Grid container spacing={2}>
-              <Grid item xs={12} className="center">
-                <TextInput
-                  id={'userId'}
-                  required={true}
-                  fullWidth={true}
-                  label="ユーザーID"
-                  value={userId}
-                  type="userId"
-                  onChange={inputUserId}
-                />
-              </Grid>
-              <Grid item xs={12} className="center">
-                <TextInput
-                  id={'userName'}
-                  required={true}
-                  fullWidth={true}
-                  label="名前"
-                  value={userName}
-                  type="name"
-                  onChange={inputUserName}
-                />
-              </Grid>
-              <Grid item xs={12} className="center">
-                <TextInput
-                  id={'email'}
-                  required={true}
-                  fullWidth={true}
-                  label="メールアドレス"
-                  value={email}
-                  type="email"
-                  onChange={inputEmail}
-                />
-              </Grid>
-              <Grid item xs={12} className="center">
-                <TextInput
-                  id={'password'}
-                  required={true}
-                  fullWidth={true}
-                  label="パスワード(半角英数字で8文字以上)"
-                  value={password}
-                  type="password"
-                  onChange={inputPassword}
-                />
-              </Grid>
-              <Grid item xs={12} className="center">
-                <TextInput
-                  id={'confirmPassword'}
-                  required={true}
-                  fullWidth={true}
-                  label="パスワードの確認"
-                  value={confirmPassword}
-                  type="password"
-                  onChange={inputConfirmPassword}
-                />
-              </Grid>
-            </Grid>
-            <div className="module-spacer--bit-small" />
+            <div>
+              <label>ユーザーID</label>
+              <TextArea
+                id={'userId'}
+                value={userId}
+                type="userId"
+                onChange={inputUserId}
+                onBlur={() => onUserIdFocusOut(email, setUserIdMessage)}
+              />
+              <InvalidMessage message={userIdMessage} />
+            </div>
+            <div className="module-spacer--small" />
+            <div>
+              <label>名前</label>
+              <TextArea
+                id={'userName'}
+                value={userName}
+                type="name"
+                onChange={inputUserName}
+                onBlur={() => onUserNameFocusOut(userName, setUserNameMessage)}
+              />
+              <InvalidMessage message={userNameMessage} />
+            </div>
+            <div className="module-spacer--small" />
+            <div>
+              <label>メールアドレス</label>
+              <TextArea
+                id={'email'}
+                value={email}
+                type="email"
+                onChange={inputEmail}
+                onBlur={() => onEmailFocusOut(email, setEmailMessage)}
+              />
+              <InvalidMessage message={emailMessage} />
+            </div>
+            <div className="module-spacer--small" />
+            <div>
+              <label>パスワード</label>
+              <TextArea
+                id={'password'}
+                value={password}
+                type="password"
+                onChange={inputPassword}
+                onBlur={() => onPasswordFocusOut(password, setPassWordMessage)}
+              />
+              <InvalidMessage message={passwordMessage} />
+            </div>
+            <div className="module-spacer--small" />
+            <div>
+              <label className="text-input__label">確認用パスワード</label>
+              <TextArea
+                id={'confirmPassword'}
+                value={confirmPassword}
+                type="password"
+                onChange={inputConfirmPassword}
+                onBlur={() =>
+                  onConfirmPasswordFocusOut(password, confirmPassword, setConfirmPasswordMessage)
+                }
+              />
+              <InvalidMessage message={confirmPasswordMessage} />
+            </div>
+            <div className="module-spacer--small" />
             <div className="center">
               <GenericButton
                 label={'アカウントを登録する'}
                 disabled={unSignUp}
-                onClick={() => dispatch(signUp(userId, userName, email, password, confirmPassword))}
+                onClick={() => dispatch(signUp(userId, userName, email, password))}
               />
             </div>
             <div className="module-spacer--bit-small" />

--- a/test/users-test/Users.test.tsx
+++ b/test/users-test/Users.test.tsx
@@ -54,7 +54,7 @@ describe('async actions users', () => {
 
     axiosMock.onPost(url, signUpReq).reply(201, resSignUp);
 
-    await signUp('kohh20', '千葉雄喜', 'kohh@gmail.com', 'kohhworst', 'kohhworst')(store.dispatch);
+    await signUp('kohh20', '千葉雄喜', 'kohh@gmail.com', 'kohhworst')(store.dispatch);
     expect(store.getActions()).toEqual(expectedSignUpActions);
   });
 


### PR DESCRIPTION
- `Hearder`にメールアドレス・パスワードを入力せずにログインできるゲストログインボタンを追加しました。

- サインアップ画面とログイン画面のバリデーションメッセージをaleert()で表示させていましたが、入力フォームの下部にメッセージを
  表示させる`InvalidMessage`を追加しました。

- サインアップ, ログイン時に使用するバリデーション関数を`validation`に追加しました。

- 入力フォームの`TextArea`を追加しました。

- `TextArea`のcssファイル`text-area.scss`を追加しました。

確認よろしくお願いします。

