### PR TITLE
Add INFORM_ERROR action to users and add ErrorIndication component

### DIFF
--- a/src/assets/modules/error-indication.scss
+++ b/src/assets/modules/error-indication.scss
@@ -1,0 +1,46 @@
+@import "../variable";
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  75% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+
+.error-indication {
+  display: flex;
+
+  &__body {
+    animation: fade-in 4.5s ease-out forwards;
+    animation-iteration-count: 1;
+    align-items: center;
+    background-color: $task-delete-color;
+    border: $task-border_color solid 2px;
+    border-radius: $task-border_radius;
+    color: $white;
+    justify-content: center;
+    font-size: $medium-font_size;
+    font-weight: bold;
+    text-align: center;
+    height: 3em;
+    width: 30em;
+    white-space: pre-line;
+    position: fixed;
+    top: 8%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1000;
+  }
+
+
+}
+

--- a/src/components/uikit/ErrorIndication.tsx
+++ b/src/components/uikit/ErrorIndication.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import '../../assets/modules/error-indication.scss';
+
+interface ErrorIndicationProps {
+  errorMessage: string;
+}
+
+const ErrorIndication = (props: ErrorIndicationProps) => {
+  return (
+    <>
+      {(() => {
+        if (!props.errorMessage.length) {
+          return null;
+        } else {
+          return (
+            <dialog className="error-indication error-indication__body">
+              {props.errorMessage}
+            </dialog>
+          );
+        }
+      })()}
+    </>
+  );
+};
+export default ErrorIndication;

--- a/src/components/uikit/TextArea.tsx
+++ b/src/components/uikit/TextArea.tsx
@@ -12,6 +12,7 @@ interface InputFormProps {
 const TextArea = (props: InputFormProps) => {
   return (
     <input
+      autoComplete="off"
       className="text-input__text-form"
       id={props.id}
       value={props.value}

--- a/src/components/uikit/index.tsx
+++ b/src/components/uikit/index.tsx
@@ -23,3 +23,4 @@ export { default as SelectSortType } from './SelectSortType';
 export { default as SelectBigCategory } from './SelectBigCategroy';
 export { default as SelectLimit } from './SelectLimit';
 export { default as TextArea } from './TextArea';
+export { default as ErrorIndication } from './ErrorIndication';

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -52,6 +52,7 @@ const initialState = {
     id: '',
     name: '',
     email: '',
+    errorMessage: '',
   },
   groups: {
     approvedGroups: [],

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -51,6 +51,7 @@ export interface State {
     id: string;
     name: string;
     email: string;
+    errorMessage: string;
   };
   groups: {
     approvedGroups: Groups;

--- a/src/reducks/users/actions.ts
+++ b/src/reducks/users/actions.ts
@@ -1,6 +1,10 @@
 import { UserInfo } from './types';
 export type userActions = ReturnType<
-  typeof signUpAction | typeof logInAction | typeof logOutAction | typeof fetchUserInfoAction
+  | typeof signUpAction
+  | typeof logInAction
+  | typeof logOutAction
+  | typeof fetchUserInfoAction
+  | typeof informErrorAction
 >;
 
 export const SIGN_UP = 'SIGN_UP';
@@ -38,5 +42,15 @@ export const fetchUserInfoAction = (userInfo: UserInfo) => {
   return {
     type: FETCH_USER_INFO,
     payload: userInfo,
+  };
+};
+
+export const INFORM_ERROR = 'INFORM_ERROR';
+export const informErrorAction = (errorMessage: string) => {
+  return {
+    type: INFORM_ERROR,
+    payload: {
+      errorMessage: errorMessage,
+    },
   };
 };

--- a/src/reducks/users/reducers.ts
+++ b/src/reducks/users/reducers.ts
@@ -23,6 +23,12 @@ export const usersReducer = (state = initialState.users, action: userActions) =>
         ...state,
         ...action.payload,
       };
+    case Actions.INFORM_ERROR:
+      return {
+        ...state,
+        ...action.payload,
+      };
+
     default:
       return state;
   }

--- a/src/reducks/users/selectors.ts
+++ b/src/reducks/users/selectors.ts
@@ -6,3 +6,4 @@ const usersSelector = (state: State) => state.users;
 export const getUserId = createSelector([usersSelector], (state) => state.id);
 export const getUserName = createSelector([usersSelector], (state) => state.name);
 export const getEmail = createSelector([usersSelector], (state) => state.email);
+export const getErrorMessage = createSelector([usersSelector], (state) => state.errorMessage);

--- a/src/templates/LogIn.tsx
+++ b/src/templates/LogIn.tsx
@@ -7,12 +7,14 @@ import PersonIcon from '@material-ui/icons/Person';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
-import { GenericButton, TextArea } from '../components/uikit/index';
-import { useDispatch } from 'react-redux';
+import { GenericButton, TextArea, ErrorIndication } from '../components/uikit/index';
+import { useDispatch, useSelector } from 'react-redux';
+import { State } from '../reducks/store/types';
 import { logIn } from '../reducks/users/operations';
 import { InvalidMessage } from '../components/uikit';
 import { onEmailFocusOut, passWordSubmit } from '../lib/validation';
 import '../assets/modules/text-area.scss';
+import { getErrorMessage } from '../reducks/users/selectors';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -39,6 +41,8 @@ const useStyles = makeStyles((theme) => ({
 const LogIn = () => {
   const classes = useStyles();
   const dispatch = useDispatch();
+  const selector = useSelector((state: State) => state);
+  const errorMessage = getErrorMessage(selector);
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [emailMessage, setEmailMessage] = useState<string>('');
@@ -58,10 +62,21 @@ const LogIn = () => {
     [setPassword]
   );
 
-  const unLogIn = email === '' || password === '' || password.length < 8;
+  const resetForm = useCallback(() => {
+    setEmail('');
+    setPassword('');
+  }, [setEmail, setPassword]);
+
+  const unLogIn =
+    email === '' ||
+    password === '' ||
+    password.length < 8 ||
+    emailMessage !== '' ||
+    passwordMessage !== '';
 
   return (
     <section className="login__form">
+      <ErrorIndication errorMessage={errorMessage} />
       <Container component="main" maxWidth="xs">
         <CssBaseline />
         <div className={classes.paper}>
@@ -101,7 +116,7 @@ const LogIn = () => {
               <GenericButton
                 label={'ログインする'}
                 disabled={unLogIn}
-                onClick={() => dispatch(logIn(email, password))}
+                onClick={() => dispatch(logIn(email, password)) && resetForm()}
               />
             </div>
             <div className="module-spacer--small" />

--- a/src/templates/SignUp.tsx
+++ b/src/templates/SignUp.tsx
@@ -7,9 +7,16 @@ import PersonIcon from '@material-ui/icons/Person';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
-import { GenericButton, InvalidMessage, TextArea } from '../components/uikit/index';
-import { useDispatch } from 'react-redux';
+import {
+  GenericButton,
+  InvalidMessage,
+  TextArea,
+  ErrorIndication,
+} from '../components/uikit/index';
+import { State } from '../reducks/store/types';
+import { useDispatch, useSelector } from 'react-redux';
 import { signUp } from '../reducks/users/operations';
+import { getErrorMessage } from '../reducks/users/selectors';
 import {
   onUserIdFocusOut,
   onUserNameFocusOut,
@@ -47,6 +54,8 @@ const useStyles = makeStyles((theme) => ({
 const SignUp = (): JSX.Element => {
   const classes = useStyles();
   const dispatch = useDispatch();
+  const selector = useSelector((state: State) => state);
+  const errorMessage = getErrorMessage(selector);
   const [userId, setUserId] = useState<string>('');
   const [userName, setUserName] = useState<string>('');
   const [email, setEmail] = useState<string>('');
@@ -96,10 +105,16 @@ const SignUp = (): JSX.Element => {
     password === '' ||
     confirmPassword === '' ||
     password.length < 8 ||
-    confirmPassword.length < 8;
+    confirmPassword.length < 8 ||
+    userIdMessage != '' ||
+    userNameMessage !== '' ||
+    passwordMessage !== '' ||
+    confirmPasswordMessage !== '' ||
+    emailMessage !== '';
 
   return (
     <section className="signup__form">
+      <ErrorIndication errorMessage={errorMessage} />
       <Container component="main" maxWidth="xs">
         <CssBaseline />
         <div className={classes.paper}>


### PR DESCRIPTION
- API通信のresponseでerror messageが返ってきた場合にmessageをstoreに格納する処理を行う`informErrorAction`を追加しました。

- `informErrorAction`でdispatchされたerror messageを表示する`ErrorIndication`コンポーネントを追加しました。

- `users / operations`の不要に`.then()`でつないでいた部分を`try, catch`の形に修正しました。

確認よろしくお願いします。
