### PR TITLE
Add kakeibo-front deploy workflow

### DIFF
--- a/.github/workflows/kakeibo-front-deploy.yaml
+++ b/.github/workflows/kakeibo-front-deploy.yaml
@@ -1,0 +1,36 @@
+name: kakeibo-front deploy
+on:
+  push:
+    branches:
+      - master
+defaults:
+  run:
+    shell: bash
+jobs:
+  deploy:
+    name: kakeibo-front deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout paypay3/kakeibo-app-api code
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate build
+        run: npm run build
+
+      - name: Deploy to S3
+        run: aws s3 sync ./build s3://kakeibo-front-web --exact-timestamps --delete


### PR DESCRIPTION
kakeibo-front deploy workflow追加。

インフラ起動していないので、CloudFrontのファイルinvalidationは後で実装します。