### PR TITLE
Add nextSearchTodoList in editTodoListItem() in src/reducks/todoList/…

### DIFF
--- a/src/reducks/groupTodoList/actions.ts
+++ b/src/reducks/groupTodoList/actions.ts
@@ -97,7 +97,8 @@ export const deleteGroupTodoListItemAction = (
   groupTodayImplementationTodoList: GroupTodoList,
   groupTodayDueTodoList: GroupTodoList,
   groupMonthImplementationTodoList: GroupTodoList,
-  groupMonthDueTodoList: GroupTodoList
+  groupMonthDueTodoList: GroupTodoList,
+  groupSearchTodoList: GroupTodoList
 ) => {
   return {
     type: DELETE_GROUP_TODO_LIST_ITEM,
@@ -107,6 +108,7 @@ export const deleteGroupTodoListItemAction = (
       groupTodayDueTodoList: groupTodayDueTodoList,
       groupMonthImplementationTodoList: groupMonthImplementationTodoList,
       groupMonthDueTodoList: groupMonthDueTodoList,
+      groupSearchTodoList: groupSearchTodoList,
     },
   };
 };

--- a/src/reducks/groupTodoList/actions.ts
+++ b/src/reducks/groupTodoList/actions.ts
@@ -33,7 +33,8 @@ export const editGroupTodoListItemAction = (
   groupTodayImplementationTodoList: GroupTodoList,
   groupTodayDueTodoList: GroupTodoList,
   groupMonthImplementationTodoList: GroupTodoList,
-  groupMonthDueTodoList: GroupTodoList
+  groupMonthDueTodoList: GroupTodoList,
+  groupSearchTodoList: GroupTodoList
 ) => {
   return {
     type: EDIT_GROUP_TODO_LIST_ITEM,
@@ -43,6 +44,7 @@ export const editGroupTodoListItemAction = (
       groupTodayDueTodoList: groupTodayDueTodoList,
       groupMonthImplementationTodoList: groupMonthImplementationTodoList,
       groupMonthDueTodoList: groupMonthDueTodoList,
+      groupSearchTodoList: groupSearchTodoList,
     },
   };
 };

--- a/src/reducks/groupTodoList/operations.ts
+++ b/src/reducks/groupTodoList/operations.ts
@@ -249,6 +249,7 @@ export const editGroupTodoListItem = (
         .groupMonthImplementationTodoList;
       const prevGroupMonthDueTodoList: GroupTodoList = getState().groupTodoList
         .groupMonthDueTodoList;
+      const prevGroupSearchTodoList: GroupTodoList = getState().groupTodoList.groupSearchTodoList;
 
       const responseImplementationMonth = dateStringToMonthString(result.data.implementation_date);
       const responseDueMonth = dateStringToMonthString(result.data.due_date);
@@ -345,6 +346,12 @@ export const editGroupTodoListItem = (
         return nextTodoList;
       };
 
+      const searchTodoListItemIdx = prevGroupSearchTodoList.findIndex(
+        (item) => item.id === todoListItemId
+      );
+      prevGroupSearchTodoList[searchTodoListItemIdx] = result.data;
+      const nextGroupSearchTodoList: GroupTodoList = [...prevGroupSearchTodoList];
+
       const nextGroupExpiredTodoList: GroupTodoList = updateGroupExpiredTodoList(
         prevGroupExpiredTodoList,
         result.data.due_date
@@ -375,7 +382,8 @@ export const editGroupTodoListItem = (
           nextGroupTodayImplementationTodoList,
           nextGroupTodayDueTodoList,
           nextGroupMonthImplementationTodoList,
-          nextGroupMonthDueTodoList
+          nextGroupMonthDueTodoList,
+          nextGroupSearchTodoList
         )
       );
     } catch (error) {

--- a/src/reducks/groupTodoList/operations.ts
+++ b/src/reducks/groupTodoList/operations.ts
@@ -534,31 +534,34 @@ export const deleteGroupTodoListItem = (groupId: number, todoListItemId: number)
         .groupMonthImplementationTodoList;
       const prevGroupMonthDueTodoList: GroupTodoList = getState().groupTodoList
         .groupMonthDueTodoList;
+      const prevGroupSearchTodoList: GroupTodoList = getState().groupTodoList.groupSearchTodoList;
       const message = result.data.message;
 
-      const updateTodoList = (prevTodoList: GroupTodoList) => {
+      const nextTodoList = (prevTodoList: GroupTodoList) => {
         return prevTodoList.filter((prevTodoListItem) => {
           return prevTodoListItem.id !== todoListItemId;
         });
       };
 
-      const updateGroupExpiredTodoList = updateTodoList(prevGroupExpiredTodoList);
-      const updateGroupTodayImplementationTodoList = updateTodoList(
+      const nextGroupExpiredTodoList = nextTodoList(prevGroupExpiredTodoList);
+      const nextGroupTodayImplementationTodoList = nextTodoList(
         prevGroupTodayImplementationTodoList
       );
-      const updateGroupTodayDueTodoList = updateTodoList(prevGroupTodayDueTodoList);
-      const updateGroupMonthImplementationTodoList = updateTodoList(
+      const nextGroupTodayDueTodoList = nextTodoList(prevGroupTodayDueTodoList);
+      const nextGroupMonthImplementationTodoList = nextTodoList(
         prevGroupMonthImplementationTodoList
       );
-      const updateGroupMonthDueTodoList = updateTodoList(prevGroupMonthDueTodoList);
+      const nextGroupMonthDueTodoList = nextTodoList(prevGroupMonthDueTodoList);
+      const nextGroupSearchTodoList = nextTodoList(prevGroupSearchTodoList);
 
       dispatch(
         deleteGroupTodoListItemAction(
-          updateGroupExpiredTodoList,
-          updateGroupTodayImplementationTodoList,
-          updateGroupTodayDueTodoList,
-          updateGroupMonthImplementationTodoList,
-          updateGroupMonthDueTodoList
+          nextGroupExpiredTodoList,
+          nextGroupTodayImplementationTodoList,
+          nextGroupTodayDueTodoList,
+          nextGroupMonthImplementationTodoList,
+          nextGroupMonthDueTodoList,
+          nextGroupSearchTodoList
         )
       );
       dispatch(openTextModalAction(message));

--- a/src/reducks/todoList/actions.ts
+++ b/src/reducks/todoList/actions.ts
@@ -34,7 +34,8 @@ export const editTodoListItemAction = (
   todayImplementationTodoList: TodoList,
   todayDueTodoList: TodoList,
   monthImplementationTodoList: TodoList,
-  monthDueTodoList: TodoList
+  monthDueTodoList: TodoList,
+  searchTodoList: TodoList
 ) => {
   return {
     type: EDIT_TODO_LIST_ITEM,
@@ -44,6 +45,7 @@ export const editTodoListItemAction = (
       todayDueTodoList: todayDueTodoList,
       monthImplementationTodoList: monthImplementationTodoList,
       monthDueTodoList: monthDueTodoList,
+      searchTodoList: searchTodoList,
     },
   };
 };

--- a/src/reducks/todoList/actions.ts
+++ b/src/reducks/todoList/actions.ts
@@ -98,7 +98,8 @@ export const deleteTodoListItemAction = (
   todayImplementationTodoList: TodoList,
   todayDueTodoList: TodoList,
   monthImplementationTodoList: TodoList,
-  monthDueTodoList: TodoList
+  monthDueTodoList: TodoList,
+  searchTodoList: TodoList
 ) => {
   return {
     type: DELETE_TODO_LIST_ITEM,
@@ -108,6 +109,7 @@ export const deleteTodoListItemAction = (
       todayDueTodoList: todayDueTodoList,
       monthImplementationTodoList: monthImplementationTodoList,
       monthDueTodoList: monthDueTodoList,
+      searchTodoList: searchTodoList,
     },
   };
 };

--- a/src/reducks/todoList/operations.ts
+++ b/src/reducks/todoList/operations.ts
@@ -493,33 +493,37 @@ export const deleteTodoListItem = (todoListItemId: number) => {
           withCredentials: true,
         }
       );
-      const prevExpiredTodoList = getState().todoList.expiredTodoList;
-      const prevTodayImplementationTodoList = getState().todoList.todayImplementationTodoList;
-      const prevTodayDueTodoList = getState().todoList.todayDueTodoList;
+      const prevExpiredTodoList: TodoList = getState().todoList.expiredTodoList;
+      const prevTodayImplementationTodoList: TodoList = getState().todoList
+        .todayImplementationTodoList;
+      const prevTodayDueTodoList: TodoList = getState().todoList.todayDueTodoList;
       const prevMonthImplementationTodoList: TodoList = getState().todoList
         .monthImplementationTodoList;
       const prevMonthDueTodoList: TodoList = getState().todoList.monthDueTodoList;
+      const prevSearchTodoList: TodoList = getState().todoList.searchTodoList;
       const message = result.data.message;
 
-      const updateTodoList = (prevTodoList: TodoList) => {
+      const nextTodoList = (prevTodoList: TodoList) => {
         return prevTodoList.filter((prevTodoListItem) => {
           return prevTodoListItem.id !== todoListItemId;
         });
       };
 
-      const updateExpiredTodoList = updateTodoList(prevExpiredTodoList);
-      const updateTodayImplementationTodoList = updateTodoList(prevTodayImplementationTodoList);
-      const updateTodayDueTodoList = updateTodoList(prevTodayDueTodoList);
-      const updateMonthImplementationTodoList = updateTodoList(prevMonthImplementationTodoList);
-      const updateMonthDueTodoList = updateTodoList(prevMonthDueTodoList);
+      const nextExpiredTodoList = nextTodoList(prevExpiredTodoList);
+      const nextTodayImplementationTodoList = nextTodoList(prevTodayImplementationTodoList);
+      const nextTodayDueTodoList = nextTodoList(prevTodayDueTodoList);
+      const nextMonthImplementationTodoList = nextTodoList(prevMonthImplementationTodoList);
+      const nextMonthDueTodoList = nextTodoList(prevMonthDueTodoList);
+      const nextSearchTodoList = nextTodoList(prevSearchTodoList);
 
       dispatch(
         deleteTodoListItemAction(
-          updateExpiredTodoList,
-          updateTodayImplementationTodoList,
-          updateTodayDueTodoList,
-          updateMonthImplementationTodoList,
-          updateMonthDueTodoList
+          nextExpiredTodoList,
+          nextTodayImplementationTodoList,
+          nextTodayDueTodoList,
+          nextMonthImplementationTodoList,
+          nextMonthDueTodoList,
+          nextSearchTodoList
         )
       );
       dispatch(openTextModalAction(message));

--- a/src/reducks/todoList/operations.ts
+++ b/src/reducks/todoList/operations.ts
@@ -245,6 +245,7 @@ export const editTodoListItem = (
       const prevMonthImplementationTodoList: TodoList = getState().todoList
         .monthImplementationTodoList;
       const prevMonthDueTodoList: TodoList = getState().todoList.monthDueTodoList;
+      const prevSearchTodoList: TodoList = getState().todoList.searchTodoList;
 
       const responseImplementationMonth = dateStringToMonthString(result.data.implementation_date);
       const responseDueMonth = dateStringToMonthString(result.data.due_date);
@@ -341,6 +342,12 @@ export const editTodoListItem = (
         return nextTodoList;
       };
 
+      const searchTodoListItemIdx = prevSearchTodoList.findIndex(
+        (item) => item.id === todoListItemId
+      );
+      prevSearchTodoList[searchTodoListItemIdx] = result.data;
+      const nextSearchTodoList: TodoList = [...prevSearchTodoList];
+
       const nextExpiredTodoList: TodoList = updateExpiredTodoList(
         prevExpiredTodoList,
         result.data.due_date
@@ -371,7 +378,8 @@ export const editTodoListItem = (
           nextTodayImplementationTodoLists,
           nextTodayDueTodoLists,
           nextMonthImplementationTodoList,
-          nextMonthDueTodoLists
+          nextMonthDueTodoLists,
+          nextSearchTodoList
         )
       );
     } catch (error) {

--- a/test/group-todolist-test/GroupTodoList.test.tsx
+++ b/test/group-todolist-test/GroupTodoList.test.tsx
@@ -642,6 +642,18 @@ describe('async actions groupTodoLists', () => {
               user_id: 'furusawa',
             },
           ],
+          groupSearchTodoList: [
+            {
+              id: 1,
+              posted_date: '2020-09-25T10:54:46Z',
+              updated_date: '2020-09-25T10:54:46Z',
+              implementation_date: '2020/09/25(金)',
+              due_date: '2020/09/25(金)',
+              todo_content: '携帯支払い',
+              complete_flag: false,
+              user_id: 'furusawa',
+            },
+          ],
         },
       },
       {

--- a/test/group-todolist-test/GroupTodoList.test.tsx
+++ b/test/group-todolist-test/GroupTodoList.test.tsx
@@ -21,8 +21,6 @@ import {
   searchGroupTodoList,
 } from '../../src/reducks/groupTodoList/operations';
 import * as ModalActions from '../../src/reducks/modal/actions';
-import * as TodoListsActions from '../../src/reducks/todoList/actions';
-import { searchTodoList } from '../../src/reducks/todoList/operations';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -104,7 +102,18 @@ const getState = () => {
         },
       ],
       groupMonthTodoListMessage: '',
-      groupSearchTodoList: [],
+      groupSearchTodoList: [
+        {
+          id: 1,
+          posted_date: '2020-09-25T10:54:46Z',
+          updated_date: '2020-09-25T10:54:46Z',
+          implementation_date: '2020/09/25(金)',
+          due_date: '2020/09/25(金)',
+          todo_content: '携帯支払い',
+          complete_flag: false,
+          user_id: 'furusawa',
+        },
+      ],
       groupSearchTodoListMessage: '',
     },
     modal: { message: '', open: false },
@@ -282,9 +291,9 @@ describe('async actions groupTodoLists', () => {
     expect(store.getActions()).toEqual(expectedAction);
   });
 
-  it('If EDIT_GROUP_TODO_LIST_ITEM is successful, the updated todoListItem will be reflected in the groupTodoList managed by the store.', async () => {
+  it('edit data in groupTodoList if fetch succeeds', async () => {
     const groupId = 1;
-    const todoListItemId = 1;
+    const todoListItemId = 2;
     const today = new Date();
     const selectedDate = new Date('2020-09-27T00:00:00');
     const implementationDate = new Date('2020-09-27T00:00:00');
@@ -365,6 +374,18 @@ describe('async actions groupTodoLists', () => {
               implementation_date: '2020/09/27(日)',
               due_date: '2020/09/28(月)',
               todo_content: '買い物へ行く',
+              complete_flag: false,
+              user_id: 'furusawa',
+            },
+          ],
+          groupSearchTodoList: [
+            {
+              id: 1,
+              posted_date: '2020-09-25T10:54:46Z',
+              updated_date: '2020-09-25T10:54:46Z',
+              implementation_date: '2020/09/25(金)',
+              due_date: '2020/09/25(金)',
+              todo_content: '携帯支払い',
               complete_flag: false,
               user_id: 'furusawa',
             },

--- a/test/todolist-test/TodoList.test.tsx
+++ b/test/todolist-test/TodoList.test.tsx
@@ -573,6 +573,17 @@ describe('async actions todoLists', () => {
               complete_flag: false,
             },
           ],
+          searchTodoList: [
+            {
+              id: 1,
+              posted_date: '2020-09-25T10:54:46Z',
+              updated_date: '2020-09-25T10:54:46Z',
+              implementation_date: '2020/09/25(金)',
+              due_date: '2020/09/25(金)',
+              todo_content: '携帯支払い',
+              complete_flag: false,
+            },
+          ],
         },
       },
       {

--- a/test/todolist-test/TodoList.test.tsx
+++ b/test/todolist-test/TodoList.test.tsx
@@ -97,7 +97,17 @@ const getState = () => {
         },
       ],
       monthTodoListMessage: '',
-      searchTodoList: [],
+      searchTodoList: [
+        {
+          id: 1,
+          posted_date: '2020-09-25T10:54:46Z',
+          updated_date: '2020-09-25T10:54:46Z',
+          implementation_date: '2020/09/25(金)',
+          due_date: '2020/09/25(金)',
+          todo_content: '携帯支払い',
+          complete_flag: false,
+        },
+      ],
       searchTodoListMessage: '',
     },
     modal: {
@@ -332,6 +342,17 @@ describe('async actions todoLists', () => {
               due_date: '2020/09/28(月)',
               todo_content: 'お掃除',
               complete_flag: true,
+            },
+          ],
+          searchTodoList: [
+            {
+              id: 1,
+              posted_date: '2020-09-25T10:54:46Z',
+              updated_date: '2020-09-25T10:54:46Z',
+              implementation_date: '2020/09/25(金)',
+              due_date: '2020/09/25(金)',
+              todo_content: '携帯支払い',
+              complete_flag: false,
             },
           ],
         },


### PR DESCRIPTION
- `src/reducks/todoList/operations.ts`の`editTodoListItem()`に`nextSearchTodoList`を追加。  959c611

- `src/reducks/todoList/operations.ts`の`deleteTodoListItem()`に`nextSearchTodoList`を追加。  2bd21ee

- `src/reducks/groupTodoList/operations.ts`の`editGroupTodoListItem()`に`nextGroupSearchTodoList`を追加。  5cf62bb

- `src/reducks/groupTodoList/operations.ts`の`deleteGroupTodoListItem()`に`nextGroupSearchTodoList`を追加。 414654a