### PR TITLE
Modify the login and signup templates and budgets template

### DIFF
--- a/src/components/history/DailyHistoryBody.tsx
+++ b/src/components/history/DailyHistoryBody.tsx
@@ -14,7 +14,7 @@ interface DailyHistoryBodyProps {
   transactionsList: TransactionsList;
   searchTransactionsList: TransactionsList;
   selectYears: number;
-  selectMonth: string;
+  selectMonth: number;
 }
 const DailyHistoryBody = (props: DailyHistoryBodyProps) => {
   const dispatch = useDispatch();

--- a/src/components/history/GroupDailyHistoryBody.tsx
+++ b/src/components/history/GroupDailyHistoryBody.tsx
@@ -8,6 +8,8 @@ import {
   getGroupIncomeCategories,
   getGroupExpenseCategories,
 } from '../../reducks/groupCategories/selectors';
+import { getApprovedGroups } from '../../reducks/groups/selectors';
+import { getUserId } from '../../reducks/users/selectors';
 import { getPathGroupId, getPathTemplateName } from '../../lib/path';
 import IconButton from '@material-ui/core/IconButton';
 import CreateIcon from '@material-ui/icons/Create';
@@ -17,13 +19,15 @@ interface GroupDailyHistoryBodyProps {
   groupTransactionsList: GroupTransactionsList;
   groupSearchTransactionsList: GroupTransactionsList;
   selectYears: number;
-  selectMonth: string;
+  selectMonth: number;
 }
 const GroupDailyHistoryBody = (props: GroupDailyHistoryBodyProps) => {
   const dispatch = useDispatch();
   const selector = useSelector((state: State) => state);
   const groupIncomeCategories = getGroupIncomeCategories(selector);
   const groupExpenseCategories = getGroupExpenseCategories(selector);
+  const approvedGroup = getApprovedGroups(selector);
+  const userId = getUserId(selector);
   const groupId = getPathGroupId(window.location.pathname);
   const pathName = getPathTemplateName(window.location.pathname);
   const [open, setOpen] = useState<boolean>(false);
@@ -103,6 +107,8 @@ const GroupDailyHistoryBody = (props: GroupDailyHistoryBodyProps) => {
                         categoryName={categoryName}
                         transactionDate={transaction_date}
                         transactionsType={transaction_type}
+                        approvedGroups={approvedGroup}
+                        paymentUserId={userId}
                       />
                     </td>
                     <td className="daily-history__td" align="center">
@@ -157,6 +163,8 @@ const GroupDailyHistoryBody = (props: GroupDailyHistoryBodyProps) => {
                         categoryName={categoryName}
                         transactionDate={transaction_date}
                         transactionsType={transaction_type}
+                        approvedGroups={approvedGroup}
+                        paymentUserId={userId}
                       />
                     </td>
                     <td className="daily-history__td" align="center">

--- a/src/components/home/GroupMothlyHistory.tsx
+++ b/src/components/home/GroupMothlyHistory.tsx
@@ -6,11 +6,16 @@ import { getGroupTransactions } from '../../reducks/groupTransactions/selectors'
 import { getApprovedGroups } from '../../reducks/groups/selectors';
 import { incomeTransactionType } from '../../lib/constant';
 import { getPathGroupId, getPathTemplateName } from '../../lib/path';
-import { year, month, customMonth } from '../../lib/constant';
-import { displayWeeks, WeeklyInfo } from '../../lib/date';
+import { month } from '../../lib/constant';
+import { displayWeeks, WeeklyInfo, SelectYears } from '../../lib/date';
 import { EditTransactionModal, SelectMenu } from '../uikit';
 
-const GroupMonthlyHistory = () => {
+interface GroupMonthlyHistoryProps {
+  year: number;
+  month: number;
+}
+
+const GroupMonthlyHistory = (props: GroupMonthlyHistoryProps) => {
   const dispatch = useDispatch();
   const selector = useSelector((state: State) => state);
   const path = window.location.pathname;
@@ -22,8 +27,12 @@ const GroupMonthlyHistory = () => {
   const [openId, setOpenId] = useState<number | undefined>(undefined);
 
   useEffect(() => {
+    const years: SelectYears = {
+      selectedYear: String(props.year),
+      selectedMonth: props.month <= 9 ? '0' + props.month : String(props.month),
+    };
     if (pathName === 'group') {
-      dispatch(fetchGroupTransactionsList(year, customMonth, groupId));
+      dispatch(fetchGroupTransactionsList(groupId, years));
     }
   }, [pathName, groupId]);
 
@@ -59,13 +68,13 @@ const GroupMonthlyHistory = () => {
     let subTotalAmountRow: ReactElement[] = [];
     let weekNum = 1;
 
-    displayWeeks().map((displayWeek: WeeklyInfo, index: number) => {
+    displayWeeks(props.year, props.month).map((displayWeek: WeeklyInfo, index: number) => {
       headerRow = [
         ...headerRow,
         <th key={index} align="center">
           {weekNum++}週目
           <br />
-          {month + '月' + displayWeek.startDate + '日'}~{displayWeek.endDate + '日'}
+          {props.month + '月' + displayWeek.startDate + '日'}~{displayWeek.endDate + '日'}
         </th>,
       ];
 
@@ -105,7 +114,11 @@ const GroupMonthlyHistory = () => {
               ) {
                 items = [
                   ...items,
-                  <dl className="monthly-history-table__dl" key={id} onClick={() => handleOpen(id)}>
+                  <dl
+                    className="monthly-history-table__dl"
+                    key={'id' + index}
+                    onClick={() => handleOpen(id)}
+                  >
                     <dt>
                       <span>
                         {(() => {

--- a/src/components/home/MonthlyHistory.tsx
+++ b/src/components/home/MonthlyHistory.tsx
@@ -3,15 +3,21 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchTransactionsList } from '../../reducks/transactions/operations';
 import { State } from '../../reducks/store/types';
 import { getTransactions } from '../../reducks/transactions/selectors';
-import { year, month, customMonth } from '../../lib/constant';
+import { month } from '../../lib/constant';
 import '../../assets/history/monthly-history.scss';
 import { displayWeeks, WeeklyInfo } from '../../lib/date';
 import { EditTransactionModal, SelectMenu } from '../uikit';
 import { incomeTransactionType } from '../../lib/constant';
 import { getPathTemplateName } from '../../lib/path';
 import GroupMonthlyHistory from './GroupMothlyHistory';
+import { SelectYears } from '../../lib/date';
 
-const MonthlyHistory = () => {
+interface MonthlyHistoryProps {
+  year: number;
+  month: number;
+}
+
+const MonthlyHistory = (props: MonthlyHistoryProps) => {
   const dispatch = useDispatch();
   const selector = useSelector((state: State) => state);
   const pathName = getPathTemplateName(window.location.pathname);
@@ -20,8 +26,12 @@ const MonthlyHistory = () => {
   const [openId, setOpenId] = useState<number | undefined>(undefined);
 
   useEffect(() => {
-    if (pathName !== 'group' && !transactionsList.length) {
-      dispatch(fetchTransactionsList(String(year), customMonth));
+    const years: SelectYears = {
+      selectedYear: String(props.year),
+      selectedMonth: props.month <= 9 ? '0' + props.month : String(props.month),
+    };
+    if (pathName !== 'group') {
+      dispatch(fetchTransactionsList(years));
     }
   }, [pathName]);
 
@@ -57,19 +67,19 @@ const MonthlyHistory = () => {
     let subTotalAmountRow: ReactElement[] = [];
     let weekNum = 1;
 
-    displayWeeks().map((displayWeek: WeeklyInfo, index: number) => {
+    displayWeeks(props.year, props.month).map((displayWeek: WeeklyInfo, index: number) => {
       headerRow = [
         ...headerRow,
         <th key={index} align="center">
           {weekNum++}週目
           <br />
-          {month + '月' + displayWeek.startDate + '日'}~{displayWeek.endDate + '日'}
+          {props.month + '月' + displayWeek.startDate + '日'}~{displayWeek.endDate + '日'}
         </th>,
       ];
 
       historyRow = [
         ...historyRow,
-        <td className="monthly-history-table__record-second" key={index}>
+        <td className="monthly-history-table__record-second" key={'week' + index}>
           {(() => {
             let items: ReactElement[] = [];
             let prevTransactionDate = '';
@@ -102,7 +112,11 @@ const MonthlyHistory = () => {
               ) {
                 items = [
                   ...items,
-                  <dl className="monthly-history-table__dl" key={id} onClick={() => handleOpen(id)}>
+                  <dl
+                    className="monthly-history-table__dl"
+                    key={'id' + index}
+                    onClick={() => handleOpen(id)}
+                  >
                     <dt>
                       <span>
                         {(() => {
@@ -206,7 +220,7 @@ const MonthlyHistory = () => {
             </>
           );
         } else {
-          return <GroupMonthlyHistory />;
+          return <GroupMonthlyHistory month={props.month} year={props.year} />;
         }
       })()}
     </>

--- a/src/components/uikit/AddTransactionModal.tsx
+++ b/src/components/uikit/AddTransactionModal.tsx
@@ -12,6 +12,7 @@ import Modal from '@material-ui/core/Modal';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import { getApprovedGroups } from '../../reducks/groups/selectors';
+import { getUserId } from '../../reducks/users/selectors';
 import { addTransactions, addLatestTransactions } from '../../reducks/transactions/operations';
 import {
   addGroupLatestTransactions,
@@ -62,6 +63,7 @@ const AddTransactionModal = (props: AddTransactionModalProps) => {
   const dispatch = useDispatch();
   const selector = useSelector((state: State) => state);
   const approvedGroup = getApprovedGroups(selector);
+  const userId = getUserId(selector);
   const pathName = getPathTemplateName(window.location.pathname);
   const groupId = getPathGroupId(window.location.pathname);
   const [amount, setAmount] = useState<string>('');
@@ -75,11 +77,15 @@ const AddTransactionModal = (props: AddTransactionModalProps) => {
   const [bigCategoryId, setBigCategoryId] = useState<number>(0);
   const [mediumCategoryId, setMediumCategoryId] = useState<number | null>(null);
   const [customCategoryId, setCustomCategoryId] = useState<number | null>(null);
-  const [paymentUserId, setPaymentUserId] = useState<string>('');
+  const [paymentUserId, setPaymentUserId] = useState<string>(userId);
 
   useEffect(() => {
     setTransactionDate(props.selectDate);
   }, [props.selectDate]);
+
+  useEffect(() => {
+    setPaymentUserId(userId);
+  }, [userId]);
 
   const handleAmountChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/uikit/InputYears.tsx
+++ b/src/components/uikit/InputYears.tsx
@@ -1,24 +1,41 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { fetchTransactionsList } from '../../reducks/transactions/operations';
 import { fetchGroupTransactionsList } from '../../reducks/groupTransactions/operations';
-import { year, month, years, months } from '../../lib/constant';
+import { years, months } from '../../lib/constant';
 import { getPathTemplateName, getPathGroupId } from '../../lib/path';
 import CloseIcon from '@material-ui/icons/Close';
 import '../../assets/modules/input-years.scss';
+import { SelectYears } from '../../lib/date';
 
 interface InputYearsProps {
   handleSelectYearsClose: () => void;
-  selectedYear: number[];
+  selectedYear: number;
   selectedMonth: number;
-  changeSelectedYear: (event: React.ChangeEvent<{ value: unknown }>) => void;
-  changeSelectedMonth: (event: React.ChangeEvent<{ value: unknown }>) => void;
+  updateSelectYear: (year: number) => void;
+  updateSelectMonth: (month: number) => void;
 }
 
 const InputYears = (props: InputYearsProps) => {
   const dispatch = useDispatch();
   const pathName = getPathTemplateName(window.location.pathname);
   const groupId = getPathGroupId(window.location.pathname);
+  const [itemYear, setItemYear] = useState<number>(props.selectedYear);
+  const [itemMonth, setItemMonth] = useState<number>(props.selectedMonth);
+
+  const changeItemYear = useCallback(
+    (event: React.ChangeEvent<{ value: unknown }>) => {
+      setItemYear(Number(event.target.value));
+    },
+    [setItemYear]
+  );
+
+  const changeItemMonth = useCallback(
+    (event: React.ChangeEvent<{ value: unknown }>) => {
+      setItemMonth(Number(event.target.value));
+    },
+    [setItemMonth]
+  );
 
   return (
     <>
@@ -28,8 +45,8 @@ const InputYears = (props: InputYearsProps) => {
         </button>
         <form className="input-years__select-position">
           <select
-            defaultValue={year}
-            onChange={props.changeSelectedYear}
+            defaultValue={props.selectedYear}
+            onChange={changeItemYear}
             className="input-years__select"
           >
             {years.map((year, index) => (
@@ -40,9 +57,9 @@ const InputYears = (props: InputYearsProps) => {
           </select>
           年
           <select
-            defaultValue={month}
+            defaultValue={props.selectedMonth}
             className="input-years__select"
-            onChange={props.changeSelectedMonth}
+            onChange={changeItemMonth}
           >
             {months.map((month, index) => (
               <option key={index} value={month}>
@@ -56,21 +73,24 @@ const InputYears = (props: InputYearsProps) => {
           <button
             className="input-years__btn__display"
             onClick={() => {
+              const selectYears: SelectYears = {
+                selectedYear: String(itemYear),
+                selectedMonth: itemMonth <= 9 ? '0' + itemMonth : String(itemMonth),
+              };
               if (pathName !== 'group') {
-                dispatch(
-                  fetchTransactionsList(
-                    String(props.selectedYear),
-                    ('0' + props.selectedMonth).slice(-2)
-                  )
-                ) && props.handleSelectYearsClose();
+                dispatch(fetchTransactionsList(selectYears));
+                props.updateSelectYear(itemYear);
+                props.updateSelectMonth(itemMonth);
+                props.handleSelectYearsClose();
               } else {
-                dispatch(
-                  fetchGroupTransactionsList(
-                    Number(props.selectedYear),
-                    String(props.selectedMonth),
-                    groupId
-                  )
-                );
+                const selectYears: SelectYears = {
+                  selectedYear: String(itemYear),
+                  selectedMonth: itemMonth <= 9 ? '0' + itemMonth : String(itemMonth),
+                };
+                dispatch(fetchGroupTransactionsList(groupId, selectYears));
+                props.updateSelectYear(itemYear);
+                props.updateSelectMonth(itemMonth);
+                props.handleSelectYearsClose();
               }
             }}
           >

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,4 +1,4 @@
-import { year, month, customMonth } from './constant';
+import { customMonth, year } from './constant';
 
 export const dateStringToDate = (date: string) => {
   const prevDates = date.split(/[/()]/, 3);
@@ -70,7 +70,7 @@ export interface WeeklyInfo {
 }
 export type Weeks = Array<WeeklyInfo>;
 
-export const displayWeeks = () => {
+export const displayWeeks = (year: number, month: number) => {
   const startDate = new Date(year, month - 1, 1);
   const endDate = new Date(year, month, 0);
   const endDayCount = endDate.getDate();
@@ -126,4 +126,68 @@ export const selectedDate = (startDay: number, endDay: number): Date[] => {
   }
 
   return selectedDays;
+};
+
+export interface SelectYears {
+  selectedYear: string;
+  selectedMonth: string;
+}
+
+export const prevSelectYears = (selectedYear: number, selectedMonth: number): SelectYears => {
+  const nextMonth = selectedMonth - 1;
+
+  if (nextMonth === 0) {
+    return {
+      selectedYear: String(selectedYear - 1),
+      selectedMonth: '12',
+    };
+  } else if (nextMonth <= 9) {
+    return {
+      selectedYear: String(selectedYear),
+      selectedMonth: '0' + nextMonth,
+    };
+  } else {
+    return {
+      selectedYear: String(selectedYear),
+      selectedMonth: String(nextMonth),
+    };
+  }
+};
+
+export const nextSelectYears = (selectedYear: number, selectedMonth: number): SelectYears => {
+  const nextMonth = selectedMonth + 1;
+
+  if (nextMonth === 13) {
+    return {
+      selectedYear: String(selectedYear + 1),
+      selectedMonth: '01',
+    };
+  } else if (nextMonth <= 9) {
+    return {
+      selectedYear: String(selectedYear),
+      selectedMonth: '0' + nextMonth,
+    };
+  } else {
+    return {
+      selectedYear: String(selectedYear),
+      selectedMonth: String(nextMonth),
+    };
+  }
+};
+
+export interface BaseYear {
+  selectedYear: boolean;
+  selectedMonth: boolean;
+}
+
+export const prevButtonDisable = (selectedYear: number, selectedMonth: number) => {
+  const minimumBaseYear = year - 3;
+
+  return selectedYear === minimumBaseYear && selectedMonth === 1;
+};
+
+export const nextButtonDisable = (selectedYear: number, selectedMonth: number) => {
+  const maximumBaseYear = year + 3;
+
+  return selectedYear === maximumBaseYear && selectedMonth === 12;
 };

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -24,11 +24,17 @@ import { isValidAmountFormat, errorHandling } from '../../lib/validation';
 import moment from 'moment';
 import { customMonth } from '../../lib/constant';
 
-export const fetchGroupTransactionsList = (year: number, customMonth: string, groupId: number) => {
+export const fetchGroupTransactionsList = (
+  groupId: number,
+  selectYears: {
+    selectedYear: string;
+    selectedMonth: string;
+  }
+) => {
   return async (dispatch: Dispatch<Action>) => {
     try {
       const result = await axios.get<FetchGroupTransactionsRes>(
-        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMonth}`,
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${selectYears.selectedYear}-${selectYears.selectedMonth}`,
         {
           withCredentials: true,
         }

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -19,11 +19,14 @@ import moment from 'moment';
 import { customMonth } from '../../lib/constant';
 import { isValidAmountFormat, errorHandling } from '../../lib/validation';
 
-export const fetchTransactionsList = (year: string, customMonth: string) => {
+export const fetchTransactionsList = (selectYears: {
+  selectedYear: string;
+  selectedMonth: string;
+}) => {
   return async (dispatch: Dispatch<Action>) => {
     try {
       const result = await axios.get<FetchTransactionsRes>(
-        `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${customMonth}`,
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${selectYears.selectedYear}-${selectYears.selectedMonth}`,
         {
           withCredentials: true,
         }

--- a/src/templates/DailyHistory.tsx
+++ b/src/templates/DailyHistory.tsx
@@ -11,16 +11,17 @@ import { fetchGroupTransactionsList } from '../reducks/groupTransactions/operati
 import { fetchCategories } from '../reducks/categories/operations';
 import { fetchGroupCategories } from '../reducks/groupCategories/operations';
 import { State } from '../reducks/store/types';
-import { customMonth, noTransactionMessage, year, month } from '../lib/constant';
+import { noTransactionMessage, year, month } from '../lib/constant';
 import { getPathTemplateName } from '../lib/path';
 import { DailyHistoryBody, GroupDailyHistoryBody } from '../components/history/index';
 import SearchTransaction from '../components/uikit/SearchTransaction';
 import '../assets/history/daily-history.scss';
 import { getPathGroupId } from '../lib/path';
+import { SelectYears } from '../lib/date';
 
 interface DailyHistoryProps {
-  selectYears: number;
-  selectMonth: string;
+  selectYear: number;
+  selectMonth: number;
 }
 
 const DailyHistory = (props: DailyHistoryProps) => {
@@ -49,12 +50,20 @@ const DailyHistory = (props: DailyHistoryProps) => {
   const [limit, setLimit] = useState<string>('');
 
   useEffect(() => {
+    const selectYears: SelectYears = {
+      selectedYear: String(props.selectYear),
+      selectedMonth: props.selectMonth <= 9 ? '0' + props.selectMonth : String(props.selectMonth),
+    };
     if (pathName !== 'group') {
-      dispatch(fetchTransactionsList(String(props.selectYears), customMonth));
+      dispatch(fetchTransactionsList(selectYears));
     } else if (pathName === 'group') {
-      dispatch(fetchGroupTransactionsList(props.selectYears, customMonth, groupId));
+      const selectYears: SelectYears = {
+        selectedYear: String(props.selectYear),
+        selectedMonth: props.selectMonth <= 9 ? '0' + props.selectMonth : String(props.selectMonth),
+      };
+      dispatch(fetchGroupTransactionsList(groupId, selectYears));
     }
-  }, [pathName, props.selectYears]);
+  }, [pathName]);
 
   useEffect(() => {
     if (pathName !== 'group') {
@@ -202,7 +211,7 @@ const DailyHistory = (props: DailyHistoryProps) => {
             } else if (transactionsList.length) {
               return (
                 <DailyHistoryBody
-                  selectYears={props.selectYears}
+                  selectYears={props.selectYear}
                   selectMonth={props.selectMonth}
                   transactionsList={transactionsList}
                   searchTransactionsList={searchTransactionsList}
@@ -215,7 +224,7 @@ const DailyHistory = (props: DailyHistoryProps) => {
             } else if (groupTransactionsList.length) {
               return (
                 <GroupDailyHistoryBody
-                  selectYears={props.selectYears}
+                  selectYears={props.selectYear}
                   selectMonth={props.selectMonth}
                   groupTransactionsList={groupTransactionsList}
                   groupSearchTransactionsList={groupSearchTransactionsList}

--- a/src/templates/Home.tsx
+++ b/src/templates/Home.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { year, month } from '../lib/constant';
 import { InputForm, RecentInput, MonthlyHistory, HistoryPieChart } from '../components/home';
 
 const Home = () => {
@@ -12,7 +13,7 @@ const Home = () => {
         <div className="box__monthlyExpense">
           <HistoryPieChart />
         </div>
-        <MonthlyHistory />
+        <MonthlyHistory month={month} year={year} />
       </div>
       <div className="home__right">
         <div className="box__input" />

--- a/src/templates/LogIn.tsx
+++ b/src/templates/LogIn.tsx
@@ -67,12 +67,7 @@ const LogIn = () => {
     setPassword('');
   }, [setEmail, setPassword]);
 
-  const unLogIn =
-    email === '' ||
-    password === '' ||
-    password.length < 8 ||
-    emailMessage !== '' ||
-    passwordMessage !== '';
+  const unLogIn = email === '' || password === '' || password.length < 8;
 
   return (
     <section className="login__form">

--- a/src/templates/SignUp.tsx
+++ b/src/templates/SignUp.tsx
@@ -105,12 +105,7 @@ const SignUp = (): JSX.Element => {
     password === '' ||
     confirmPassword === '' ||
     password.length < 8 ||
-    confirmPassword.length < 8 ||
-    userIdMessage != '' ||
-    userNameMessage !== '' ||
-    passwordMessage !== '' ||
-    confirmPasswordMessage !== '' ||
-    emailMessage !== '';
+    confirmPassword.length < 8;
 
   return (
     <section className="signup__form">
@@ -132,7 +127,7 @@ const SignUp = (): JSX.Element => {
                 value={userId}
                 type="userId"
                 onChange={inputUserId}
-                onBlur={() => onUserIdFocusOut(email, setUserIdMessage)}
+                onBlur={() => onUserIdFocusOut(userId, setUserIdMessage)}
               />
               <InvalidMessage message={userIdMessage} />
             </div>
@@ -162,7 +157,7 @@ const SignUp = (): JSX.Element => {
             </div>
             <div className="module-spacer--small" />
             <div>
-              <label>パスワード</label>
+              <label>パスワード（半角英数字の8文字以上で入力してください）</label>
               <TextArea
                 id={'password'}
                 value={password}

--- a/test/group-transactions-test/GroupTransactions.test.tsx
+++ b/test/group-transactions-test/GroupTransactions.test.tsx
@@ -5,6 +5,7 @@ import axiosMockAdapter from 'axios-mock-adapter';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { GroupTransactionsReq } from '../../src/reducks/groupTransactions/types';
+import { SelectYears } from '../../src/lib/date';
 import {
   addGroupTransactions,
   fetchGroupTransactionsList,
@@ -34,7 +35,6 @@ import groupAccountList from './groupAccountList.json';
 import editGroupAccountList from './editGroupAccoountResponse.json';
 import deleteAccountResponse from './deleteGroupAccountResponse.json';
 import searchGroupTransactionsRes from './fetchSearchGroupTransactionsResponse.json';
-import { year, customMonth } from '../../src/lib/constant';
 
 const axiosMock = new axiosMockAdapter(axios);
 const middlewares = [thunk];
@@ -52,7 +52,13 @@ describe('async actions groupTransactions', () => {
     const store = mockStore({ groupTransactions: { groupTransactionsList: [] } });
 
     const groupId = 1;
-    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMonth}`;
+
+    const years: SelectYears = {
+      selectedYear: '2020',
+      selectedMonth: '11',
+    };
+
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${years.selectedYear}-${years.selectedMonth}`;
 
     const expectedAddActions = [
       {
@@ -63,7 +69,7 @@ describe('async actions groupTransactions', () => {
 
     axiosMock.onGet(url).reply(200, mockResponse);
 
-    await fetchGroupTransactionsList(year, customMonth, groupId)(store.dispatch);
+    await fetchGroupTransactionsList(groupId, years)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAddActions);
   });
 

--- a/test/transactions-test/Transactions.test.tsx
+++ b/test/transactions-test/Transactions.test.tsx
@@ -5,6 +5,7 @@ import axiosMockAdapter from 'axios-mock-adapter';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import { TransactionsReq } from '../../src/reducks/transactions/types';
+import { SelectYears } from '../../src/lib/date';
 import {
   fetchTransactionsList,
   fetchLatestTransactionsList,
@@ -35,14 +36,16 @@ process.on('unhandledRejection', console.dir);
 
 describe('async actions fetchTransactionsList', () => {
   const store = mockStore({ transactionsList: [] });
-  const date = new Date();
-  const year = date.getFullYear();
-  const month = '11';
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${month}`;
 
   beforeEach(() => {
     store.clearActions();
   });
+
+  const years: SelectYears = {
+    selectedYear: '2020',
+    selectedMonth: '11',
+  };
+  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${years.selectedYear}-${years.selectedMonth}`;
 
   it('Get transactionsList if fetch succeeds', async () => {
     const mockResponse = transactionsList;
@@ -59,7 +62,7 @@ describe('async actions fetchTransactionsList', () => {
 
     axiosMock.onGet(url).reply(200, mockResponse);
 
-    await fetchTransactionsList(String(year), month)(store.dispatch);
+    await fetchTransactionsList(years)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAddActions);
   });
 });


### PR DESCRIPTION
- `MonthlyHistory, GroupMonthlyHistory`の`displayWeeks()`に親のyear, monthを引数に渡すことで`History`のstateが更新
   された際に表示が切り替わるように修正しました。

- グループの際に`AddTransactionsModal`に支払いを行ったユーザーのid、`payment_user_id`を選択できるように修正しました。

- `Login, Signup`でバリデーションの修正を行いました。

- `date.ts`に来月に進める、先月に戻るボタンのdisabled関数を追加しました。

確認よろしくお願いします。