### PR TITLE
Modify kakeibo-front deploy workflow

### DIFF
--- a/.github/workflows/kakeibo-front-deploy.yaml
+++ b/.github/workflows/kakeibo-front-deploy.yaml
@@ -27,7 +27,7 @@ jobs:
           node-version: 12.x
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Generate build
         run: npm run build


### PR DESCRIPTION
kakeibo-front deploy workflowを修正。

パッケージのinstallコマンドを変更しました。
`npm ci` --> `npm install`