### PR TITLE
Add last month expenses to budgets and groupBudgets

### DIFF
--- a/src/assets/history/monthly-history.scss
+++ b/src/assets/history/monthly-history.scss
@@ -9,14 +9,14 @@
   width: 100%;
 
   &__spacer {
+    display: block;
+    width: 100%;
 
     &__big{
-      margin-top: 50px;
+      height: 50px;
     }
 
     &__small {
-      display: block;
-      width: 100%;
       height: 14px
     }
   }
@@ -36,7 +36,7 @@
 
   &__thead {
     border: solid 1px $border_color;
-    background-color: #f5f5f5;
+    background-color: $main_background_color;
     display: table-row;
     font-weight: 400;
     height:60px;

--- a/src/assets/variable.scss
+++ b/src/assets/variable.scss
@@ -1,5 +1,6 @@
 $border_color: #e1e3e3;
 $main_color: #ff6600;
+$main_background_color: #f5f5f5;
 $small-font-size:12px;
 $middle-font-size:14px;
 $medium-font_size:16px;

--- a/src/assets/variable.scss
+++ b/src/assets/variable.scss
@@ -1,5 +1,5 @@
 $border_color: #e1e3e3;
-$main_color: #4db5fa;
+$main_color: #ff6600;
 $small-font-size:12px;
 $middle-font-size:14px;
 $medium-font_size:16px;

--- a/src/components/budget/EditGroupStandardBudgets.tsx
+++ b/src/components/budget/EditGroupStandardBudgets.tsx
@@ -115,7 +115,7 @@ const EditGroupStandardBudgets = () => {
                   groupInMonth,
                   Number(id),
                   groupCustomBudgets.map((groupCustomBudget) => {
-                    let { big_category_name, last_month_expenses, ...rest } = groupCustomBudget; // eslint-disable-line
+                    const { big_category_name, last_month_expenses, ...rest } = groupCustomBudget; // eslint-disable-line
                     return {
                       big_category_id: rest.big_category_id,
                       budget: Number(rest.budget),

--- a/src/components/budget/EditGroupStandardBudgets.tsx
+++ b/src/components/budget/EditGroupStandardBudgets.tsx
@@ -5,82 +5,34 @@ import {
   addGroupCustomBudgets,
   copyGroupStandardBudgets,
 } from '../../reducks/groupBudgets/operations';
-import { State } from '../../reducks/store/types';
 import { GroupCustomBudgetsList } from '../../reducks/groupBudgets/types';
-import { getGroupCustomBudgets } from '../../reducks/groupBudgets/selectors';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-import TableRow from '@material-ui/core/TableRow';
-import TableCell from '@material-ui/core/TableCell';
+import {
+  getGroupCustomBudgets,
+  getGroupTotalStandardBudget,
+} from '../../reducks/groupBudgets/selectors';
 import TextField from '@material-ui/core/TextField';
 import { push } from 'connected-react-router';
-import TableContainer from '@material-ui/core/TableContainer';
-import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
-import TableHead from '@material-ui/core/TableHead';
-import TableBody from '@material-ui/core/TableBody';
 import GenericButton from '../uikit/GenericButton';
-import { getPathGroupId, getGroupPathYear, getGroupPathMonth } from '../../lib/path';
+import { getGroupPathYear, getGroupPathMonth } from '../../lib/path';
 import { fetchGroups } from '../../reducks/groups/operations';
 import axios, { CancelTokenSource } from 'axios';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      margin: '0 auto',
-      flexDirection: 'column',
-      alignItems: 'center',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    tablePosition: {
-      margin: '0 auto',
-      marginTop: 40,
-      alignItems: 'center',
-      tableLayout: 'fixed',
-      width: '100%',
-    },
-    tableSize: {
-      width: 250,
-      textAlign: 'center',
-    },
-    buttonSize: {
-      width: 360,
-      marginTop: 40,
-      backgroundColor: '#fff',
-      margin: '0 auto',
-    },
-    buttonGroupPosition: {
-      margin: '0 auto',
-      marginLeft: '7%',
-    },
-    updateButton: {
-      textAlign: 'center',
-    },
-    tableTop: {
-      backgroundColor: '#4db5fa',
-    },
-    tableMain: {
-      border: 'solid 1px #e1e3e3',
-    },
-  })
-);
+import { useParams } from 'react-router';
 
 const EditGroupStandardBudgets = () => {
-  const classes = useStyles();
   const dispatch = useDispatch();
-  const groupId = getPathGroupId(window.location.pathname);
+  const { id } = useParams();
   const groupInYear = getGroupPathYear(window.location.pathname);
   const groupInMonth = getGroupPathMonth(window.location.pathname);
-  const selector = useSelector((state: State) => state);
-  const groupCustomBudgetsList = getGroupCustomBudgets(selector);
+  const yearsInGroup = `${groupInYear}年${groupInMonth}月`;
+  const groupCustomBudgetsList = useSelector(getGroupCustomBudgets);
+  const groupTotalStandardBudget = useSelector(getGroupTotalStandardBudget);
   const [groupCustomBudgets, setGroupCustomBudgets] = useState<GroupCustomBudgetsList>([]);
-  const unInputBudgets = groupCustomBudgets === groupCustomBudgetsList;
+  const unAddCustomBudgets = groupCustomBudgets === groupCustomBudgetsList;
   const [editing, setEditing] = useState<boolean>(false);
 
   const fetchEditGroupStandardBudgetsData = (signal: CancelTokenSource) => {
     async function fetchGroupBudgets(signal: CancelTokenSource) {
-      await dispatch(fetchGroupStandardBudgets(groupId, signal));
+      await dispatch(fetchGroupStandardBudgets(Number(id), signal));
       dispatch(copyGroupStandardBudgets());
       dispatch(fetchGroups(signal));
     }
@@ -107,22 +59,22 @@ const EditGroupStandardBudgets = () => {
 
   return (
     <>
-      <TableContainer className={classes.tablePosition} component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell className={classes.tableTop} align="center">
-                カテゴリー
-              </TableCell>
-              <TableCell className={classes.tableTop} align="center">
-                先月の支出
-              </TableCell>
-              <TableCell className={classes.tableTop} align="center">
-                予算
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
+      <div className="budget__spacer budget__spacer--medium" />
+      <div className="budget budget__background budget__background__table">
+        <div className="budget__spacer budget__spacer--medium" />
+        <div className="budget__total-budget budget__total-budget__position">標準予算設定</div>
+        <div className="budget__total-budget budget__total-budget__space">{yearsInGroup}</div>
+        <div className="budget__total-budget budget__total-budget__space">
+          総予算 ¥ {groupTotalStandardBudget}
+        </div>
+        <div className="budget__spacer budget__spacer--medium" />
+        <table className="budget budget__background__table">
+          <tbody>
+            <tr className="budget__th">
+              <th align="center">カテゴリー</th>
+              <th align="center">先月の支出</th>
+              <th align="center">予算</th>
+            </tr>
             {groupCustomBudgets.map((groupCustomBudget, index) => {
               const onChangeBudget = (event: { target: { value: string } }) => {
                 const newBudgets = [...groupCustomBudgets];
@@ -131,51 +83,52 @@ const EditGroupStandardBudgets = () => {
                 setEditing(true);
               };
               return (
-                <TableRow key={groupCustomBudget.big_category_id}>
-                  <TableCell className={classes.tableSize} component="th" scope="row">
+                <tr key={groupCustomBudget.big_category_id}>
+                  <td className="budget__td" scope="row">
                     {groupCustomBudget.big_category_name}
-                  </TableCell>
-                  <TableCell className={classes.tableSize}>￥10,000</TableCell>
-                  <TableCell className={classes.tableSize} align="center">
+                  </td>
+                  <td className="budget__td">￥ {groupCustomBudget.last_month_expenses}</td>
+                  <td className="budget__td" align="center">
                     <TextField
                       size={'small'}
-                      id={'groupBudgets'}
+                      id={'budgets'}
                       variant="outlined"
                       type={'number'}
                       value={groupCustomBudget.budget}
                       onChange={onChangeBudget}
                     />
-                  </TableCell>
-                </TableRow>
+                  </td>
+                </tr>
               );
             })}
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <div className={classes.updateButton}>
-        <GenericButton
-          label={'更新する'}
-          disabled={unInputBudgets}
-          onClick={() => {
-            dispatch(
-              addGroupCustomBudgets(
-                groupInYear,
-                groupInMonth,
-                groupId,
-                groupCustomBudgets.map((groupCustomBudget) => {
-                  let { big_category_name, ...rest } = groupCustomBudget; // eslint-disable-line
-                  rest = {
-                    big_category_id: rest.big_category_id,
-                    budget: Number(rest.budget),
-                  };
-                  return rest;
-                })
-              )
-            );
-            dispatch(push(`/group/${groupId}/yearly/budgets`));
-            setEditing(false);
-          }}
-        />
+          </tbody>
+        </table>
+        <div className="budget__spacer budget__spacer--medium" />
+        <div className="budget__submit-btn">
+          <GenericButton
+            label={'更新する'}
+            disabled={unAddCustomBudgets}
+            onClick={() => {
+              dispatch(
+                addGroupCustomBudgets(
+                  groupInYear,
+                  groupInMonth,
+                  Number(id),
+                  groupCustomBudgets.map((groupCustomBudget) => {
+                    let { big_category_name, last_month_expenses, ...rest } = groupCustomBudget; // eslint-disable-line
+                    rest = {
+                      big_category_id: rest.big_category_id,
+                      budget: Number(rest.budget),
+                    };
+                    return rest;
+                  })
+                )
+              );
+              dispatch(push(`/group/${id}/yearly/budgets`));
+              setEditing(false);
+            }}
+          />
+        </div>
       </div>
     </>
   );

--- a/src/components/budget/EditGroupStandardBudgets.tsx
+++ b/src/components/budget/EditGroupStandardBudgets.tsx
@@ -76,9 +76,9 @@ const EditGroupStandardBudgets = () => {
               <th align="center">予算</th>
             </tr>
             {groupCustomBudgets.map((groupCustomBudget, index) => {
-              const onChangeBudget = (event: { target: { value: string } }) => {
-                const newBudgets = [...groupCustomBudgets];
-                newBudgets[index].budget = (event.target.value as unknown) as number;
+              const onChangeBudget = (event: React.ChangeEvent<HTMLInputElement>) => {
+                const newBudgets = groupCustomBudgets.concat();
+                newBudgets[index].budget = Number(event.target.value);
                 setGroupCustomBudgets(newBudgets);
                 setEditing(true);
               };
@@ -116,11 +116,10 @@ const EditGroupStandardBudgets = () => {
                   Number(id),
                   groupCustomBudgets.map((groupCustomBudget) => {
                     let { big_category_name, last_month_expenses, ...rest } = groupCustomBudget; // eslint-disable-line
-                    rest = {
+                    return {
                       big_category_id: rest.big_category_id,
                       budget: Number(rest.budget),
                     };
-                    return rest;
                   })
                 )
               );

--- a/src/components/budget/GroupCustomBudgets.tsx
+++ b/src/components/budget/GroupCustomBudgets.tsx
@@ -72,9 +72,9 @@ const GroupCustomBudgets = () => {
               <th align="center">予算</th>
             </tr>
             {groupCustomBudgets.map((groupCustomBudget, index) => {
-              const onChangeBudget = (event: { target: { value: string } }) => {
-                const newBudgets = [...groupCustomBudgets];
-                newBudgets[index].budget = (event.target.value as unknown) as number;
+              const onChangeBudget = (event: React.ChangeEvent<HTMLInputElement>) => {
+                const newBudgets = groupCustomBudgets.concat();
+                newBudgets[index].budget = Number(event.target.value);
                 setGroupCustomBudgets(newBudgets);
                 setEditing(true);
               };
@@ -112,11 +112,10 @@ const GroupCustomBudgets = () => {
                   Number(id),
                   groupCustomBudgets.map((groupBudget) => {
                     let { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
-                    rest = {
+                    return {
                       big_category_id: rest.big_category_id,
                       budget: Number(rest.budget),
                     };
-                    return rest;
                   })
                 )
               );

--- a/src/components/budget/GroupCustomBudgets.tsx
+++ b/src/components/budget/GroupCustomBudgets.tsx
@@ -111,7 +111,7 @@ const GroupCustomBudgets = () => {
                   groupInMonth,
                   Number(id),
                   groupCustomBudgets.map((groupBudget) => {
-                    let { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
+                    const { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
                     return {
                       big_category_id: rest.big_category_id,
                       budget: Number(rest.budget),

--- a/src/components/budget/GroupCustomBudgets.tsx
+++ b/src/components/budget/GroupCustomBudgets.tsx
@@ -1,85 +1,38 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { push } from 'connected-react-router';
+import axios, { CancelTokenSource } from 'axios';
+import { useParams } from 'react-router';
 import {
   fetchGroupCustomBudgets,
   editGroupCustomBudgets,
 } from '../../reducks/groupBudgets/operations';
-import { getGroupCustomBudgets } from '../../reducks/groupBudgets/selectors';
+import {
+  getGroupCustomBudgets,
+  getTotalGroupCustomBudget,
+} from '../../reducks/groupBudgets/selectors';
+import { fetchGroups } from '../../reducks/groups/operations';
 import { GroupCustomBudgetsList } from '../../reducks/groupBudgets/types';
-import { State } from '../../reducks/store/types';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-import TableRow from '@material-ui/core/TableRow';
-import TableBody from '@material-ui/core/TableBody';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableCell from '@material-ui/core/TableCell';
 import TextField from '@material-ui/core/TextField';
 import GenericButton from '../uikit/GenericButton';
-import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
-import TableHead from '@material-ui/core/TableHead';
-import { getGroupPathYear, getGroupPathMonth, getPathGroupId } from '../../lib/path';
-import { fetchGroups } from '../../reducks/groups/operations';
-import axios, { CancelTokenSource } from 'axios';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      margin: '0 auto',
-      flexDirection: 'column',
-      alignItems: 'center',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    tablePosition: {
-      margin: '0 auto',
-      marginTop: 40,
-      alignItems: 'center',
-      tableLayout: 'fixed',
-      width: '100%',
-    },
-    tableSize: {
-      width: 250,
-      textAlign: 'center',
-    },
-    buttonSize: {
-      width: 360,
-      marginTop: 40,
-      backgroundColor: '#fff',
-      margin: '0 auto',
-    },
-    buttonGroupPosition: {
-      margin: '0 auto',
-      marginLeft: '7%',
-    },
-    centerPosition: {
-      textAlign: 'center',
-    },
-    tableTop: {
-      backgroundColor: '#4db5fa',
-    },
-    tableMain: {
-      border: 'solid 1px #e1e3e3',
-    },
-  })
-);
+import { getGroupPathYear, getGroupPathMonth } from '../../lib/path';
+import './budget.scss';
 
 const GroupCustomBudgets = () => {
-  const classes = useStyles();
   const dispatch = useDispatch();
+  const { id } = useParams();
   const groupInYear = getGroupPathYear(window.location.pathname);
   const groupInMonth = getGroupPathMonth(window.location.pathname);
-  const groupId = getPathGroupId(window.location.pathname);
-  const selector = useSelector((state: State) => state);
-  const groupCustomBudgetsList = getGroupCustomBudgets(selector);
+  const yearsInGroup = `${groupInYear}年${groupInMonth}月`;
+  const groupCustomBudgetsList = useSelector(getGroupCustomBudgets);
+  const groupTotalCustomBudget = useSelector(getTotalGroupCustomBudget);
   const [groupCustomBudgets, setGroupCustomBudgets] = useState<GroupCustomBudgetsList>([]);
-  const unInput = groupCustomBudgets === groupCustomBudgetsList;
   const [editing, setEditing] = useState<boolean>(false);
+  const unEditCustomBudget = groupCustomBudgets === groupCustomBudgetsList;
 
   const fetchGroupCustomBudgetsData = (signal: CancelTokenSource) => {
     dispatch(fetchGroups(signal));
-    dispatch(fetchGroupCustomBudgets(groupInYear, groupInMonth, groupId, signal));
+    dispatch(fetchGroupCustomBudgets(groupInYear, groupInMonth, Number(id), signal));
   };
 
   useEffect(() => {
@@ -102,22 +55,22 @@ const GroupCustomBudgets = () => {
 
   return (
     <>
-      <TableContainer className={classes.tablePosition} component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell className={classes.tableTop} align="center">
-                カテゴリー
-              </TableCell>
-              <TableCell className={classes.tableTop} align="center">
-                先月の支出
-              </TableCell>
-              <TableCell className={classes.tableTop} align="center">
-                予算
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
+      <div className="budget__spacer budget__spacer--medium" />
+      <div className="budget budget__background budget__background__table">
+        <div className="budget__spacer budget__spacer--medium" />
+        <div className="budget__total-budget budget__total-budget__position">標準予算設定</div>
+        <div className="budget__total-budget budget__total-budget__space">{yearsInGroup}</div>
+        <div className="budget__total-budget budget__total-budget__space">
+          総予算 ¥ {groupTotalCustomBudget}
+        </div>
+        <div className="budget__spacer budget__spacer--medium" />
+        <table className="budget budget__background__table">
+          <tbody>
+            <tr className="budget__th">
+              <th align="center">カテゴリー</th>
+              <th align="center">先月の支出</th>
+              <th align="center">予算</th>
+            </tr>
             {groupCustomBudgets.map((groupCustomBudget, index) => {
               const onChangeBudget = (event: { target: { value: string } }) => {
                 const newBudgets = [...groupCustomBudgets];
@@ -126,12 +79,12 @@ const GroupCustomBudgets = () => {
                 setEditing(true);
               };
               return (
-                <TableRow key={groupCustomBudget.big_category_id}>
-                  <TableCell className={classes.tableSize} component="th" scope="row">
+                <tr key={groupCustomBudget.big_category_id}>
+                  <td className="budget__td" scope="row">
                     {groupCustomBudget.big_category_name}
-                  </TableCell>
-                  <TableCell className={classes.tableSize}>￥10,000</TableCell>
-                  <TableCell className={classes.tableSize} align="center">
+                  </td>
+                  <td className="budget__td">￥ {groupCustomBudget.last_month_expenses}</td>
+                  <td className="budget__td" align="center">
                     <TextField
                       size={'small'}
                       id={'budgets'}
@@ -140,37 +93,38 @@ const GroupCustomBudgets = () => {
                       value={groupCustomBudget.budget}
                       onChange={onChangeBudget}
                     />
-                  </TableCell>
-                </TableRow>
+                  </td>
+                </tr>
               );
             })}
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <div className={classes.centerPosition}>
-        <GenericButton
-          label={'更新する'}
-          disabled={unInput}
-          onClick={() => {
-            dispatch(
-              editGroupCustomBudgets(
-                groupInYear,
-                groupInMonth,
-                groupId,
-                groupCustomBudgets.map((groupBudget) => {
-                  let { big_category_name, ...rest } = groupBudget; // eslint-disable-line
-                  rest = {
-                    big_category_id: rest.big_category_id,
-                    budget: Number(rest.budget),
-                  };
-                  return rest;
-                })
-              )
-            );
-            dispatch(push(`/group/${groupId}/yearly/budgets`));
-            setEditing(false);
-          }}
-        />
+          </tbody>
+        </table>
+        <div className="budget__spacer budget__spacer--medium" />
+        <div className="budget__submit-btn">
+          <GenericButton
+            label={'更新する'}
+            disabled={unEditCustomBudget}
+            onClick={() => {
+              dispatch(
+                editGroupCustomBudgets(
+                  groupInYear,
+                  groupInMonth,
+                  Number(id),
+                  groupCustomBudgets.map((groupBudget) => {
+                    let { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
+                    rest = {
+                      big_category_id: rest.big_category_id,
+                      budget: Number(rest.budget),
+                    };
+                    return rest;
+                  })
+                )
+              );
+              dispatch(push(`/group/${id}/yearly/budgets`));
+              setEditing(false);
+            }}
+          />
+        </div>
       </div>
     </>
   );

--- a/src/components/budget/GroupStandardBudgets.tsx
+++ b/src/components/budget/GroupStandardBudgets.tsx
@@ -102,7 +102,7 @@ const GroupStandardBudgets = () => {
               dispatch(
                 editGroupStandardBudgets(
                   groupStandardBudgets.map((groupBudget) => {
-                    let { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
+                    const { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
                     return {
                       big_category_id: rest.big_category_id,
                       budget: Number(rest.budget),

--- a/src/components/budget/GroupStandardBudgets.tsx
+++ b/src/components/budget/GroupStandardBudgets.tsx
@@ -1,82 +1,33 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getGroupStandardBudgets } from '../../reducks/groupBudgets/selectors';
+import { useParams } from 'react-router';
+import axios, { CancelTokenSource } from 'axios';
+import {
+  getGroupStandardBudgets,
+  getGroupTotalStandardBudget,
+} from '../../reducks/groupBudgets/selectors';
 import {
   editGroupStandardBudgets,
   fetchGroupStandardBudgets,
 } from '../../reducks/groupBudgets/operations';
+import { fetchGroups } from '../../reducks/groups/operations';
 import { GroupStandardBudgetsList } from '../../reducks/groupBudgets/types';
-import { State } from '../../reducks/store/types';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import TableBody from '@material-ui/core/TableBody';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableCell from '@material-ui/core/TableCell';
 import TextField from '@material-ui/core/TextField';
 import GenericButton from '../uikit/GenericButton';
-import { getPathGroupId } from '../../lib/path';
-import { fetchGroups } from '../../reducks/groups/operations';
-import axios, { CancelTokenSource } from 'axios';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      margin: '0 auto',
-      flexDirection: 'column',
-      alignItems: 'center',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    tablePosition: {
-      margin: '0 auto',
-      marginTop: 40,
-      alignItems: 'center',
-      tableLayout: 'fixed',
-      width: '100%',
-    },
-    tableSize: {
-      width: 250,
-      textAlign: 'center',
-    },
-    buttonSize: {
-      width: 360,
-      marginTop: 40,
-      backgroundColor: '#fff',
-      margin: '0 auto',
-    },
-    buttonGroupPosition: {
-      margin: '0 auto',
-      marginLeft: '7%',
-    },
-    centerPosition: {
-      textAlign: 'center',
-    },
-    tableTop: {
-      backgroundColor: '#4db5fa',
-    },
-    tableMain: {
-      border: 'solid 1px #e1e3e3',
-    },
-  })
-);
+import './budget.scss';
 
 const GroupStandardBudgets = () => {
-  const classes = useStyles();
   const dispatch = useDispatch();
-  const selector = useSelector((state: State) => state);
-  const groupStandardBudgetsList = getGroupStandardBudgets(selector);
+  const { id } = useParams();
+  const groupStandardBudgetsList = useSelector(getGroupStandardBudgets);
+  const groupTotalStandardBudget = useSelector(getGroupTotalStandardBudget);
   const [groupStandardBudgets, setGroupStandardBudgets] = useState<GroupStandardBudgetsList>([]);
-  const groupId = getPathGroupId(window.location.pathname);
-  const unEditBudgets = groupStandardBudgets === groupStandardBudgetsList;
   const [editing, setEditing] = useState<boolean>(false);
+  const unEditBudgets = groupStandardBudgets === groupStandardBudgetsList;
 
   const fetchGroupStandardBudgetsData = (signal: CancelTokenSource) => {
     dispatch(fetchGroups(signal));
-    dispatch(fetchGroupStandardBudgets(groupId, signal));
+    dispatch(fetchGroupStandardBudgets(Number(id), signal));
   };
 
   useEffect(() => {
@@ -99,22 +50,21 @@ const GroupStandardBudgets = () => {
 
   return (
     <>
-      <TableContainer className={classes.tablePosition} component={Paper}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell className={classes.tableTop} align="center">
-                カテゴリー
-              </TableCell>
-              <TableCell className={classes.tableTop} align="center">
-                先月の支出
-              </TableCell>
-              <TableCell className={classes.tableTop} align="center">
-                予算
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
+      <div className="budget__spacer budget__spacer--medium" />
+      <div className="budget budget__background budget__background__table">
+        <div className="budget__spacer budget__spacer--medium" />
+        <div className="budget__total-budget budget__total-budget__position">標準予算設定</div>
+        <div className="budget__total-budget budget__total-budget__space">
+          総予算 ¥ {groupTotalStandardBudget}
+        </div>
+        <div className="budget__spacer budget__spacer--medium" />
+        <table className="budget budget__background__table">
+          <tbody>
+            <tr className="budget__th">
+              <th align="center">カテゴリー</th>
+              <th align="center">先月の支出</th>
+              <th align="center">予算</th>
+            </tr>
             {groupStandardBudgets.map((groupBudget, index) => {
               const onChangeBudget = (event: { target: { value: string } }) => {
                 const newBudgets = [...groupStandardBudgets];
@@ -123,12 +73,12 @@ const GroupStandardBudgets = () => {
                 setEditing(true);
               };
               return (
-                <TableRow key={groupBudget.big_category_id}>
-                  <TableCell className={classes.tableSize} component="th" scope="row">
+                <tr key={groupBudget.big_category_id}>
+                  <td className="budget__td" scope="row">
                     {groupBudget.big_category_name}
-                  </TableCell>
-                  <TableCell className={classes.tableSize}>￥10,000</TableCell>
-                  <TableCell className={classes.tableSize} align="center">
+                  </td>
+                  <td className="budget__td">￥ {groupBudget.last_month_expenses}</td>
+                  <td className="budget__td" align="center">
                     <TextField
                       size={'small'}
                       id={'budgets'}
@@ -137,33 +87,34 @@ const GroupStandardBudgets = () => {
                       value={groupBudget.budget}
                       onChange={onChangeBudget}
                     />
-                  </TableCell>
-                </TableRow>
+                  </td>
+                </tr>
               );
             })}
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <div className={classes.centerPosition}>
-        <GenericButton
-          label={'更新する'}
-          disabled={unEditBudgets}
-          onClick={() => {
-            dispatch(
-              editGroupStandardBudgets(
-                groupStandardBudgets.map((groupBudget) => {
-                  let { big_category_name, ...rest } = groupBudget; // eslint-disable-line
-                  rest = {
-                    big_category_id: rest.big_category_id,
-                    budget: Number(rest.budget),
-                  };
-                  return rest;
-                })
-              )
-            );
-            setEditing(false);
-          }}
-        />
+          </tbody>
+        </table>
+        <div className="budget__spacer budget__spacer--medium" />
+        <div className="budget__submit-btn">
+          <GenericButton
+            label={'更新する'}
+            disabled={unEditBudgets}
+            onClick={() => {
+              dispatch(
+                editGroupStandardBudgets(
+                  groupStandardBudgets.map((groupBudget) => {
+                    let { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
+                    rest = {
+                      big_category_id: rest.big_category_id,
+                      budget: Number(rest.budget),
+                    };
+                    return rest;
+                  })
+                )
+              );
+              setEditing(false);
+            }}
+          />
+        </div>
       </div>
     </>
   );

--- a/src/components/budget/GroupStandardBudgets.tsx
+++ b/src/components/budget/GroupStandardBudgets.tsx
@@ -66,9 +66,9 @@ const GroupStandardBudgets = () => {
               <th align="center">予算</th>
             </tr>
             {groupStandardBudgets.map((groupBudget, index) => {
-              const onChangeBudget = (event: { target: { value: string } }) => {
-                const newBudgets = [...groupStandardBudgets];
-                newBudgets[index].budget = (event.target.value as unknown) as number;
+              const onChangeBudget = (event: React.ChangeEvent<HTMLInputElement>) => {
+                const newBudgets = groupStandardBudgets.concat();
+                newBudgets[index].budget = Number(event.target.value);
                 setGroupStandardBudgets(newBudgets);
                 setEditing(true);
               };
@@ -103,11 +103,10 @@ const GroupStandardBudgets = () => {
                 editGroupStandardBudgets(
                   groupStandardBudgets.map((groupBudget) => {
                     let { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
-                    rest = {
+                    return {
                       big_category_id: rest.big_category_id,
                       budget: Number(rest.budget),
                     };
-                    return rest;
                   })
                 )
               );

--- a/src/components/budget/budget.scss
+++ b/src/components/budget/budget.scss
@@ -1,0 +1,104 @@
+@import "src/assets/variable";
+
+.budget {
+  border-collapse: collapse;
+  margin: 0 auto;
+  display: table;
+
+  &__table-position{
+    align-items: center;
+    flex-direction: column;
+    margin: 0 auto;
+  }
+
+  &__background {
+    background-color: white;
+    border: 1px solid rgba(0, 0, 0, 0.3);
+    border-radius: 5px;
+    box-sizing: border-box;
+    height: auto;
+    margin: 40px auto;
+    width: 55%;
+    padding: 20px;
+
+    &__table {
+      border: 1px solid $border_color;
+      margin: 0 auto;
+    }
+
+  }
+
+  &__year-selector {
+    background-color: #fff;
+    display: flex;
+    margin: 0 auto;
+    width: 40%;
+  }
+
+  &__spacer {
+    display: block;
+    width: 100%;
+
+    &--medium {
+      height: 30px;
+    }
+
+    &__small {
+      height: 10px;
+    }
+  }
+
+  &__th {
+    align-self: center;
+    background-color: #f5f5f5;
+    border: solid 1px $border_color;
+    font-weight: $large-font_weight;
+    font-size: $medium-font_size;
+    height: 3rem;
+    width: 250px;
+  }
+
+  &__td {
+    border-collapse: collapse;
+    empty-cells: show;
+    text-align: center;
+    margin: 0 auto;
+    padding: 5px;
+    width: 250px;
+  }
+
+  &__total-budget {
+    font-size: 1.2rem;
+    font-weight: bolder;
+
+    &__space{
+      padding-left: 15px;
+    }
+
+    &__position {
+      text-align: center;
+    }
+  }
+
+  &__years-position {
+    margin-right: auto;
+  }
+
+  &__switch-btn {
+    width: 250px;
+
+
+    &--color {
+      background-color: #fff;
+    }
+  }
+
+  &__submit-btn {
+    text-align: center;
+  }
+
+  &__switching-btn {
+    margin: 0 auto;
+  }
+
+}

--- a/src/components/home/ColorExplanation.tsx
+++ b/src/components/home/ColorExplanation.tsx
@@ -7,8 +7,8 @@ interface ColorExplanationProps {
 }
 
 const ColorExplanation = (props: ColorExplanationProps) => {
-  const payerColor = (payerUserId: string): React.CSSProperties | undefined => {
-    let color = '';
+  const payerColorBox = (payerUserId: string): React.CSSProperties => {
+    let color!: string;
 
     if (props.approvedGroup !== undefined) {
       for (const groupUser of props.approvedGroup.approved_users_list) {
@@ -34,7 +34,7 @@ const ColorExplanation = (props: ColorExplanationProps) => {
                 <div key={group.user_id} className="color-explanation__payer-position">
                   <span
                     className="color-explanation__payer-color"
-                    style={payerColor(group.user_id)}
+                    style={payerColorBox(group.user_id)}
                   />
                   <span>{group.user_name}</span>
                 </div>

--- a/src/components/home/ColorExplanation.tsx
+++ b/src/components/home/ColorExplanation.tsx
@@ -8,7 +8,7 @@ interface ColorExplanationProps {
 
 const ColorExplanation = (props: ColorExplanationProps) => {
   const payerColorBox = (payerUserId?: string): React.CSSProperties => {
-    let color = '';
+    let color;
 
     if (props.approvedGroup) {
       if (props.approvedGroup.approved_users_list) {

--- a/src/components/home/ColorExplanation.tsx
+++ b/src/components/home/ColorExplanation.tsx
@@ -7,17 +7,20 @@ interface ColorExplanationProps {
 }
 
 const ColorExplanation = (props: ColorExplanationProps) => {
-  const payerColorBox = (payerUserId: string): React.CSSProperties => {
-    let color!: string;
+  const payerColorBox = (payerUserId?: string): React.CSSProperties => {
+    let color = '';
 
-    if (props.approvedGroup !== undefined) {
-      for (const groupUser of props.approvedGroup.approved_users_list) {
-        if (groupUser.user_id === payerUserId) {
-          color = groupUser.color_code;
+    if (props.approvedGroup) {
+      if (props.approvedGroup.approved_users_list) {
+        const approvedUser = props.approvedGroup.approved_users_list.find(
+          (user) => user.user_id === payerUserId
+        );
+
+        if (approvedUser) {
+          color = approvedUser.color_code;
         }
       }
     }
-
     return { backgroundColor: color, boxSizing: 'border-box' };
   };
 

--- a/src/components/home/GroupMothlyHistory.tsx
+++ b/src/components/home/GroupMothlyHistory.tsx
@@ -60,12 +60,10 @@ const GroupMonthlyHistory = (props: GroupMonthlyHistoryProps) => {
       return {
         border: 'solid 2px #E2750F',
       };
-    } else {
-      return;
     }
   };
 
-  const payerColor = (payerUserId: string): React.CSSProperties | undefined => {
+  const payerUnderLineColor = (payerUserId: string): React.CSSProperties | undefined => {
     let color = '';
 
     for (const groupUser of currentGroup.approved_users_list) {
@@ -173,7 +171,7 @@ const GroupMonthlyHistory = (props: GroupMonthlyHistoryProps) => {
                                   {medium_category_name}
                                 </span>
                                 <span
-                                  style={payerColor(payment_user_id)}
+                                  style={payerUnderLineColor(payment_user_id)}
                                   className="monthly-history-table__item-font--position monthly-history-table__item-font"
                                 >
                                   ¥ {amount.toLocaleString()}

--- a/src/components/home/GroupRecentInputBody.tsx
+++ b/src/components/home/GroupRecentInputBody.tsx
@@ -75,20 +75,20 @@ const GroupRecentInputBody = (props: RecentInputBodyProps) => {
               <span style={payerColor(payment_user_id)}>￥ {amount.toLocaleString()}</span>
             </dt>
             <dt>
-              {shop !== null ? (
+              {shop !== null && (
                 <>
                   <span className="recent-input__item-font">店名: </span>
                   {shop}
                 </>
-              ) : null}
+              )}
             </dt>
             <dt>
-              {memo !== null ? (
+              {memo !== null && (
                 <>
                   <span className="recent-input__item-font">メモ :</span>
                   {memo}
                 </>
-              ) : null}
+              )}
             </dt>
           </dl>
           <EditTransactionModal

--- a/src/components/home/RecentInputBody.tsx
+++ b/src/components/home/RecentInputBody.tsx
@@ -58,19 +58,19 @@ const RecentInputBody = (props: RecentInputBodyProps) => {
             </dt>
             <dt className="recent-input__recent-text">￥ {amount.toLocaleString()}</dt>
             <dt>
-              {shop !== null ? (
+              {shop !== null && (
                 <>
                   <span className="recent-input__item-font">店名: </span> {shop}
                 </>
-              ) : null}
+              )}
             </dt>
             <dt>
-              {memo !== null ? (
+              {memo !== null && (
                 <>
                   <span className="recent-input__item-font">メモ: </span>
                   {memo}
                 </>
-              ) : null}
+              )}
             </dt>
           </dl>
           <EditTransactionModal

--- a/src/lib/constant.ts
+++ b/src/lib/constant.ts
@@ -24,23 +24,40 @@ export const monthStatusColor = '#47a414';
 export const weekStatusColor = '#ffba16';
 export const dayStatusColor = '#f45e36';
 
+const foodExpenseColor = '#ff6600';
+const necessitiesExpenseColor = '#0088FE';
+const hobbyExpenseColor = '#029c4f';
+const entertainmentExpensesColor = '#f9d423';
+const travelingExpenseColor = '#2020f5';
+const clothingExpenseColor = '#f573b4';
+const medicalExpenseColor = '#00C49F';
+const postageExpenseColor = '#FFBEDA';
+const educationExpenseColor = '#a8e063';
+const housingExpenseColor = '#8426a6';
+const utilityExpenseColor = '#00ced1';
+const carExpenseColor = '#e9967a';
+const insuranceExpenseColor = '#5da1f5';
+const taxExpenseColor = '#ff416c';
+const cashExpenseColor = '#e8ff3d';
+const otherExpenseColor = '#bdc3c7';
+
 export const colors = [
-  '#ff6600',
-  '#0088FE',
-  '#029c4f',
-  '#f9d423',
-  '#2020f5',
-  '#f573b4',
-  '#00C49F',
-  '#FFBEDA',
-  '#a8e063',
-  '#8426a6',
-  '#00ced1',
-  '#e9967a',
-  '#5da1f5',
-  '#ff416c',
-  '#e8ff3d',
-  '#bdc3c7',
+  foodExpenseColor,
+  necessitiesExpenseColor,
+  hobbyExpenseColor,
+  entertainmentExpensesColor,
+  travelingExpenseColor,
+  clothingExpenseColor,
+  medicalExpenseColor,
+  postageExpenseColor,
+  educationExpenseColor,
+  housingExpenseColor,
+  utilityExpenseColor,
+  carExpenseColor,
+  insuranceExpenseColor,
+  taxExpenseColor,
+  cashExpenseColor,
+  otherExpenseColor,
 ];
 
 export const defaultIncomeCategoryList: AssociatedCategory[] = [

--- a/src/lib/function.ts
+++ b/src/lib/function.ts
@@ -3,65 +3,35 @@ import { colors } from './constant';
 export const bigCategoryColor = (bigCategoryName: string) => {
   if (bigCategoryName === '食費') {
     return { backgroundColor: colors[0] };
-  }
-
-  if (bigCategoryName === '日用品') {
+  } else if (bigCategoryName === '日用品') {
     return { backgroundColor: colors[1] };
-  }
-
-  if (bigCategoryName === '趣味・娯楽') {
+  } else if (bigCategoryName === '趣味・娯楽') {
     return { backgroundColor: colors[2] };
-  }
-
-  if (bigCategoryName === '交際費') {
+  } else if (bigCategoryName === '交際費') {
     return { backgroundColor: colors[3] };
-  }
-
-  if (bigCategoryName === '交通費') {
+  } else if (bigCategoryName === '交通費') {
     return { backgroundColor: colors[4] };
-  }
-
-  if (bigCategoryName === '衣服・美容') {
+  } else if (bigCategoryName === '衣服・美容') {
     return { backgroundColor: colors[5] };
-  }
-
-  if (bigCategoryName === '健康・医療') {
+  } else if (bigCategoryName === '健康・医療') {
     return { backgroundColor: colors[6] };
-  }
-
-  if (bigCategoryName === '通信費') {
+  } else if (bigCategoryName === '通信費') {
     return { backgroundColor: colors[7] };
-  }
-
-  if (bigCategoryName === '教養・教育') {
+  } else if (bigCategoryName === '教養・教育') {
     return { backgroundColor: colors[8] };
-  }
-
-  if (bigCategoryName === '住宅') {
+  } else if (bigCategoryName === '住宅') {
     return { backgroundColor: colors[9] };
-  }
-
-  if (bigCategoryName === '水道・光熱費') {
+  } else if (bigCategoryName === '水道・光熱費') {
     return { backgroundColor: colors[10] };
-  }
-
-  if (bigCategoryName === '自動車') {
+  } else if (bigCategoryName === '自動車') {
     return { backgroundColor: colors[11] };
-  }
-
-  if (bigCategoryName === '保険') {
+  } else if (bigCategoryName === '保険') {
     return { backgroundColor: colors[12] };
-  }
-
-  if (bigCategoryName === '税金・社会保険') {
+  } else if (bigCategoryName === '税金・社会保険') {
     return { backgroundColor: colors[13] };
-  }
-
-  if (bigCategoryName === '現金・カード') {
+  } else if (bigCategoryName === '現金・カード') {
     return { backgroundColor: colors[14] };
-  }
-
-  if (bigCategoryName === 'その他') {
+  } else if (bigCategoryName === 'その他') {
     return { backgroundColor: colors[15] };
   }
 };

--- a/src/reducks/budgets/selectors.ts
+++ b/src/reducks/budgets/selectors.ts
@@ -106,3 +106,30 @@ export const getCurrentMonthBudgets = createSelector(
     return currentBudgetStatusList;
   }
 );
+
+const standardBudgetsList = (state: State) => state.budgets.standard_budgets_list;
+
+export const getTotalStandardBudget = createSelector(
+  [standardBudgetsList],
+  (standardBudgetsList) => {
+    let totalStandardBudget = 0;
+
+    for (let i = 0; i < standardBudgetsList.length; i++) {
+      totalStandardBudget += standardBudgetsList[i].budget;
+    }
+
+    return totalStandardBudget;
+  }
+);
+
+const customBudgetsList = (state: State) => state.budgets.custom_budgets_list;
+
+export const getTotalCustomBudget = createSelector([customBudgetsList], (customBudgetsList) => {
+  let totalCustomBudget = 0;
+
+  for (let i = 0; i < customBudgetsList.length; i++) {
+    totalCustomBudget += customBudgetsList[i].budget;
+  }
+
+  return totalCustomBudget;
+});

--- a/src/reducks/budgets/types.ts
+++ b/src/reducks/budgets/types.ts
@@ -2,6 +2,7 @@ export interface Budget {
   big_category_id: number;
   big_category_name: string;
   budget: number;
+  last_month_expenses: number;
 }
 
 export interface MonthlyBudget {

--- a/src/reducks/groupBudgets/selectors.ts
+++ b/src/reducks/groupBudgets/selectors.ts
@@ -108,3 +108,33 @@ export const getCurrentMonthGroupBudget = createSelector(
     return currentBudgetStatusList;
   }
 );
+
+const groupStandardBudgetsList = (state: State) => state.groupBudgets.groupStandardBudgetsList;
+
+export const getGroupTotalStandardBudget = createSelector(
+  [groupStandardBudgetsList],
+  (groupStandardBudgetsList) => {
+    let totalStandardBudget = 0;
+
+    for (let i = 0; i < groupStandardBudgetsList.length; i++) {
+      totalStandardBudget += groupStandardBudgetsList[i].budget;
+    }
+
+    return totalStandardBudget;
+  }
+);
+
+const groupCustomBudgetsList = (state: State) => state.groupBudgets.groupCustomBudgetsList;
+
+export const getTotalGroupCustomBudget = createSelector(
+  [groupCustomBudgetsList],
+  (groupCustomBudgetsList) => {
+    let totalCustomBudget = 0;
+
+    for (let i = 0; i < groupCustomBudgetsList.length; i++) {
+      totalCustomBudget += groupCustomBudgetsList[i].budget;
+    }
+
+    return totalCustomBudget;
+  }
+);

--- a/src/reducks/groupBudgets/types.ts
+++ b/src/reducks/groupBudgets/types.ts
@@ -2,6 +2,7 @@ export interface GroupBudget {
   big_category_id: number;
   big_category_name: string;
   budget: number;
+  last_month_expenses: number;
 }
 
 export interface GroupMonthlyBudgets {

--- a/src/templates/CustomBudgets.tsx
+++ b/src/templates/CustomBudgets.tsx
@@ -144,7 +144,7 @@ const CustomBudgets = () => {
                         selectYear,
                         selectMonth,
                         customBudgets.map((budget) => {
-                          let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
+                          const { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
                           return {
                             big_category_id: rest.big_category_id,
                             budget: Number(rest.budget),

--- a/src/templates/CustomBudgets.tsx
+++ b/src/templates/CustomBudgets.tsx
@@ -66,7 +66,7 @@ const CustomBudgets = () => {
                 {
                   pathName !== 'group'
                     ? dispatch(push('/standard/budgets'))
-                    : dispatch(push(`/group/${Number(id)}/standard/budgets`));
+                    : dispatch(push(`/group/${id}/standard/budgets`));
                 }
               }}
             >
@@ -77,95 +77,90 @@ const CustomBudgets = () => {
               onClick={() => {
                 pathName !== 'group'
                   ? dispatch(push('/yearly/budgets'))
-                  : dispatch(push(`/group/${Number(id)}/yearly/budgets`));
+                  : dispatch(push(`/group/${id}/yearly/budgets`));
               }}
             >
               月別カスタム予算
             </Button>
           </ButtonGroup>
         </div>
-        {(() => {
-          if (pathName !== 'group') {
-            return (
-              <>
-                <div className="budget__spacer budget__spacer--medium" />
-                <div className="budget budget__background budget__background__table">
-                  <div className="budget__spacer budget__spacer--medium" />
-                  <div className="budget__total-budget budget__total-budget__position">
-                    カスタム予算編集
-                  </div>
-                  <div className="budget__total-budget budget__total-budget__space">
-                    {yearsInPersonal}
-                  </div>
-                  <div className="budget__spacer budget__spacer--medium" />
-                  <div className="budget__total-budget budget__total-budget__space">
-                    総予算 ¥ {totalCustomBudget}
-                  </div>
-                  <div className="budget__spacer budget__spacer--medium" />
-                  <table className="budget budget__background__table">
-                    <tbody>
-                      <tr className="budget__th">
-                        <th align="center">カテゴリー</th>
-                        <th align="center">先月の支出</th>
-                        <th align="center">予算</th>
+        {pathName !== 'group' ? (
+          <>
+            <div className="budget__spacer budget__spacer--medium" />
+            <div className="budget budget__background budget__background__table">
+              <div className="budget__spacer budget__spacer--medium" />
+              <div className="budget__total-budget budget__total-budget__position">
+                カスタム予算編集
+              </div>
+              <div className="budget__total-budget budget__total-budget__space">
+                {yearsInPersonal}
+              </div>
+              <div className="budget__spacer budget__spacer--medium" />
+              <div className="budget__total-budget budget__total-budget__space">
+                総予算 ¥ {totalCustomBudget}
+              </div>
+              <div className="budget__spacer budget__spacer--medium" />
+              <table className="budget budget__background__table">
+                <tbody>
+                  <tr className="budget__th">
+                    <th align="center">カテゴリー</th>
+                    <th align="center">先月の支出</th>
+                    <th align="center">予算</th>
+                  </tr>
+                  {customBudgets.map((customBudget, index) => {
+                    const onChangeBudget = (event: React.ChangeEvent<HTMLInputElement>) => {
+                      const newBudgets = customBudgets.concat();
+                      newBudgets[index].budget = Number(event.target.value);
+                      setCustomBudgets(newBudgets);
+                    };
+                    return (
+                      <tr key={customBudget.big_category_id}>
+                        <td className="budget__td" scope="row">
+                          {customBudget.big_category_name}
+                        </td>
+                        <td className="budget__td">￥ {customBudget.last_month_expenses}</td>
+                        <td className="budget__td" align="center">
+                          <TextField
+                            size={'small'}
+                            id={'budgets'}
+                            variant="outlined"
+                            type={'number'}
+                            value={customBudget.budget}
+                            onChange={onChangeBudget}
+                          />
+                        </td>
                       </tr>
-                      {customBudgets.map((customBudget, index) => {
-                        const onChangeBudget = (event: { target: { value: string } }) => {
-                          const newBudgets = [...customBudgets];
-                          newBudgets[index].budget = (event.target.value as unknown) as number;
-                          setCustomBudgets(newBudgets);
-                        };
-                        return (
-                          <tr key={customBudget.big_category_id}>
-                            <td className="budget__td" scope="row">
-                              {customBudget.big_category_name}
-                            </td>
-                            <td className="budget__td">￥ {customBudget.last_month_expenses}</td>
-                            <td className="budget__td" align="center">
-                              <TextField
-                                size={'small'}
-                                id={'budgets'}
-                                variant="outlined"
-                                type={'number'}
-                                value={customBudget.budget}
-                                onChange={onChangeBudget}
-                              />
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                  <div className="budget__submit-btn">
-                    <GenericButton
-                      label={'更新する'}
-                      disabled={unInput}
-                      onClick={() => {
-                        dispatch(
-                          editCustomBudgets(
-                            selectYear,
-                            selectMonth,
-                            customBudgets.map((budget) => {
-                              let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
-                              rest = {
-                                big_category_id: rest.big_category_id,
-                                budget: Number(rest.budget),
-                              };
-                              return rest;
-                            })
-                          )
-                        );
-                        dispatch(push('/yearly/budgets'));
-                      }}
-                    />
-                  </div>
-                </div>
-              </>
-            );
-          } else {
-            return <GroupCustomBudgets />;
-          }
-        })()}
+                    );
+                  })}
+                </tbody>
+              </table>
+              <div className="budget__submit-btn">
+                <GenericButton
+                  label={'更新する'}
+                  disabled={unInput}
+                  onClick={() => {
+                    dispatch(
+                      editCustomBudgets(
+                        selectYear,
+                        selectMonth,
+                        customBudgets.map((budget) => {
+                          let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
+                          return {
+                            big_category_id: rest.big_category_id,
+                            budget: Number(rest.budget),
+                          };
+                        })
+                      )
+                    );
+                    dispatch(push('/yearly/budgets'));
+                  }}
+                />
+              </div>
+            </div>
+          </>
+        ) : (
+          <GroupCustomBudgets />
+        )}
       </main>
     </>
   );

--- a/src/templates/CustomBudgets.tsx
+++ b/src/templates/CustomBudgets.tsx
@@ -1,91 +1,30 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router';
+import axios from 'axios';
 import { fetchCustomBudgets, editCustomBudgets } from '../reducks/budgets/operations';
-import { getCustomBudgets } from '../reducks/budgets/selectors';
+import { getCustomBudgets, getTotalCustomBudget } from '../reducks/budgets/selectors';
 import { CustomBudgetsList } from '../reducks/budgets/types';
-import { State } from '../reducks/store/types';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-import TableRow from '@material-ui/core/TableRow';
-import TableBody from '@material-ui/core/TableBody';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableCell from '@material-ui/core/TableCell';
 import TextField from '@material-ui/core/TextField';
 import GenericButton from '../components/uikit/GenericButton';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
 import Button from '@material-ui/core/Button';
 import { push } from 'connected-react-router';
-import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
-import TableHead from '@material-ui/core/TableHead';
-import {
-  getPathYear,
-  getPathMonth,
-  getPathGroupId,
-  getPathTemplateName,
-  getGroupPathYear,
-  getGroupPathMonth,
-} from '../lib/path';
-import GroupCustomBudgets from '../components/budget/GroupCustomBudgets';
+import { getPathYear, getPathMonth, getPathTemplateName } from '../lib/path';
 import { fetchGroups } from '../reducks/groups/operations';
 import { Header } from '../components/header';
-import axios from 'axios';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      margin: '0 auto',
-      flexDirection: 'column',
-      alignItems: 'center',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    tablePosition: {
-      margin: '0 auto',
-      marginTop: 40,
-      alignItems: 'center',
-      tableLayout: 'fixed',
-      width: '100%',
-    },
-    tableSize: {
-      width: 250,
-      textAlign: 'center',
-    },
-    buttonSize: {
-      width: 360,
-      marginTop: 40,
-      backgroundColor: '#fff',
-      margin: '0 auto',
-    },
-    buttonGroupPosition: {
-      margin: '0 auto',
-      marginLeft: '7%',
-    },
-    centerPosition: {
-      textAlign: 'center',
-    },
-    tableTop: {
-      backgroundColor: '#4db5fa',
-    },
-    tableMain: {
-      border: 'solid 1px #e1e3e3',
-    },
-  })
-);
+import GroupCustomBudgets from '../components/budget/GroupCustomBudgets';
+import '../components/budget/budget.scss';
 
 const CustomBudgets = () => {
-  const classes = useStyles();
   const dispatch = useDispatch();
+  const { id } = useParams();
   const selectYear = getPathYear(window.location.pathname);
   const selectMonth = getPathMonth(window.location.pathname);
-  const yearInGroup = getGroupPathYear(window.location.pathname);
-  const groupId = getPathGroupId(window.location.pathname);
-  const monthInGroup = getGroupPathMonth(window.location.pathname);
   const pathName = getPathTemplateName(window.location.pathname);
   const yearsInPersonal = `${selectYear}年${selectMonth}月`;
-  const yearsInGroup = `${yearInGroup}年${monthInGroup}月`;
-  const selector = useSelector((state: State) => state);
-  const customBudgetsList = getCustomBudgets(selector);
+  const customBudgetsList = useSelector(getCustomBudgets);
+  const totalCustomBudget = useSelector(getTotalCustomBudget);
   const [customBudgets, setCustomBudgets] = useState<CustomBudgetsList>([]);
   const unInput = customBudgets === customBudgetsList;
 
@@ -119,97 +58,95 @@ const CustomBudgets = () => {
     <>
       <Header />
       <main className="section__container">
-        <div className={classes.root}>
-          <ButtonGroup
-            className={classes.buttonGroupPosition}
-            size="large"
-            aria-label="budgets-kind"
-          >
+        <div className="budget__switching-btn">
+          <ButtonGroup className="budget__switch-btn--color" size="large" aria-label="budgets-kind">
             <Button
-              className={classes.buttonSize}
+              className="budget__switch-btn budget__switch-btn"
               onClick={() => {
-                if (pathName !== 'group') {
-                  dispatch(push('/standard/budgets'));
-                } else {
-                  dispatch(push(`/group/${groupId}/standard/budgets`));
+                {
+                  pathName !== 'group'
+                    ? dispatch(push('/standard/budgets'))
+                    : dispatch(push(`/group/${Number(id)}/standard/budgets`));
                 }
               }}
             >
               標準予算
             </Button>
             <Button
-              className={classes.buttonSize}
+              className="budget__switch-btn budget__switch-btn"
               onClick={() => {
-                if (pathName !== 'group') {
-                  dispatch(push('/yearly/budgets'));
-                } else {
-                  dispatch(push(`/group/${groupId}/yearly/budgets`));
-                }
+                pathName !== 'group'
+                  ? dispatch(push('/yearly/budgets'))
+                  : dispatch(push(`/group/${Number(id)}/yearly/budgets`));
               }}
             >
               月別カスタム予算
             </Button>
           </ButtonGroup>
-          <h2>{pathName !== 'group' ? yearsInPersonal : yearsInGroup}</h2>
-          {(() => {
-            if (pathName !== 'group') {
-              return (
-                <>
-                  <TableContainer className={classes.tablePosition} component={Paper}>
-                    <Table>
-                      <TableHead>
-                        <TableRow>
-                          <TableCell className={classes.tableTop} align="center">
-                            カテゴリー
-                          </TableCell>
-                          <TableCell className={classes.tableTop} align="center">
-                            先月の支出
-                          </TableCell>
-                          <TableCell className={classes.tableTop} align="center">
-                            予算
-                          </TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {customBudgets.map((customBudget, index) => {
-                          const onChangeBudget = (event: { target: { value: string } }) => {
-                            const newBudgets = [...customBudgets];
-                            newBudgets[index].budget = (event.target.value as unknown) as number;
-                            setCustomBudgets(newBudgets);
-                          };
-                          return (
-                            <TableRow key={customBudget.big_category_id}>
-                              <TableCell className={classes.tableSize} component="th" scope="row">
-                                {customBudget.big_category_name}
-                              </TableCell>
-                              <TableCell className={classes.tableSize}>￥10,000</TableCell>
-                              <TableCell className={classes.tableSize} align="center">
-                                <TextField
-                                  size={'small'}
-                                  id={'budgets'}
-                                  variant="outlined"
-                                  type={'number'}
-                                  value={customBudget.budget}
-                                  onChange={onChangeBudget}
-                                />
-                              </TableCell>
-                            </TableRow>
-                          );
-                        })}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                  <div className={classes.centerPosition}>
+        </div>
+        {(() => {
+          if (pathName !== 'group') {
+            return (
+              <>
+                <div className="budget__spacer budget__spacer--medium" />
+                <div className="budget budget__background budget__background__table">
+                  <div className="budget__spacer budget__spacer--medium" />
+                  <div className="budget__total-budget budget__total-budget__position">
+                    カスタム予算編集
+                  </div>
+                  <div className="budget__total-budget budget__total-budget__space">
+                    {yearsInPersonal}
+                  </div>
+                  <div className="budget__spacer budget__spacer--medium" />
+                  <div className="budget__total-budget budget__total-budget__space">
+                    総予算 ¥ {totalCustomBudget}
+                  </div>
+                  <div className="budget__spacer budget__spacer--medium" />
+                  <table className="budget budget__background__table">
+                    <tbody>
+                      <tr className="budget__th">
+                        <th align="center">カテゴリー</th>
+                        <th align="center">先月の支出</th>
+                        <th align="center">予算</th>
+                      </tr>
+                      {customBudgets.map((customBudget, index) => {
+                        const onChangeBudget = (event: { target: { value: string } }) => {
+                          const newBudgets = [...customBudgets];
+                          newBudgets[index].budget = (event.target.value as unknown) as number;
+                          setCustomBudgets(newBudgets);
+                        };
+                        return (
+                          <tr key={customBudget.big_category_id}>
+                            <td className="budget__td" scope="row">
+                              {customBudget.big_category_name}
+                            </td>
+                            <td className="budget__td">￥ {customBudget.last_month_expenses}</td>
+                            <td className="budget__td" align="center">
+                              <TextField
+                                size={'small'}
+                                id={'budgets'}
+                                variant="outlined"
+                                type={'number'}
+                                value={customBudget.budget}
+                                onChange={onChangeBudget}
+                              />
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                  <div className="budget__submit-btn">
                     <GenericButton
                       label={'更新する'}
                       disabled={unInput}
-                      onClick={() =>
+                      onClick={() => {
                         dispatch(
                           editCustomBudgets(
                             selectYear,
                             selectMonth,
                             customBudgets.map((budget) => {
-                              let { big_category_name, ...rest } = budget; // eslint-disable-line
+                              let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
                               rest = {
                                 big_category_id: rest.big_category_id,
                                 budget: Number(rest.budget),
@@ -217,17 +154,18 @@ const CustomBudgets = () => {
                               return rest;
                             })
                           )
-                        ) && dispatch(push('/yearly/budgets'))
-                      }
+                        );
+                        dispatch(push('/yearly/budgets'));
+                      }}
                     />
                   </div>
-                </>
-              );
-            } else {
-              return <GroupCustomBudgets />;
-            }
-          })()}
-        </div>
+                </div>
+              </>
+            );
+          } else {
+            return <GroupCustomBudgets />;
+          }
+        })()}
       </main>
     </>
   );

--- a/src/templates/EditStandardBudgets.tsx
+++ b/src/templates/EditStandardBudgets.tsx
@@ -1,96 +1,35 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router';
+import axios from 'axios';
 import {
   fetchStandardBudgets,
   addCustomBudgets,
   copyStandardBudgets,
 } from '../reducks/budgets/operations';
-import { State } from '../reducks/store/types';
 import { CustomBudgetsList } from '../reducks/budgets/types';
-import { getCustomBudgets } from '../reducks/budgets/selectors';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-import TableRow from '@material-ui/core/TableRow';
-import TableCell from '@material-ui/core/TableCell';
+import { getCustomBudgets, getTotalStandardBudget } from '../reducks/budgets/selectors';
 import TextField from '@material-ui/core/TextField';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
 import Button from '@material-ui/core/Button';
 import { push } from 'connected-react-router';
-import TableContainer from '@material-ui/core/TableContainer';
-import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
-import TableHead from '@material-ui/core/TableHead';
-import TableBody from '@material-ui/core/TableBody';
 import GenericButton from '../components/uikit/GenericButton';
-import {
-  getPathTemplateName,
-  getPathGroupId,
-  getGroupPathYear,
-  getGroupPathMonth,
-  getPathYear,
-  getPathMonth,
-} from '../lib/path';
+import { getPathTemplateName, getPathYear, getPathMonth } from '../lib/path';
 import EditGroupStandardBudgets from '../components/budget/EditGroupStandardBudgets';
 import { fetchGroups } from '../reducks/groups/operations';
 import { Header } from '../components/header';
-import axios from 'axios';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      margin: '0 auto',
-      flexDirection: 'column',
-      alignItems: 'center',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    tablePosition: {
-      margin: '0 auto',
-      marginTop: 40,
-      alignItems: 'center',
-      tableLayout: 'fixed',
-      width: '100%',
-    },
-    tableSize: {
-      width: 250,
-      textAlign: 'center',
-    },
-    buttonSize: {
-      width: 360,
-      marginTop: 40,
-      backgroundColor: '#fff',
-      margin: '0 auto',
-    },
-    buttonGroupPosition: {
-      margin: '0 auto',
-      marginLeft: '7%',
-    },
-    updateButton: {
-      textAlign: 'center',
-    },
-    tableTop: {
-      backgroundColor: '#4db5fa',
-    },
-    tableMain: {
-      border: 'solid 1px #e1e3e3',
-    },
-  })
-);
+import '../components/budget/budget.scss';
 
 const EditStandardBudgets = () => {
-  const classes = useStyles();
   const dispatch = useDispatch();
   const selectYear = getPathYear(window.location.pathname);
   const selectMonth = getPathMonth(window.location.pathname);
   const pathName = getPathTemplateName(window.location.pathname);
-  const groupId = getPathGroupId(window.location.pathname);
-  const yearInGroup = getGroupPathYear(window.location.pathname);
-  const monthInGroup = getGroupPathMonth(window.location.pathname);
-  const selector = useSelector((state: State) => state);
-  const customBudgetsList = getCustomBudgets(selector);
+  const { id } = useParams();
+  const customBudgetsList = useSelector(getCustomBudgets);
+  const totalStandardBudget = useSelector(getTotalStandardBudget);
   const [customBudgets, setCustomBudgets] = useState<CustomBudgetsList>([]);
   const yearsInPersonal = `${selectYear}年${selectMonth}月`;
-  const yearsInGroup = `${yearInGroup}年${monthInGroup}月`;
   const unInputBudgets = customBudgets === customBudgetsList;
 
   useEffect(() => {
@@ -128,97 +67,95 @@ const EditStandardBudgets = () => {
     <>
       <Header />
       <main className="section__container">
-        <div className={classes.root}>
-          <ButtonGroup
-            className={classes.buttonGroupPosition}
-            size="large"
-            aria-label="budgets-kind"
-          >
+        <div className="budget__switching-btn">
+          <ButtonGroup className="budget__switch-btn--color" size="large" aria-label="budgets-kind">
             <Button
-              className={classes.buttonSize}
+              className="budget__switch-btn budget__switch-btn"
               onClick={() => {
-                if (pathName !== 'group') {
-                  dispatch(push('/standard/budgets'));
-                } else {
-                  dispatch(push(`/group/${groupId}/standard/budgets`));
+                {
+                  pathName !== 'group'
+                    ? dispatch(push('/standard/budgets'))
+                    : dispatch(push(`/group/${Number(id)}/standard/budgets`));
                 }
               }}
             >
-              標準
+              標準予算
             </Button>
             <Button
-              className={classes.buttonSize}
+              className="budget__switch-btn budget__switch-btn"
               onClick={() => {
-                if (pathName !== 'group') {
-                  dispatch(push('/yearly/budgets'));
-                } else {
-                  dispatch(push(`/group/${groupId}/yearly/budgets`));
-                }
+                pathName !== 'group'
+                  ? dispatch(push('/yearly/budgets'))
+                  : dispatch(push(`/group/${Number(id)}/yearly/budgets`));
               }}
             >
-              月ごと
+              月別カスタム予算
             </Button>
           </ButtonGroup>
-          <h1>{pathName !== 'group' ? yearsInPersonal : yearsInGroup}</h1>
-          {(() => {
-            if (pathName !== 'group') {
-              return (
-                <>
-                  <TableContainer className={classes.tablePosition} component={Paper}>
-                    <Table>
-                      <TableHead>
-                        <TableRow>
-                          <TableCell className={classes.tableTop} align="center">
-                            カテゴリー
-                          </TableCell>
-                          <TableCell className={classes.tableTop} align="center">
-                            先月の支出
-                          </TableCell>
-                          <TableCell className={classes.tableTop} align="center">
-                            予算
-                          </TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {customBudgets.map((customBudget, index) => {
-                          const onChangeBudget = (event: { target: { value: string } }) => {
-                            const newBudgets = [...customBudgets];
-                            newBudgets[index].budget = (event.target.value as unknown) as number;
-                            setCustomBudgets(newBudgets);
-                          };
-                          return (
-                            <TableRow key={customBudget.big_category_id}>
-                              <TableCell className={classes.tableSize} component="th" scope="row">
-                                {customBudget.big_category_name}
-                              </TableCell>
-                              <TableCell className={classes.tableSize}>￥10,000</TableCell>
-                              <TableCell className={classes.tableSize} align="center">
-                                <TextField
-                                  size={'small'}
-                                  id={'budgets'}
-                                  variant="outlined"
-                                  type={'number'}
-                                  value={customBudget.budget}
-                                  onChange={onChangeBudget}
-                                />
-                              </TableCell>
-                            </TableRow>
-                          );
-                        })}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                  <div className={classes.updateButton}>
+        </div>
+        {(() => {
+          if (pathName !== 'group') {
+            return (
+              <>
+                <div className="budget__spacer budget__spacer--medium" />
+                <div className="budget budget__background budget__background__table">
+                  <div className="budget__spacer budget__spacer--medium" />
+                  <div className="budget__total-budget budget__total-budget__position">
+                    カスタム予算追加
+                  </div>
+                  <div className="budget__total-budget budget__total-budget__space">
+                    {yearsInPersonal}
+                  </div>
+                  <div className="budget__total-budget budget__total-budget__space">
+                    総予算 ¥ {totalStandardBudget}
+                  </div>
+                  <div className="budget__spacer budget__spacer--medium" />
+                  <table className="budget budget__background__table">
+                    <tbody>
+                      <tr className="budget__th">
+                        <th align="center">カテゴリー</th>
+                        <th align="center">先月の支出</th>
+                        <th align="center">予算</th>
+                      </tr>
+                      {customBudgets.map((customBudget, index) => {
+                        const onChangeBudget = (event: { target: { value: string } }) => {
+                          const newBudgets = [...customBudgets];
+                          newBudgets[index].budget = (event.target.value as unknown) as number;
+                          setCustomBudgets(newBudgets);
+                        };
+                        return (
+                          <tr key={customBudget.big_category_id}>
+                            <td className="budget__td" scope="row">
+                              {customBudget.big_category_name}
+                            </td>
+                            <td className="budget__td">￥ {customBudget.last_month_expenses}</td>
+                            <td className="budget__td" align="center">
+                              <TextField
+                                size={'small'}
+                                id={'budgets'}
+                                variant="outlined"
+                                type={'number'}
+                                value={customBudget.budget}
+                                onChange={onChangeBudget}
+                              />
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                  <div className="budget__spacer budget__spacer--medium" />
+                  <div className="budget__submit-btn">
                     <GenericButton
                       label={'更新する'}
                       disabled={unInputBudgets}
-                      onClick={() =>
+                      onClick={() => {
                         dispatch(
                           addCustomBudgets(
                             selectYear,
                             selectMonth,
                             customBudgets.map((budget) => {
-                              let { big_category_name, ...rest } = budget; // eslint-disable-line
+                              let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
                               rest = {
                                 big_category_id: rest.big_category_id,
                                 budget: Number(rest.budget),
@@ -226,17 +163,18 @@ const EditStandardBudgets = () => {
                               return rest;
                             })
                           )
-                        ) && dispatch(push('/yearly/budgets'))
-                      }
+                        );
+                        dispatch(push('/yearly/budgets'));
+                      }}
                     />
                   </div>
-                </>
-              );
-            } else {
-              return <EditGroupStandardBudgets />;
-            }
-          })()}
-        </div>
+                </div>
+              </>
+            );
+          } else {
+            return <EditGroupStandardBudgets />;
+          }
+        })()}
       </main>
     </>
   );

--- a/src/templates/EditStandardBudgets.tsx
+++ b/src/templates/EditStandardBudgets.tsx
@@ -75,7 +75,7 @@ const EditStandardBudgets = () => {
                 {
                   pathName !== 'group'
                     ? dispatch(push('/standard/budgets'))
-                    : dispatch(push(`/group/${Number(id)}/standard/budgets`));
+                    : dispatch(push(`/group/${id}/standard/budgets`));
                 }
               }}
             >
@@ -86,95 +86,90 @@ const EditStandardBudgets = () => {
               onClick={() => {
                 pathName !== 'group'
                   ? dispatch(push('/yearly/budgets'))
-                  : dispatch(push(`/group/${Number(id)}/yearly/budgets`));
+                  : dispatch(push(`/group/${id}/yearly/budgets`));
               }}
             >
               月別カスタム予算
             </Button>
           </ButtonGroup>
         </div>
-        {(() => {
-          if (pathName !== 'group') {
-            return (
-              <>
-                <div className="budget__spacer budget__spacer--medium" />
-                <div className="budget budget__background budget__background__table">
-                  <div className="budget__spacer budget__spacer--medium" />
-                  <div className="budget__total-budget budget__total-budget__position">
-                    カスタム予算追加
-                  </div>
-                  <div className="budget__total-budget budget__total-budget__space">
-                    {yearsInPersonal}
-                  </div>
-                  <div className="budget__total-budget budget__total-budget__space">
-                    総予算 ¥ {totalStandardBudget}
-                  </div>
-                  <div className="budget__spacer budget__spacer--medium" />
-                  <table className="budget budget__background__table">
-                    <tbody>
-                      <tr className="budget__th">
-                        <th align="center">カテゴリー</th>
-                        <th align="center">先月の支出</th>
-                        <th align="center">予算</th>
+        {pathName !== 'group' ? (
+          <>
+            <div className="budget__spacer budget__spacer--medium" />
+            <div className="budget budget__background budget__background__table">
+              <div className="budget__spacer budget__spacer--medium" />
+              <div className="budget__total-budget budget__total-budget__position">
+                カスタム予算追加
+              </div>
+              <div className="budget__total-budget budget__total-budget__space">
+                {yearsInPersonal}
+              </div>
+              <div className="budget__total-budget budget__total-budget__space">
+                総予算 ¥ {totalStandardBudget}
+              </div>
+              <div className="budget__spacer budget__spacer--medium" />
+              <table className="budget budget__background__table">
+                <tbody>
+                  <tr className="budget__th">
+                    <th align="center">カテゴリー</th>
+                    <th align="center">先月の支出</th>
+                    <th align="center">予算</th>
+                  </tr>
+                  {customBudgets.map((customBudget, index) => {
+                    const onChangeBudget = (event: React.ChangeEvent<HTMLInputElement>) => {
+                      const newBudgets = customBudgets.concat();
+                      newBudgets[index].budget = Number(event.target.value);
+                      setCustomBudgets(newBudgets);
+                    };
+                    return (
+                      <tr key={customBudget.big_category_id}>
+                        <td className="budget__td" scope="row">
+                          {customBudget.big_category_name}
+                        </td>
+                        <td className="budget__td">￥ {customBudget.last_month_expenses}</td>
+                        <td className="budget__td" align="center">
+                          <TextField
+                            size={'small'}
+                            id={'budgets'}
+                            variant="outlined"
+                            type={'number'}
+                            value={customBudget.budget}
+                            onChange={onChangeBudget}
+                          />
+                        </td>
                       </tr>
-                      {customBudgets.map((customBudget, index) => {
-                        const onChangeBudget = (event: { target: { value: string } }) => {
-                          const newBudgets = [...customBudgets];
-                          newBudgets[index].budget = (event.target.value as unknown) as number;
-                          setCustomBudgets(newBudgets);
-                        };
-                        return (
-                          <tr key={customBudget.big_category_id}>
-                            <td className="budget__td" scope="row">
-                              {customBudget.big_category_name}
-                            </td>
-                            <td className="budget__td">￥ {customBudget.last_month_expenses}</td>
-                            <td className="budget__td" align="center">
-                              <TextField
-                                size={'small'}
-                                id={'budgets'}
-                                variant="outlined"
-                                type={'number'}
-                                value={customBudget.budget}
-                                onChange={onChangeBudget}
-                              />
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                  <div className="budget__spacer budget__spacer--medium" />
-                  <div className="budget__submit-btn">
-                    <GenericButton
-                      label={'更新する'}
-                      disabled={unInputBudgets}
-                      onClick={() => {
-                        dispatch(
-                          addCustomBudgets(
-                            selectYear,
-                            selectMonth,
-                            customBudgets.map((budget) => {
-                              let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
-                              rest = {
-                                big_category_id: rest.big_category_id,
-                                budget: Number(rest.budget),
-                              };
-                              return rest;
-                            })
-                          )
-                        );
-                        dispatch(push('/yearly/budgets'));
-                      }}
-                    />
-                  </div>
-                </div>
-              </>
-            );
-          } else {
-            return <EditGroupStandardBudgets />;
-          }
-        })()}
+                    );
+                  })}
+                </tbody>
+              </table>
+              <div className="budget__spacer budget__spacer--medium" />
+              <div className="budget__submit-btn">
+                <GenericButton
+                  label={'更新する'}
+                  disabled={unInputBudgets}
+                  onClick={() => {
+                    dispatch(
+                      addCustomBudgets(
+                        selectYear,
+                        selectMonth,
+                        customBudgets.map((budget) => {
+                          let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
+                          return {
+                            big_category_id: rest.big_category_id,
+                            budget: Number(rest.budget),
+                          };
+                        })
+                      )
+                    );
+                    dispatch(push('/yearly/budgets'));
+                  }}
+                />
+              </div>
+            </div>
+          </>
+        ) : (
+          <EditGroupStandardBudgets />
+        )}
       </main>
     </>
   );

--- a/src/templates/EditStandardBudgets.tsx
+++ b/src/templates/EditStandardBudgets.tsx
@@ -153,7 +153,7 @@ const EditStandardBudgets = () => {
                         selectYear,
                         selectMonth,
                         customBudgets.map((budget) => {
-                          let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
+                          const { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
                           return {
                             big_category_id: rest.big_category_id,
                             budget: Number(rest.budget),

--- a/src/templates/StandardBudgets.tsx
+++ b/src/templates/StandardBudgets.tsx
@@ -1,80 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useLocation, useParams } from 'react-router';
 import { push } from 'connected-react-router';
-import { getStandardBudgets } from '../reducks/budgets/selectors';
+import axios from 'axios';
+import { getStandardBudgets, getTotalStandardBudget } from '../reducks/budgets/selectors';
 import { fetchStandardBudgets, editStandardBudgets } from '../reducks/budgets/operations';
+import { fetchGroups } from '../reducks/groups/operations';
 import { StandardBudgetsList } from '../reducks/budgets/types';
-import { State } from '../reducks/store/types';
 import Button from '@material-ui/core/Button';
 import ButtonGroup from '@material-ui/core/ButtonGroup';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import TableBody from '@material-ui/core/TableBody';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableCell from '@material-ui/core/TableCell';
 import TextField from '@material-ui/core/TextField';
 import GenericButton from '../components/uikit/GenericButton';
-import { getPathTemplateName, getPathGroupId } from '../lib/path';
 import GroupStandardBudgets from '../components/budget/GroupStandardBudgets';
-import { fetchGroups } from '../reducks/groups/operations';
 import { Header } from '../components/header';
-import axios from 'axios';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      margin: '0 auto',
-      flexDirection: 'column',
-      alignItems: 'center',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    tablePosition: {
-      margin: '0 auto',
-      marginTop: 40,
-      alignItems: 'center',
-      tableLayout: 'fixed',
-      width: '100%',
-    },
-    tableSize: {
-      width: 250,
-      textAlign: 'center',
-    },
-    buttonSize: {
-      width: 360,
-      marginTop: 40,
-      backgroundColor: '#fff',
-      margin: '0 auto',
-    },
-    buttonGroupPosition: {
-      margin: '0 auto',
-      marginLeft: '7%',
-    },
-    centerPosition: {
-      textAlign: 'center',
-    },
-    tableTop: {
-      backgroundColor: '#4db5fa',
-    },
-    tableMain: {
-      border: 'solid 1px #e1e3e3',
-    },
-  })
-);
+import '../components/budget/budget.scss';
 
 const StandardBudgets = () => {
-  const classes = useStyles();
   const dispatch = useDispatch();
-  const selector = useSelector((state: State) => state);
-  const standardBudgets = getStandardBudgets(selector);
+  const { id } = useParams();
+  const path = useLocation().pathname;
+  const pathName = useLocation().pathname.split('/')[1];
+  const standardBudgets = useSelector(getStandardBudgets);
+  const totalStandardBudget = useSelector(getTotalStandardBudget);
   const [budgets, setBudgets] = useState<StandardBudgetsList>([]);
-  const [updateMessage, setUpdateMessage] = useState<boolean>(false);
-  const pathName = getPathTemplateName(window.location.pathname);
-  const groupId = getPathGroupId(window.location.pathname);
   const unEditBudgets = budgets === standardBudgets;
 
   useEffect(() => {
@@ -103,91 +51,93 @@ const StandardBudgets = () => {
     setBudgets(standardBudgets);
   }, [standardBudgets]);
 
+  const currentPageColor = () => {
+    if (path === '/standard/budgets' || path === `/group/${id}/standard/budgets`) {
+      return { backgroundColor: '#ff6600', color: '#fff' };
+    }
+  };
+
   return (
     <>
       <Header />
       <main className="section__container">
-        <div className={classes.root}>
-          <ButtonGroup
-            className={classes.buttonGroupPosition}
-            size="large"
-            aria-label="budgets-kind"
-          >
+        <div className="budget__switching-btn">
+          <ButtonGroup className="budget__switch-btn--color" size="large" aria-label="budgets-kind">
             <Button
-              className={classes.buttonSize}
+              style={currentPageColor()}
+              className="budget__switch-btn budget__switch-btn"
               onClick={() => {
                 {
                   pathName !== 'group'
                     ? dispatch(push('/standard/budgets'))
-                    : dispatch(push(`/group/${groupId}/standard/budgets`));
+                    : dispatch(push(`/group/${Number(id)}/standard/budgets`));
                 }
               }}
             >
               標準予算
             </Button>
             <Button
-              className={classes.buttonSize}
+              className="budget__switch-btn budget__switch-btn"
               onClick={() => {
                 pathName !== 'group'
                   ? dispatch(push('/yearly/budgets'))
-                  : dispatch(push(`/group/${groupId}/yearly/budgets`));
+                  : dispatch(push(`/group/${Number(id)}/yearly/budgets`));
               }}
             >
               月別カスタム予算
             </Button>
           </ButtonGroup>
-          <h2 className={classes.centerPosition}>
-            {updateMessage ? '標準予算を更新しました' : null}
-          </h2>
-          {(() => {
-            if (pathName !== 'group') {
-              return (
-                <>
-                  <TableContainer className={classes.tablePosition} component={Paper}>
-                    <Table>
-                      <TableHead>
-                        <TableRow>
-                          <TableCell className={classes.tableTop} align="center">
-                            カテゴリー
-                          </TableCell>
-                          <TableCell className={classes.tableTop} align="center">
-                            先月の支出
-                          </TableCell>
-                          <TableCell className={classes.tableTop} align="center">
-                            予算
-                          </TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {budgets.map((budget, index) => {
-                          const onChangeBudget = (event: { target: { value: string } }) => {
-                            const newBudgets = [...budgets];
-                            newBudgets[index].budget = (event.target.value as unknown) as number;
-                            setBudgets(newBudgets);
-                          };
-                          return (
-                            <TableRow key={budget.big_category_id}>
-                              <TableCell className={classes.tableSize} component="th" scope="row">
-                                {budget.big_category_name}
-                              </TableCell>
-                              <TableCell className={classes.tableSize}>￥10,000</TableCell>
-                              <TableCell className={classes.tableSize} align="center">
-                                <TextField
-                                  size={'small'}
-                                  id={'budgets'}
-                                  variant="outlined"
-                                  type={'number'}
-                                  value={budget.budget}
-                                  onChange={onChangeBudget}
-                                />
-                              </TableCell>
-                            </TableRow>
-                          );
-                        })}
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-                  <div className={classes.centerPosition}>
+        </div>
+        {(() => {
+          if (pathName !== 'group') {
+            return (
+              <>
+                <div className="budget__spacer budget__spacer--medium" />
+                <div className="budget budget__background budget__background__table">
+                  <div className="budget__spacer budget__spacer--medium" />
+                  <div className="budget__total-budget budget__total-budget__position">
+                    標準予算設定
+                  </div>
+                  <div className="budget__total-budget budget__total-budget__space">
+                    総予算 ¥ {totalStandardBudget}
+                  </div>
+                  <div className="budget__spacer budget__spacer--medium" />
+                  <table className="budget budget__background__table">
+                    <tbody>
+                      <tr className="budget__th">
+                        <th align="center">カテゴリー</th>
+                        <th align="center">先月の支出</th>
+                        <th align="center">予算</th>
+                      </tr>
+                      {budgets.map((budget, index) => {
+                        const onChangeBudget = (event: { target: { value: string } }) => {
+                          const newBudgets = [...budgets];
+                          newBudgets[index].budget = (event.target.value as unknown) as number;
+                          setBudgets(newBudgets);
+                        };
+                        return (
+                          <tr key={budget.big_category_id}>
+                            <td className="budget__td" scope="row">
+                              {budget.big_category_name}
+                            </td>
+                            <td className="budget__td">￥ {budget.last_month_expenses}</td>
+                            <td className="budget__td" align="center">
+                              <TextField
+                                size={'small'}
+                                id={'budgets'}
+                                variant="outlined"
+                                type={'number'}
+                                value={budget.budget}
+                                onChange={onChangeBudget}
+                              />
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                  <div className="budget__spacer budget__spacer--medium" />
+                  <div className="budget__submit-btn">
                     <GenericButton
                       label={'更新する'}
                       disabled={unEditBudgets}
@@ -195,7 +145,7 @@ const StandardBudgets = () => {
                         dispatch(
                           editStandardBudgets(
                             budgets.map((budget) => {
-                              let { big_category_name, ...rest } = budget; // eslint-disable-line
+                              let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
                               rest = {
                                 big_category_id: rest.big_category_id,
                                 budget: Number(rest.budget),
@@ -203,17 +153,17 @@ const StandardBudgets = () => {
                               return rest;
                             })
                           )
-                        ) && setUpdateMessage(true);
+                        );
                       }}
                     />
                   </div>
-                </>
-              );
-            } else {
-              return <GroupStandardBudgets />;
-            }
-          })()}
-        </div>
+                </div>
+              </>
+            );
+          } else {
+            return <GroupStandardBudgets />;
+          }
+        })()}
       </main>
     </>
   );

--- a/src/templates/StandardBudgets.tsx
+++ b/src/templates/StandardBudgets.tsx
@@ -70,7 +70,7 @@ const StandardBudgets = () => {
                 {
                   pathName !== 'group'
                     ? dispatch(push('/standard/budgets'))
-                    : dispatch(push(`/group/${Number(id)}/standard/budgets`));
+                    : dispatch(push(`/group/${id}/standard/budgets`));
                 }
               }}
             >
@@ -81,89 +81,84 @@ const StandardBudgets = () => {
               onClick={() => {
                 pathName !== 'group'
                   ? dispatch(push('/yearly/budgets'))
-                  : dispatch(push(`/group/${Number(id)}/yearly/budgets`));
+                  : dispatch(push(`/group/${id}/yearly/budgets`));
               }}
             >
               月別カスタム予算
             </Button>
           </ButtonGroup>
         </div>
-        {(() => {
-          if (pathName !== 'group') {
-            return (
-              <>
-                <div className="budget__spacer budget__spacer--medium" />
-                <div className="budget budget__background budget__background__table">
-                  <div className="budget__spacer budget__spacer--medium" />
-                  <div className="budget__total-budget budget__total-budget__position">
-                    標準予算設定
-                  </div>
-                  <div className="budget__total-budget budget__total-budget__space">
-                    総予算 ¥ {totalStandardBudget}
-                  </div>
-                  <div className="budget__spacer budget__spacer--medium" />
-                  <table className="budget budget__background__table">
-                    <tbody>
-                      <tr className="budget__th">
-                        <th align="center">カテゴリー</th>
-                        <th align="center">先月の支出</th>
-                        <th align="center">予算</th>
+        {pathName !== 'group' ? (
+          <>
+            <div className="budget__spacer budget__spacer--medium" />
+            <div className="budget budget__background budget__background__table">
+              <div className="budget__spacer budget__spacer--medium" />
+              <div className="budget__total-budget budget__total-budget__position">
+                標準予算設定
+              </div>
+              <div className="budget__total-budget budget__total-budget__space">
+                総予算 ¥ {totalStandardBudget}
+              </div>
+              <div className="budget__spacer budget__spacer--medium" />
+              <table className="budget budget__background__table">
+                <tbody>
+                  <tr className="budget__th">
+                    <th align="center">カテゴリー</th>
+                    <th align="center">先月の支出</th>
+                    <th align="center">予算</th>
+                  </tr>
+                  {budgets.map((budget, index) => {
+                    const onChangeBudget = (event: React.ChangeEvent<HTMLInputElement>) => {
+                      const newBudgets = budgets.concat();
+                      newBudgets[index].budget = Number(event.target.value);
+                      setBudgets(newBudgets);
+                    };
+                    return (
+                      <tr key={budget.big_category_id}>
+                        <td className="budget__td" scope="row">
+                          {budget.big_category_name}
+                        </td>
+                        <td className="budget__td">￥ {budget.last_month_expenses}</td>
+                        <td className="budget__td" align="center">
+                          <TextField
+                            size={'small'}
+                            id={'budgets'}
+                            variant="outlined"
+                            type={'number'}
+                            value={budget.budget}
+                            onChange={onChangeBudget}
+                          />
+                        </td>
                       </tr>
-                      {budgets.map((budget, index) => {
-                        const onChangeBudget = (event: { target: { value: string } }) => {
-                          const newBudgets = [...budgets];
-                          newBudgets[index].budget = (event.target.value as unknown) as number;
-                          setBudgets(newBudgets);
-                        };
-                        return (
-                          <tr key={budget.big_category_id}>
-                            <td className="budget__td" scope="row">
-                              {budget.big_category_name}
-                            </td>
-                            <td className="budget__td">￥ {budget.last_month_expenses}</td>
-                            <td className="budget__td" align="center">
-                              <TextField
-                                size={'small'}
-                                id={'budgets'}
-                                variant="outlined"
-                                type={'number'}
-                                value={budget.budget}
-                                onChange={onChangeBudget}
-                              />
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                  <div className="budget__spacer budget__spacer--medium" />
-                  <div className="budget__submit-btn">
-                    <GenericButton
-                      label={'更新する'}
-                      disabled={unEditBudgets}
-                      onClick={() => {
-                        dispatch(
-                          editStandardBudgets(
-                            budgets.map((budget) => {
-                              let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
-                              rest = {
-                                big_category_id: rest.big_category_id,
-                                budget: Number(rest.budget),
-                              };
-                              return rest;
-                            })
-                          )
-                        );
-                      }}
-                    />
-                  </div>
-                </div>
-              </>
-            );
-          } else {
-            return <GroupStandardBudgets />;
-          }
-        })()}
+                    );
+                  })}
+                </tbody>
+              </table>
+              <div className="budget__spacer budget__spacer--medium" />
+              <div className="budget__submit-btn">
+                <GenericButton
+                  label={'更新する'}
+                  disabled={unEditBudgets}
+                  onClick={() => {
+                    dispatch(
+                      editStandardBudgets(
+                        budgets.map((budget) => {
+                          let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
+                          return {
+                            big_category_id: rest.big_category_id,
+                            budget: Number(rest.budget),
+                          };
+                        })
+                      )
+                    );
+                  }}
+                />
+              </div>
+            </div>
+          </>
+        ) : (
+          <GroupStandardBudgets />
+        )}
       </main>
     </>
   );

--- a/src/templates/StandardBudgets.tsx
+++ b/src/templates/StandardBudgets.tsx
@@ -143,7 +143,7 @@ const StandardBudgets = () => {
                     dispatch(
                       editStandardBudgets(
                         budgets.map((budget) => {
-                          let { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
+                          const { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
                           return {
                             big_category_id: rest.big_category_id,
                             budget: Number(rest.budget),

--- a/test/budgets-test/addCustomBudgetsResponse.json
+++ b/test/budgets-test/addCustomBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 25000
+      "budget": 25000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 5000
+      "budget": 5000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 4500
+      "budget": 4500,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 2000
+      "budget": 2000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 4900
+      "budget": 4900,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 4400
+      "budget": 4400,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 15000
+      "budget": 15000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 3000
+      "budget": 3000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 9800
+      "budget": 9800,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }

--- a/test/budgets-test/editBudgetsResponse.json
+++ b/test/budgets-test/editBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 25000
+      "budget": 25000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 5000
+      "budget": 5000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 4500
+      "budget": 4500,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 4900
+      "budget": 4900,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 4400
+      "budget": 4400,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 15000
+      "budget": 15000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 3000
+      "budget": 3000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 9800
+      "budget": 9800,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }

--- a/test/budgets-test/editCustomBudgetsResponse.json
+++ b/test/budgets-test/editCustomBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 38000
+      "budget": 38000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 4000
+      "budget": 4000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 7500
+      "budget": 7500,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 4900
+      "budget": 4900,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 4400
+      "budget": 4400,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 15000
+      "budget": 15000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 3000
+      "budget": 3000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 3800
+      "budget": 3800,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }

--- a/test/budgets-test/fetchBudgetsResponse.json
+++ b/test/budgets-test/fetchBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }

--- a/test/budgets-test/fetchCustomBudgetsResponse.json
+++ b/test/budgets-test/fetchCustomBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 25000
+      "budget": 25000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 5000
+      "budget": 5000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 4500
+      "budget": 4500,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 4900
+      "budget": 4900,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 4400
+      "budget": 4400,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 15000
+      "budget": 15000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 3000
+      "budget": 3000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 9800
+      "budget": 9800,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }

--- a/test/group-budgets-test/addGroupCustomBudgetsResponse.json
+++ b/test/group-budgets-test/addGroupCustomBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 25000
+      "budget": 25000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 5000
+      "budget": 5000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 5000
+      "budget": 5000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 8000
+      "budget": 8000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 65000
+      "budget": 65000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 7000
+      "budget": 7000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 8000
+      "budget": 8000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }

--- a/test/group-budgets-test/editGroupCustomBudgetsResponse.json
+++ b/test/group-budgets-test/editGroupCustomBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 25000
+      "budget": 25000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 8000
+      "budget": 8000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 9000
+      "budget": 9000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 3000
+      "budget": 3000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 8000
+      "budget": 8000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 65000
+      "budget": 65000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 7000
+      "budget": 7000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 8000
+      "budget": 8000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }

--- a/test/group-budgets-test/editGroupStandardBudgetsResponse.json
+++ b/test/group-budgets-test/editGroupStandardBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 25000
+      "budget": 25000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 5000
+      "budget": 5000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 4500
+      "budget": 4500,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 5000
+      "budget": 5000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 5000
+      "budget": 5000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 60000
+      "budget": 60000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 8000
+      "budget": 8000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }

--- a/test/group-budgets-test/fetchGroupCustomBudgetsResponse.json
+++ b/test/group-budgets-test/fetchGroupCustomBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 25000
+      "budget": 25000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 5000
+      "budget": 5000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 4500
+      "budget": 4500,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 1000
+      "budget": 1000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 4900
+      "budget": 4900,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 4400
+      "budget": 4400,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 10000
+      "budget": 10000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 15000
+      "budget": 15000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 3000
+      "budget": 3000,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 9800
+      "budget": 9800,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }

--- a/test/group-budgets-test/fetchGroupStandardBudgetsResponse.json
+++ b/test/group-budgets-test/fetchGroupStandardBudgetsResponse.json
@@ -3,82 +3,98 @@
     {
       "big_category_id": 2,
       "big_category_name": "食費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 3,
       "big_category_name": "日用品",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 4,
       "big_category_name": "趣味・娯楽",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 5,
       "big_category_name": "交際費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 6,
       "big_category_name": "交通費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 7,
       "big_category_name": "衣服・美容",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 8,
       "big_category_name": "健康・医療",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 9,
       "big_category_name": "通信費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 10,
       "big_category_name": "教養・教育",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 11,
       "big_category_name": "住宅",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 12,
       "big_category_name": "水道・光熱費",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 13,
       "big_category_name": "自動車",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 14,
       "big_category_name": "保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 15,
       "big_category_name": "税金・社会保険",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 16,
       "big_category_name": "現金・カード",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     },
     {
       "big_category_id": 17,
       "big_category_name": "その他",
-      "budget": 0
+      "budget": 0,
+      "last_month_expenses": 0
     }
   ]
 }


### PR DESCRIPTION
- 各カテゴリー事の予算の設定を行う`StandardBudgets, GroupStandardBudgets, CustomBudgets, GroupCustomBudgets`に
  先月の支出を見て予算設定を行えるように各カテゴリーの先月の支出`last_month_expenses `を追加しました。

- 先月の支出追加に伴ってテストの修正を行いました。

- `transactions / selectors, groupTransactions / selectors`にStandardBudgetsとCustomBudgetsの総予算を追加しました。

- `StandardBudgets, GroupStandardBudgets, CustomBudgets, GroupCustomBudgets`に使用していたmaterial-uiを削除し
  HTMLタグに変更しました。

確認よろしくお願いします。