### PR TITLE
Modify the transaction date sort and add categoryId to transaction

### DIFF
--- a/src/components/history/DailyHistoryBody.tsx
+++ b/src/components/history/DailyHistoryBody.tsx
@@ -75,6 +75,9 @@ const DailyHistoryBody = (props: DailyHistoryBodyProps) => {
                   id,
                   transaction_type,
                   transaction_date,
+                  big_category_id,
+                  medium_category_id,
+                  custom_category_id,
                   big_category_name,
                   medium_category_name,
                   custom_category_name,
@@ -105,6 +108,9 @@ const DailyHistoryBody = (props: DailyHistoryBodyProps) => {
                         categoryName={categoryName}
                         transactionDate={transaction_date}
                         transactionsType={transaction_type}
+                        bigCategoryId={big_category_id}
+                        mediumCategoryId={medium_category_id}
+                        customCategoryId={custom_category_id}
                       />
                     </td>
                     <td className="daily-history__td" align="center">
@@ -131,6 +137,9 @@ const DailyHistoryBody = (props: DailyHistoryBodyProps) => {
                   id,
                   transaction_type,
                   transaction_date,
+                  big_category_id,
+                  medium_category_id,
+                  custom_category_id,
                   big_category_name,
                   medium_category_name,
                   custom_category_name,
@@ -161,6 +170,9 @@ const DailyHistoryBody = (props: DailyHistoryBodyProps) => {
                         categoryName={categoryName}
                         transactionDate={transaction_date}
                         transactionsType={transaction_type}
+                        bigCategoryId={big_category_id}
+                        mediumCategoryId={medium_category_id}
+                        customCategoryId={custom_category_id}
                       />
                     </td>
                     <td className="daily-history__td" align="center">

--- a/src/components/history/GroupDailyHistoryBody.tsx
+++ b/src/components/history/GroupDailyHistoryBody.tsx
@@ -63,6 +63,9 @@ const GroupDailyHistoryBody = (props: GroupDailyHistoryBodyProps) => {
                   id,
                   transaction_type,
                   transaction_date,
+                  big_category_id,
+                  medium_category_id,
+                  custom_category_id,
                   big_category_name,
                   medium_category_name,
                   custom_category_name,
@@ -95,6 +98,9 @@ const GroupDailyHistoryBody = (props: GroupDailyHistoryBodyProps) => {
                         transactionsType={transaction_type}
                         approvedGroups={approvedGroup}
                         paymentUserId={userId}
+                        bigCategoryId={big_category_id}
+                        mediumCategoryId={medium_category_id}
+                        customCategoryId={custom_category_id}
                       />
                     </td>
                     <td className="daily-history__td" align="center">
@@ -121,6 +127,9 @@ const GroupDailyHistoryBody = (props: GroupDailyHistoryBodyProps) => {
                   id,
                   transaction_type,
                   transaction_date,
+                  big_category_id,
+                  medium_category_id,
+                  custom_category_id,
                   big_category_name,
                   medium_category_name,
                   custom_category_name,
@@ -153,6 +162,9 @@ const GroupDailyHistoryBody = (props: GroupDailyHistoryBodyProps) => {
                         transactionsType={transaction_type}
                         approvedGroups={approvedGroup}
                         paymentUserId={userId}
+                        bigCategoryId={big_category_id}
+                        mediumCategoryId={medium_category_id}
+                        customCategoryId={custom_category_id}
                       />
                     </td>
                     <td className="daily-history__td" align="center">

--- a/src/components/home/GroupMothlyHistory.tsx
+++ b/src/components/home/GroupMothlyHistory.tsx
@@ -110,6 +110,9 @@ const GroupMonthlyHistory = (props: GroupMonthlyHistoryProps) => {
                 id,
                 transaction_date,
                 transaction_type,
+                big_category_id,
+                medium_category_id,
+                custom_category_id,
                 big_category_name,
                 medium_category_name,
                 custom_category_name,
@@ -211,6 +214,9 @@ const GroupMonthlyHistory = (props: GroupMonthlyHistoryProps) => {
                     transactionsType={transaction_type}
                     paymentUserId={payment_user_id}
                     approvedGroups={approvedGroup}
+                    bigCategoryId={big_category_id}
+                    mediumCategoryId={medium_category_id}
+                    customCategoryId={custom_category_id}
                   />,
                 ];
               }

--- a/src/components/home/GroupRecentInputBody.tsx
+++ b/src/components/home/GroupRecentInputBody.tsx
@@ -43,6 +43,9 @@ const GroupRecentInputBody = (props: RecentInputBodyProps) => {
         id,
         transaction_type,
         transaction_date,
+        big_category_id,
+        medium_category_id,
+        custom_category_id,
         big_category_name,
         medium_category_name,
         custom_category_name,
@@ -101,6 +104,9 @@ const GroupRecentInputBody = (props: RecentInputBodyProps) => {
             transactionsType={transaction_type}
             approvedGroups={props.approvedGroup}
             paymentUserId={payment_user_id}
+            bigCategoryId={big_category_id}
+            mediumCategoryId={medium_category_id}
+            customCategoryId={custom_category_id}
           />
         </div>
       );

--- a/src/components/home/MonthlyHistory.tsx
+++ b/src/components/home/MonthlyHistory.tsx
@@ -108,6 +108,9 @@ const MonthlyHistory = (props: MonthlyHistoryProps) => {
                 id,
                 transaction_date,
                 transaction_type,
+                big_category_id,
+                medium_category_id,
+                custom_category_id,
                 big_category_name,
                 medium_category_name,
                 custom_category_name,
@@ -200,6 +203,9 @@ const MonthlyHistory = (props: MonthlyHistoryProps) => {
                     categoryName={categoryName}
                     transactionDate={transaction_date}
                     transactionsType={transaction_type}
+                    bigCategoryId={big_category_id}
+                    mediumCategoryId={medium_category_id}
+                    customCategoryId={custom_category_id}
                   />,
                 ];
               }

--- a/src/components/home/RecentInputBody.tsx
+++ b/src/components/home/RecentInputBody.tsx
@@ -28,6 +28,9 @@ const RecentInputBody = (props: RecentInputBodyProps) => {
         id,
         transaction_type,
         transaction_date,
+        big_category_id,
+        medium_category_id,
+        custom_category_id,
         big_category_name,
         medium_category_name,
         custom_category_name,
@@ -81,6 +84,9 @@ const RecentInputBody = (props: RecentInputBodyProps) => {
             onClose={handleClose}
             transactionDate={transaction_date}
             transactionsType={transaction_type}
+            bigCategoryId={big_category_id}
+            mediumCategoryId={medium_category_id}
+            customCategoryId={custom_category_id}
           />
         </div>
       );

--- a/src/components/uikit/EditTransactionModal.tsx
+++ b/src/components/uikit/EditTransactionModal.tsx
@@ -30,8 +30,7 @@ import {
   getGroupExpenseCategories,
 } from '../../reducks/groupCategories/selectors';
 import { State } from '../../reducks/store/types';
-import { AssociatedCategory, Category, CategoryId } from '../../reducks/categories/types';
-import { expenseTransactionType, incomeTransactionType } from '../../lib/constant';
+import { AssociatedCategory, Category } from '../../reducks/categories/types';
 import { IconButton } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { TransactionsReq } from '../../reducks/transactions/types';
@@ -81,6 +80,9 @@ interface InputModalProps {
   amount: number;
   memo: string | null;
   shop: string | null;
+  bigCategoryId: number;
+  mediumCategoryId: number;
+  customCategoryId: number;
   categoryName: {
     bigCategory: string;
     mediumCategory: string;
@@ -114,87 +116,13 @@ const EditTransactionModal = (props: InputModalProps) => {
     props.categoryName.mediumCategory || props.categoryName.customCategory
   );
   const [bigCategoryIndex, setBigCategoryIndex] = useState<number>(0);
-  const [bigCategoryId, setBigCategoryId] = useState<number>(0);
-  const [mediumCategoryId, setMediumCategoryId] = useState<number | null>(null);
-  const [customCategoryId, setCustomCategoryId] = useState<number | null>(null);
+  const [bigCategoryId, setBigCategoryId] = useState<number>(props.bigCategoryId);
+  const [mediumCategoryId, setMediumCategoryId] = useState<number | null>(props.mediumCategoryId);
+  const [customCategoryId, setCustomCategoryId] = useState<number | null>(props.customCategoryId);
   const adjustTransactionDate = props.transactionDate.replace('/', '-').slice(0, 10);
   const changeTypeTransactionDate = new Date(adjustTransactionDate);
   const [transactionDate, setTransactionDate] = useState<Date | null>(changeTypeTransactionDate);
   const signal = axios.CancelToken.source();
-
-  const categoryId = (): CategoryId => {
-    const categoriesId: CategoryId = {
-      bigCategoryId: 0,
-      mediumCategoryId: 0,
-      customCategoryId: 0,
-    };
-
-    if (props.transactionsType === expenseTransactionType) {
-      if (pathName !== 'group') {
-        for (const expenseCategory of expenseCategories) {
-          for (const associatedCategory of expenseCategory.associated_categories_list) {
-            if (props.categoryName.mediumCategory === associatedCategory.name) {
-              categoriesId.bigCategoryId = associatedCategory.big_category_id;
-              categoriesId.mediumCategoryId = associatedCategory.id;
-              categoriesId.customCategoryId = null;
-            } else if (props.categoryName.customCategory === associatedCategory.name) {
-              categoriesId.bigCategoryId = associatedCategory.big_category_id;
-              categoriesId.mediumCategoryId = null;
-              categoriesId.customCategoryId = associatedCategory.id;
-            }
-          }
-        }
-      } else if (pathName === 'group') {
-        for (const groupExpenseCategory of groupExpenseCategories) {
-          for (const groupAssociatedCategory of groupExpenseCategory.associated_categories_list) {
-            if (props.categoryName.mediumCategory === groupAssociatedCategory.name) {
-              categoriesId.bigCategoryId = groupAssociatedCategory.big_category_id;
-              categoriesId.mediumCategoryId = groupAssociatedCategory.id;
-              categoriesId.customCategoryId = null;
-            } else if (props.categoryName.customCategory === groupAssociatedCategory.name) {
-              categoriesId.bigCategoryId = groupAssociatedCategory.big_category_id;
-              categoriesId.mediumCategoryId = null;
-              categoriesId.customCategoryId = groupAssociatedCategory.id;
-            }
-          }
-        }
-      }
-    }
-
-    if (props.transactionsType === incomeTransactionType) {
-      if (pathName !== 'group') {
-        for (const incomeCategory of incomeCategories) {
-          for (const associatedCategory of incomeCategory.associated_categories_list) {
-            if (props.categoryName.mediumCategory === associatedCategory.name) {
-              categoriesId.bigCategoryId = associatedCategory.big_category_id;
-              categoriesId.mediumCategoryId = associatedCategory.id;
-              categoriesId.customCategoryId = null;
-            } else if (props.categoryName.customCategory === associatedCategory.name) {
-              categoriesId.bigCategoryId = associatedCategory.big_category_id;
-              categoriesId.mediumCategoryId = null;
-              categoriesId.customCategoryId = associatedCategory.id;
-            }
-          }
-        }
-      } else if (pathName === 'group') {
-        for (const groupIncomeCategory of groupIncomeCategories) {
-          for (const groupAssociatedCategory of groupIncomeCategory.associated_categories_list) {
-            if (props.categoryName.mediumCategory === groupAssociatedCategory.name) {
-              categoriesId.bigCategoryId = groupAssociatedCategory.big_category_id;
-              categoriesId.mediumCategoryId = groupAssociatedCategory.id;
-              categoriesId.customCategoryId = null;
-            } else if (props.categoryName.customCategory === groupAssociatedCategory.name) {
-              categoriesId.bigCategoryId = groupAssociatedCategory.big_category_id;
-              categoriesId.mediumCategoryId = null;
-              categoriesId.customCategoryId = groupAssociatedCategory.id;
-            }
-          }
-        }
-      }
-    }
-
-    return categoriesId;
-  };
 
   useEffect(() => {
     if (props.open) {
@@ -224,16 +152,16 @@ const EditTransactionModal = (props: InputModalProps) => {
   }, [props.categoryName.mediumCategory, props.categoryName.customCategory]);
 
   useEffect(() => {
-    setBigCategoryId(categoryId().bigCategoryId);
-  }, [categoryId().bigCategoryId]);
+    setBigCategoryId(props.bigCategoryId);
+  }, [props.bigCategoryId]);
 
   useEffect(() => {
-    setMediumCategoryId(categoryId().mediumCategoryId);
-  }, [categoryId().mediumCategoryId]);
+    setMediumCategoryId(props.mediumCategoryId);
+  }, [props.mediumCategoryId]);
 
   useEffect(() => {
-    setCustomCategoryId(categoryId().customCategoryId);
-  }, [categoryId().customCategoryId]);
+    setCustomCategoryId(props.customCategoryId);
+  }, [props.customCategoryId]);
 
   useEffect(() => {
     setTransactionDate(changeTypeTransactionDate);
@@ -374,9 +302,9 @@ const EditTransactionModal = (props: InputModalProps) => {
     setAmount(String(props.amount));
     setTransactionType(props.transactionsType);
     setTransactionDate(changeTypeTransactionDate);
-    setBigCategoryId(categoryId().bigCategoryId);
-    setMediumCategoryId(categoryId().mediumCategoryId);
-    setCustomCategoryId(categoryId().customCategoryId);
+    setBigCategoryId(props.bigCategoryId);
+    setMediumCategoryId(props.mediumCategoryId);
+    setCustomCategoryId(props.customCategoryId);
     setBigCategory(props.categoryName.bigCategory);
     setAssociatedCategory(props.categoryName.mediumCategory || props.categoryName.customCategory);
     setPaymentUserId(String(props.paymentUserId));

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -43,12 +43,7 @@ export const fetchGroupTransactionsList = (
       const groupTransactionsList = result.data.transactions_list;
 
       if (groupTransactionsList !== undefined) {
-        const aligningGroupTransactionsList = groupTransactionsList.sort(
-          (a, b) =>
-            Number(a.transaction_date.slice(8, 10)) - Number(b.transaction_date.slice(8, 10))
-        );
-
-        dispatch(updateGroupTransactionsAction(aligningGroupTransactionsList));
+        dispatch(updateGroupTransactionsAction(groupTransactionsList));
       } else {
         const emptyGroupTransactionsList: GroupTransactionsList = [];
 

--- a/src/reducks/groupTransactions/types.ts
+++ b/src/reducks/groupTransactions/types.ts
@@ -10,8 +10,11 @@ export interface GroupTransactions {
   posted_user_id: string;
   updated_user_id: string;
   payment_user_id: string;
+  big_category_id: number;
   big_category_name: string;
+  medium_category_id: number;
   medium_category_name: string | null;
+  custom_category_id: number;
   custom_category_name: string | null;
 }
 

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -38,13 +38,9 @@ export const fetchTransactionsList = (
       const transactionsList = result.data.transactions_list;
 
       if (transactionsList !== undefined) {
-        const resMessage = '';
-        const aligningTransactionsList = transactionsList.sort(
-          (a, b) =>
-            Number(a.transaction_date.slice(8, 10)) - Number(b.transaction_date.slice(8, 10))
-        );
+        const message = '';
 
-        dispatch(fetchTransactionsActions(aligningTransactionsList, resMessage));
+        dispatch(fetchTransactionsActions(transactionsList, message));
       } else {
         const emptyTransactionsList: TransactionsList = [];
 

--- a/src/reducks/transactions/types.ts
+++ b/src/reducks/transactions/types.ts
@@ -7,8 +7,11 @@ export interface FetchTransactions {
   shop: string | null;
   memo: string | null;
   amount: number;
+  big_category_id: number;
   big_category_name: string;
+  medium_category_id: number;
   medium_category_name: string | null;
+  custom_category_id: number;
   custom_category_name: string | null;
 }
 
@@ -41,8 +44,11 @@ export interface TransactionsRes {
   shop: string | null;
   memo: string | null;
   amount: number;
+  big_category_id: number;
   big_category_name: string;
+  medium_category_id: number;
   medium_category_name: string | null;
+  custom_category_id: number;
   custom_category_name: string | null;
 }
 

--- a/test/group-transactions-test/addResponse.json
+++ b/test/group-transactions-test/addResponse.json
@@ -10,7 +10,10 @@
   "posted_user_id":"taira",
   "updated_user_id":null,
   "payment_user_id":"taira",
+  "big_category_nid": 3,
   "big_category_name":"日用品",
+  "medium_category_id": 17,
   "medium_category_name":"家電",
+  "custom_category_id": null,
   "custom_category_name":null
 }

--- a/test/group-transactions-test/addedGroupLatestTransactions.json
+++ b/test/group-transactions-test/addedGroupLatestTransactions.json
@@ -2,19 +2,22 @@
   "transactions_list": [
     {
       "id": 101,
-      "transaction_type": "expense",
-      "posted_date": "2020-11-12T23:54:59Z",
-      "updated_date": "2020-11-12T23:54:59Z",
-      "transaction_date": "2020/11/17(火)",
-      "shop": "ビッグカメラ",
-      "memo": "コーヒーメーカー",
-      "amount": 20000,
-      "posted_user_id": "taira",
-      "updated_user_id": null,
-      "payment_user_id": "taira",
-      "big_category_name": "日用品",
-      "medium_category_name": "家電",
-      "custom_category_name": null
+      "transaction_type":"expense",
+      "posted_date":"2020-11-12T23:54:59Z",
+      "updated_date":"2020-11-12T23:54:59Z",
+      "transaction_date":"2020/11/17(火)",
+      "shop":"ビッグカメラ",
+      "memo":"コーヒーメーカー",
+      "amount":20000,
+      "posted_user_id":"taira",
+      "updated_user_id":null,
+      "payment_user_id":"taira",
+      "big_category_nid": 3,
+      "big_category_name":"日用品",
+      "medium_category_id": 17,
+      "medium_category_name":"家電",
+      "custom_category_id": null,
+      "custom_category_name":null
     },
     {
       "id": 99,
@@ -28,9 +31,12 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 6,
+      "medium_category_name": "食料品",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
       "id": 98,
@@ -44,8 +50,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 10,
       "medium_category_name": "外食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -60,8 +69,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -76,8 +88,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -92,8 +107,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -108,8 +126,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -124,8 +145,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -140,8 +164,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -156,8 +183,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/group-transactions-test/addedGroupTransactions.json
+++ b/test/group-transactions-test/addedGroupTransactions.json
@@ -12,8 +12,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -28,8 +31,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -44,8 +50,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -60,8 +69,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -76,8 +88,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -92,8 +107,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -108,8 +126,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -124,8 +145,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -140,8 +164,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 10,
       "medium_category_name": "外食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -156,25 +183,31 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 6,
+      "medium_category_name": "食料品",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
       "id": 101,
-      "transaction_type": "expense",
-      "posted_date": "2020-11-12T23:54:59Z",
-      "updated_date": "2020-11-12T23:54:59Z",
-      "transaction_date": "2020/11/17(火)",
-      "shop": "ビッグカメラ",
-      "memo": "コーヒーメーカー",
-      "amount": 20000,
-      "posted_user_id": "taira",
-      "updated_user_id": null,
-      "payment_user_id": "taira",
-      "big_category_name": "日用品",
-      "medium_category_name": "家電",
-      "custom_category_name": null
+      "transaction_type":"expense",
+      "posted_date":"2020-11-12T23:54:59Z",
+      "updated_date":"2020-11-12T23:54:59Z",
+      "transaction_date":"2020/11/17(火)",
+      "shop":"ビッグカメラ",
+      "memo":"コーヒーメーカー",
+      "amount":20000,
+      "posted_user_id":"taira",
+      "updated_user_id":null,
+      "payment_user_id":"taira",
+      "big_category_nid": 3,
+      "big_category_name":"日用品",
+      "medium_category_id": 17,
+      "medium_category_name":"家電",
+      "custom_category_id": null,
+      "custom_category_name":null
     }
   ]
 }

--- a/test/group-transactions-test/deletedGroupLatestTransactions.json
+++ b/test/group-transactions-test/deletedGroupLatestTransactions.json
@@ -12,9 +12,12 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 6,
+      "medium_category_name": "食料品",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
       "id": 98,
@@ -28,8 +31,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 10,
       "medium_category_name": "外食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -44,8 +50,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -60,8 +69,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -76,8 +88,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -92,8 +107,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -108,8 +126,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -124,8 +145,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -140,8 +164,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/group-transactions-test/editResponse.json
+++ b/test/group-transactions-test/editResponse.json
@@ -10,7 +10,10 @@
   "posted_user_id":"taira",
   "updated_user_id":"taira",
   "payment_user_id":"taira",
+  "big_category_id": 3,
   "big_category_name":"日用品",
+  "medium_category_id" : 16,
   "medium_category_name":"家具",
+  "custom_category_id" : null,
   "custom_category_name":null
 }

--- a/test/group-transactions-test/editedGroupLatestTransactions.json
+++ b/test/group-transactions-test/editedGroupLatestTransactions.json
@@ -1,20 +1,23 @@
 {
   "transactions_list": [
     {
-      "id": 101,
-      "transaction_type": "expense",
-      "posted_date": "2020-11-12T23:54:59Z",
-      "updated_date": "2020-11-12T23:59:00Z",
-      "transaction_date": "2020/11/16(月)",
-      "shop": "ニトリ",
-      "memo": "テーブル",
-      "amount": 8000,
-      "posted_user_id": "taira",
-      "updated_user_id": "taira",
-      "payment_user_id": "taira",
-      "big_category_name": "日用品",
-      "medium_category_name": "家具",
-      "custom_category_name": null
+      "id":101,
+      "transaction_type":"expense",
+      "posted_date":"2020-11-12T23:54:59Z",
+      "updated_date":"2020-11-12T23:59:00Z",
+      "transaction_date":"2020/11/16(月)",
+      "shop":"ニトリ",
+      "memo":"テーブル",
+      "amount":8000,
+      "posted_user_id":"taira",
+      "updated_user_id":"taira",
+      "payment_user_id":"taira",
+      "big_category_id": 3,
+      "big_category_name":"日用品",
+      "medium_category_id" : 16,
+      "medium_category_name":"家具",
+      "custom_category_id" : null,
+      "custom_category_name":null
     },
     {
       "id": 99,
@@ -28,9 +31,12 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 6,
+      "medium_category_name": "食料品",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
       "id": 98,
@@ -44,8 +50,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 10,
       "medium_category_name": "外食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -60,8 +69,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -76,8 +88,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -92,8 +107,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -108,8 +126,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -124,8 +145,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -140,8 +164,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -156,8 +183,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/group-transactions-test/editedGroupTransactions.json
+++ b/test/group-transactions-test/editedGroupTransactions.json
@@ -12,8 +12,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -28,8 +31,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -44,8 +50,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -60,8 +69,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -76,8 +88,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -92,8 +107,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -108,8 +126,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -124,8 +145,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -140,8 +164,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 10,
       "medium_category_name": "外食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -156,25 +183,31 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 6,
+      "medium_category_name": "食料品",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
-      "id": 101,
-      "transaction_type": "expense",
-      "posted_date": "2020-11-12T23:54:59Z",
-      "updated_date": "2020-11-12T23:59:00Z",
-      "transaction_date": "2020/11/16(月)",
-      "shop": "ニトリ",
-      "memo": "テーブル",
-      "amount": 8000,
-      "posted_user_id": "taira",
-      "updated_user_id": "taira",
-      "payment_user_id": "taira",
-      "big_category_name": "日用品",
-      "medium_category_name": "家具",
-      "custom_category_name": null
+      "id":101,
+      "transaction_type":"expense",
+      "posted_date":"2020-11-12T23:54:59Z",
+      "updated_date":"2020-11-12T23:59:00Z",
+      "transaction_date":"2020/11/16(月)",
+      "shop":"ニトリ",
+      "memo":"テーブル",
+      "amount":8000,
+      "posted_user_id":"taira",
+      "updated_user_id":"taira",
+      "payment_user_id":"taira",
+      "big_category_id": 3,
+      "big_category_name":"日用品",
+      "medium_category_id" : 16,
+      "medium_category_name":"家具",
+      "custom_category_id" : null,
+      "custom_category_name":null
     }
   ]
 }

--- a/test/group-transactions-test/fetchSearchGroupTransactionsResponse.json
+++ b/test/group-transactions-test/fetchSearchGroupTransactionsResponse.json
@@ -12,8 +12,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 9,
       "medium_category_name": "夕食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -28,8 +31,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "tati1",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -44,8 +50,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 8,
       "medium_category_name": "昼食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -60,8 +69,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/group-transactions-test/groupLatestTransactions.json
+++ b/test/group-transactions-test/groupLatestTransactions.json
@@ -12,9 +12,12 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 6,
+      "medium_category_name": "食料品",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
       "id": 98,
@@ -28,8 +31,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 10,
       "medium_category_name": "外食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -44,8 +50,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -60,8 +69,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -76,8 +88,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -92,8 +107,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -108,8 +126,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -124,8 +145,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -140,8 +164,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -156,8 +183,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/group-transactions-test/groupTransactions.json
+++ b/test/group-transactions-test/groupTransactions.json
@@ -12,8 +12,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -28,8 +31,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -44,8 +50,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -60,8 +69,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -76,8 +88,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -92,8 +107,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -108,8 +126,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -124,8 +145,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -140,8 +164,11 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 10,
       "medium_category_name": "外食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -156,9 +183,12 @@
       "posted_user_id": "taira",
       "updated_user_id": null,
       "payment_user_id": "taira",
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 6,
+      "medium_category_name": "食料品",
+      "custom_category_id": null,
+      "custom_category_name": null
     }
   ]
 }

--- a/test/transactions-test/addLatestTransactions.json
+++ b/test/transactions-test/addLatestTransactions.json
@@ -9,8 +9,11 @@
       "shop": "ニトリ",
       "memo": "椅子",
       "amount": 9000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 16,
       "medium_category_name": "家具",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -22,8 +25,11 @@
       "shop": null,
       "memo": "タバコ",
       "amount": 570,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -32,12 +38,15 @@
       "posted_date": "2020-11-07T16:55:56Z",
       "updated_date": "2020-11-07T16:55:56Z",
       "transaction_date": "2020/11/07(土)",
-      "shop": null,
-      "memo": "味ぽん",
+      "shop": "スタバ",
+      "memo": null,
       "amount": 500,
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 11,
+      "medium_category_name": "カフェ",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
       "id": 125,
@@ -48,8 +57,11 @@
       "shop": null,
       "memo": "シャンプー",
       "amount": 1000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -61,8 +73,11 @@
       "shop": "ビッグカメラ",
       "memo": "炊飯器",
       "amount": 20000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 17,
       "medium_category_name": "家電",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -74,8 +89,11 @@
       "shop": "Nike",
       "memo": "ウェア",
       "amount": 3000,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -87,8 +105,11 @@
       "shop": "ドトール",
       "memo": "モーニングセット",
       "amount": 300,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 7,
       "medium_category_name": "朝食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -101,7 +122,10 @@
       "memo": "南林間",
       "amount": 2000,
       "big_category_name": "交通費",
+      "big_category_id": 6,
+      "medium_category_id": 33,
       "medium_category_name": "電車",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -113,8 +137,11 @@
       "shop": "王将",
       "memo": "炒飯・餃子",
       "amount": 800,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 8,
       "medium_category_name": "昼食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -126,8 +153,11 @@
       "shop": "座間イオン",
       "memo": "鬼滅の刃",
       "amount": 1300,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 23,
       "medium_category_name": "映画・動画",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/transactions-test/addResponse.json
+++ b/test/transactions-test/addResponse.json
@@ -7,7 +7,10 @@
   "shop": "ニトリ",
   "memo": "椅子",
   "amount": 9000,
+  "big_category_id": 3,
   "big_category_name": "日用品",
+  "medium_category_id": 16,
   "medium_category_name": "家具",
+  "custom_category_id": null,
   "custom_category_name": null
 }

--- a/test/transactions-test/addTransactions.json
+++ b/test/transactions-test/addTransactions.json
@@ -9,8 +9,11 @@
       "shop": "座間イオン",
       "memo": "鬼滅の刃",
       "amount": 1300,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 23,
       "medium_category_name": "映画・動画",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -22,8 +25,11 @@
       "shop": "王将",
       "memo": "炒飯・餃子",
       "amount": 800,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 8,
       "medium_category_name": "昼食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -35,8 +41,11 @@
       "shop": "ドトール",
       "memo": "モーニングセット",
       "amount": 300,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 7,
       "medium_category_name": "朝食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -48,8 +57,11 @@
       "shop": null,
       "memo": "南林間",
       "amount": 2000,
+      "big_category_id": 6,
       "big_category_name": "交通費",
+      "medium_category_id": 33,
       "medium_category_name": "電車",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -61,8 +73,11 @@
       "shop": "ニトリ",
       "memo": "椅子",
       "amount": 9000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 16,
       "medium_category_name": "家具",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -74,8 +89,11 @@
       "shop": "Nike",
       "memo": "ウェア",
       "amount": 3000,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -87,8 +105,11 @@
       "shop": "ビッグカメラ",
       "memo": "炊飯器",
       "amount": 20000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 17,
       "medium_category_name": "家電",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -100,8 +121,11 @@
       "shop": null,
       "memo": "シャンプー",
       "amount": 1000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -113,8 +137,11 @@
       "shop": null,
       "memo": "タバコ",
       "amount": 570,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -123,12 +150,15 @@
       "posted_date": "2020-11-07T16:55:56Z",
       "updated_date": "2020-11-07T16:55:56Z",
       "transaction_date": "2020/11/07(土)",
-      "shop": null,
-      "memo": "味ぽん",
+      "shop": "スタバ",
+      "memo": null,
       "amount": 500,
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id":11,
+      "medium_category_name": "カフェ",
+      "custom_category_id": null,
+      "custom_category_name": null
     }
   ]
 }

--- a/test/transactions-test/deleteLatestTransactions.json
+++ b/test/transactions-test/deleteLatestTransactions.json
@@ -9,8 +9,11 @@
       "shop": null,
       "memo": "タバコ",
       "amount": 570,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -19,12 +22,15 @@
       "posted_date": "2020-11-07T16:55:56Z",
       "updated_date": "2020-11-07T16:55:56Z",
       "transaction_date": "2020/11/07(土)",
-      "shop": null,
-      "memo": "味ぽん",
+      "shop": "スタバ",
+      "memo": null,
       "amount": 500,
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 11,
+      "medium_category_name": "カフェ",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
       "id": 125,
@@ -35,8 +41,11 @@
       "shop": null,
       "memo": "シャンプー",
       "amount": 1000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -48,8 +57,11 @@
       "shop": "ビッグカメラ",
       "memo": "炊飯器",
       "amount": 20000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 17,
       "medium_category_name": "家電",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -61,8 +73,11 @@
       "shop": "Nike",
       "memo": "ウェア",
       "amount": 3000,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -74,8 +89,11 @@
       "shop": "ドトール",
       "memo": "モーニングセット",
       "amount": 300,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 7,
       "medium_category_name": "朝食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -87,8 +105,11 @@
       "shop": null,
       "memo": "南林間",
       "amount": 2000,
+      "big_category_id": 6,
       "big_category_name": "交通費",
+      "medium_category_id": 33,
       "medium_category_name": "電車",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -100,8 +121,11 @@
       "shop": "王将",
       "memo": "炒飯・餃子",
       "amount": 800,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 8,
       "medium_category_name": "昼食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -113,8 +137,11 @@
       "shop": "座間イオン",
       "memo": "鬼滅の刃",
       "amount": 1300,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id":23,
       "medium_category_name": "映画・動画",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/transactions-test/editLatestTransactions.json
+++ b/test/transactions-test/editLatestTransactions.json
@@ -9,8 +9,11 @@
       "shop": "ビッグカメラ",
       "memo": "コーヒーメーカー",
       "amount": 25000,
+      "big_category_id":3,
       "big_category_name": "日用品",
+      "medium_category_id": 17,
       "medium_category_name": "家電",
+      "custom_category_id" : null,
       "custom_category_name": null
     },
     {
@@ -22,8 +25,11 @@
       "shop": null,
       "memo": "タバコ",
       "amount": 570,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -32,12 +38,15 @@
       "posted_date": "2020-11-07T16:55:56Z",
       "updated_date": "2020-11-07T16:55:56Z",
       "transaction_date": "2020/11/07(土)",
-      "shop": null,
-      "memo": "味ぽん",
+      "shop": "スタバ",
+      "memo": null,
       "amount": 500,
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id": 11,
+      "medium_category_name": "カフェ",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
       "id": 125,
@@ -48,8 +57,11 @@
       "shop": null,
       "memo": "シャンプー",
       "amount": 1000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -61,8 +73,11 @@
       "shop": "ビッグカメラ",
       "memo": "炊飯器",
       "amount": 20000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 17,
       "medium_category_name": "家電",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -74,8 +89,11 @@
       "shop": "Nike",
       "memo": "ウェア",
       "amount": 3000,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -87,8 +105,11 @@
       "shop": "ドトール",
       "memo": "モーニングセット",
       "amount": 300,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 7,
       "medium_category_name": "朝食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -100,8 +121,11 @@
       "shop": null,
       "memo": "南林間",
       "amount": 2000,
+      "big_category_id": 6,
       "big_category_name": "交通費",
+      "medium_category_id": 33,
       "medium_category_name": "電車",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -113,8 +137,11 @@
       "shop": "王将",
       "memo": "炒飯・餃子",
       "amount": 800,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 8,
       "medium_category_name": "昼食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -126,8 +153,11 @@
       "shop": "座間イオン",
       "memo": "鬼滅の刃",
       "amount": 1300,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 23,
       "medium_category_name": "映画・動画",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/transactions-test/editResponse.json
+++ b/test/transactions-test/editResponse.json
@@ -7,7 +7,10 @@
   "shop": "ビッグカメラ",
   "memo": "コーヒーメーカー",
   "amount": 25000,
+  "big_category_id":3,
   "big_category_name": "日用品",
+  "medium_category_id": 17,
   "medium_category_name": "家電",
+  "custom_category_id" : null,
   "custom_category_name": null
 }

--- a/test/transactions-test/editTransactions.json
+++ b/test/transactions-test/editTransactions.json
@@ -9,8 +9,11 @@
       "shop": "座間イオン",
       "memo": "鬼滅の刃",
       "amount": 1300,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 23,
       "medium_category_name": "映画・動画",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -22,8 +25,11 @@
       "shop": "王将",
       "memo": "炒飯・餃子",
       "amount": 800,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 8,
       "medium_category_name": "昼食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -35,8 +41,11 @@
       "shop": "ドトール",
       "memo": "モーニングセット",
       "amount": 300,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 7,
       "medium_category_name": "朝食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -48,8 +57,11 @@
       "shop": null,
       "memo": "南林間",
       "amount": 2000,
+      "big_category_id": 6,
       "big_category_name": "交通費",
+      "medium_category_id": 33,
       "medium_category_name": "電車",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -61,8 +73,11 @@
       "shop": "ビッグカメラ",
       "memo": "コーヒーメーカー",
       "amount": 25000,
+      "big_category_id":3,
       "big_category_name": "日用品",
+      "medium_category_id": 17,
       "medium_category_name": "家電",
+      "custom_category_id" : null,
       "custom_category_name": null
     },
     {
@@ -74,8 +89,11 @@
       "shop": "Nike",
       "memo": "ウェア",
       "amount": 3000,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -87,8 +105,11 @@
       "shop": "ビッグカメラ",
       "memo": "炊飯器",
       "amount": 20000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 17,
       "medium_category_name": "家電",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -100,8 +121,11 @@
       "shop": null,
       "memo": "シャンプー",
       "amount": 1000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -113,8 +137,11 @@
       "shop": null,
       "memo": "タバコ",
       "amount": 570,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -123,12 +150,15 @@
       "posted_date": "2020-11-07T16:55:56Z",
       "updated_date": "2020-11-07T16:55:56Z",
       "transaction_date": "2020/11/07(土)",
-      "shop": null,
-      "memo": "味ぽん",
+      "shop": "スタバ",
+      "memo": null,
       "amount": 500,
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id":11,
+      "medium_category_name": "カフェ",
+      "custom_category_id": null,
+      "custom_category_name": null
     }
   ]
 }

--- a/test/transactions-test/fetchSearchTransactionsRes.json
+++ b/test/transactions-test/fetchSearchTransactionsRes.json
@@ -9,8 +9,11 @@
       "shop": "コストコ",
       "memo": "牛肉ブロック購入",
       "amount": 5000,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -22,8 +25,11 @@
       "shop": null,
       "memo": null,
       "amount": 3000,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 8,
       "medium_category_name": "昼食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -35,8 +41,11 @@
       "shop": "ビッグヨーサン",
       "memo": "鍋食材",
       "amount": 3000,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -48,8 +57,11 @@
       "shop": "コストコ",
       "memo": "セールで牛肉購入",
       "amount": 4500,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 6,
       "medium_category_name": "食料品",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/transactions-test/latestTransactions.json
+++ b/test/transactions-test/latestTransactions.json
@@ -9,8 +9,11 @@
       "shop": null,
       "memo": "タバコ",
       "amount": 570,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -19,12 +22,15 @@
       "posted_date": "2020-11-07T16:55:56Z",
       "updated_date": "2020-11-07T16:55:56Z",
       "transaction_date": "2020/11/07(土)",
-      "shop": null,
-      "memo": "味ぽん",
+      "shop": "スタバ",
+      "memo": null,
       "amount": 500,
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id":11,
+      "medium_category_name": "カフェ",
+      "custom_category_id": null,
+      "custom_category_name": null
     },
     {
       "id": 125,
@@ -35,8 +41,11 @@
       "shop": null,
       "memo": "シャンプー",
       "amount": 1000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -48,8 +57,11 @@
       "shop": "ビッグカメラ",
       "memo": "炊飯器",
       "amount": 20000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 17,
       "medium_category_name": "家電",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -61,8 +73,11 @@
       "shop": "Nike",
       "memo": "ウェア",
       "amount": 3000,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -74,8 +89,11 @@
       "shop": "ドトール",
       "memo": "モーニングセット",
       "amount": 300,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 7,
       "medium_category_name": "朝食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -87,8 +105,11 @@
       "shop": null,
       "memo": "南林間",
       "amount": 2000,
+      "big_category_id": 6,
       "big_category_name": "交通費",
+      "medium_category_id": 33,
       "medium_category_name": "電車",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -100,8 +121,11 @@
       "shop": "王将",
       "memo": "炒飯・餃子",
       "amount": 800,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 8,
       "medium_category_name": "昼食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -113,8 +137,11 @@
       "shop": "座間イオン",
       "memo": "鬼滅の刃",
       "amount": 1300,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 23,
       "medium_category_name": "映画・動画",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -126,8 +153,11 @@
       "shop": "MIDWEST",
       "memo": "Rafニット",
       "amount": 100000,
+      "big_category_id": 7,
       "big_category_name": "衣服・美容",
+      "medium_category_id":39,
       "medium_category_name": "衣服",
+      "custom_category_id": null,
       "custom_category_name": null
     }
   ]

--- a/test/transactions-test/transactions.json
+++ b/test/transactions-test/transactions.json
@@ -9,8 +9,11 @@
       "shop": "座間イオン",
       "memo": "鬼滅の刃",
       "amount": 1300,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id":23,
       "medium_category_name": "映画・動画",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -22,8 +25,11 @@
       "shop": "王将",
       "memo": "炒飯・餃子",
       "amount": 800,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 8,
       "medium_category_name": "昼食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -35,8 +41,11 @@
       "shop": "ドトール",
       "memo": "モーニングセット",
       "amount": 300,
+      "big_category_id": 2,
       "big_category_name": "食費",
+      "medium_category_id": 7,
       "medium_category_name": "朝食",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -48,8 +57,11 @@
       "shop": null,
       "memo": "南林間",
       "amount": 2000,
+      "big_category_id": 6,
       "big_category_name": "交通費",
+      "medium_category_id": 33,
       "medium_category_name": "電車",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -61,8 +73,11 @@
       "shop": "Nike",
       "memo": "ウェア",
       "amount": 3000,
+      "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
+      "medium_category_id": 22,
       "medium_category_name": "スポーツ",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -74,8 +89,11 @@
       "shop": "ビッグカメラ",
       "memo": "炊飯器",
       "amount": 20000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 17,
       "medium_category_name": "家電",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -87,8 +105,11 @@
       "shop": null,
       "memo": "シャンプー",
       "amount": 1000,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -100,8 +121,11 @@
       "shop": null,
       "memo": "タバコ",
       "amount": 570,
+      "big_category_id": 3,
       "big_category_name": "日用品",
+      "medium_category_id": 13,
       "medium_category_name": "消耗品",
+      "custom_category_id": null,
       "custom_category_name": null
     },
     {
@@ -110,12 +134,15 @@
       "posted_date": "2020-11-07T16:55:56Z",
       "updated_date": "2020-11-07T16:55:56Z",
       "transaction_date": "2020/11/07(土)",
-      "shop": null,
-      "memo": "味ぽん",
+      "shop": "スタバ",
+      "memo": null,
       "amount": 500,
+      "big_category_id": 2,
       "big_category_name": "食費",
-      "medium_category_name": null,
-      "custom_category_name": "調味料"
+      "medium_category_id":11,
+      "medium_category_name": "カフェ",
+      "custom_category_id": null,
+      "custom_category_name": null
     }
   ]
 }


### PR DESCRIPTION
- transactionsListを取得する`fetchTransactionsList, fetchGroupTransactionsList`でtransaction_dateの昇順になるようにsort処理を
  行っていましたがsortされた状態でレスポンスを受け取る形に変更したので`fetchTransactionsList, fetchGroupTransactionsList`の
  sort処理を削除しました。

- transactionsList, groupTransactionsListを取得する際に`big_category_id, medium_category_id, custom_category_id`を受け取る形に
  修正しました。

- `EditTransactionModal`でcategoryIdの初期値をセットする際にcategoryName, transactionTypeから条件分岐で求めていましたが、
   transactionsList, groupTransactionsListに追加したcategory_idをpropsで受け取りセットする形に修正しました。

- categoryIdの追加に伴って、`transactions / test,  groupTransactions / test`にcategoryIdを追加しました。

確認よろしくお願いします。