### PR TITLE
Add a function to fetch groupYearlyAccount

### DIFF
--- a/src/components/home/graph/HistoryBarChart.tsx
+++ b/src/components/home/graph/HistoryBarChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Cell, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
 import { CurrentMonthBudgetStatusList } from '../../../reducks/budgets/types';
 import { CurrentMonthBudgetGroupStatusList } from '../../../reducks/groupBudgets/types';
-import { monthStatusColor, weekStatusColor, dayStatusColor } from '../../../lib/constant';
+import { monthStatusColor, weekStatusColor, dayStatusColor } from '../../../lib/colorConstant';
 import './bar-chart.scss';
 
 interface HistoryBarChartProps {

--- a/src/components/home/graph/HistoryPieChart.tsx
+++ b/src/components/home/graph/HistoryPieChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { PieChart, Pie, Cell, Tooltip, Label } from 'recharts';
 import { FetchTransactions } from '../../../reducks/transactions/types';
 import { GroupTransactions } from '../../../reducks/groupTransactions/types';
-import { colors } from '../../../lib/constant';
+import { colors } from '../../../lib/colorConstant';
 import './bar-chart.scss';
 
 interface HistoryPieChartProps {

--- a/src/lib/colorConstant.ts
+++ b/src/lib/colorConstant.ts
@@ -1,0 +1,39 @@
+export const monthStatusColor = '#47a414';
+export const weekStatusColor = '#ffba16';
+export const dayStatusColor = '#f45e36';
+
+const foodExpenseColor = '#ff6600';
+const necessitiesExpenseColor = '#0088FE';
+const hobbyExpenseColor = '#029c4f';
+const entertainmentExpensesColor = '#f9d423';
+const travelingExpenseColor = '#2020f5';
+const clothingExpenseColor = '#f573b4';
+const medicalExpenseColor = '#00C49F';
+const postageExpenseColor = '#FFBEDA';
+const educationExpenseColor = '#a8e063';
+const housingExpenseColor = '#8426a6';
+const utilityExpenseColor = '#00ced1';
+const carExpenseColor = '#e9967a';
+const insuranceExpenseColor = '#5da1f5';
+const taxExpenseColor = '#ff416c';
+const cashExpenseColor = '#e8ff3d';
+const otherExpenseColor = '#bdc3c7';
+
+export const colors = [
+  foodExpenseColor,
+  necessitiesExpenseColor,
+  hobbyExpenseColor,
+  entertainmentExpensesColor,
+  travelingExpenseColor,
+  clothingExpenseColor,
+  medicalExpenseColor,
+  postageExpenseColor,
+  educationExpenseColor,
+  housingExpenseColor,
+  utilityExpenseColor,
+  carExpenseColor,
+  insuranceExpenseColor,
+  taxExpenseColor,
+  cashExpenseColor,
+  otherExpenseColor,
+];

--- a/src/lib/constant.ts
+++ b/src/lib/constant.ts
@@ -20,46 +20,6 @@ export const noTransactionMessage = 'この月には、まだ記録がありま�
 export const months = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 export const years = [year - 3, year - 2, year - 1, year, year + 1, year + 2, year + 3];
 
-export const monthStatusColor = '#47a414';
-export const weekStatusColor = '#ffba16';
-export const dayStatusColor = '#f45e36';
-
-const foodExpenseColor = '#ff6600';
-const necessitiesExpenseColor = '#0088FE';
-const hobbyExpenseColor = '#029c4f';
-const entertainmentExpensesColor = '#f9d423';
-const travelingExpenseColor = '#2020f5';
-const clothingExpenseColor = '#f573b4';
-const medicalExpenseColor = '#00C49F';
-const postageExpenseColor = '#FFBEDA';
-const educationExpenseColor = '#a8e063';
-const housingExpenseColor = '#8426a6';
-const utilityExpenseColor = '#00ced1';
-const carExpenseColor = '#e9967a';
-const insuranceExpenseColor = '#5da1f5';
-const taxExpenseColor = '#ff416c';
-const cashExpenseColor = '#e8ff3d';
-const otherExpenseColor = '#bdc3c7';
-
-export const colors = [
-  foodExpenseColor,
-  necessitiesExpenseColor,
-  hobbyExpenseColor,
-  entertainmentExpensesColor,
-  travelingExpenseColor,
-  clothingExpenseColor,
-  medicalExpenseColor,
-  postageExpenseColor,
-  educationExpenseColor,
-  housingExpenseColor,
-  utilityExpenseColor,
-  carExpenseColor,
-  insuranceExpenseColor,
-  taxExpenseColor,
-  cashExpenseColor,
-  otherExpenseColor,
-];
-
 export const defaultIncomeCategoryList: AssociatedCategory[] = [
   {
     category_type: 'MediumCategory',

--- a/src/lib/function.ts
+++ b/src/lib/function.ts
@@ -1,4 +1,4 @@
-import { colors } from './constant';
+import { colors } from './colorConstant';
 
 export const bigCategoryColor = (bigCategoryName: string) => {
   if (bigCategoryName === '食費') {

--- a/src/reducks/groupTransactions/actions.ts
+++ b/src/reducks/groupTransactions/actions.ts
@@ -1,9 +1,12 @@
 import { GroupTransactionsList, GroupAccountList, GroupYearlyAccountList } from './types';
 
 export type groupTransactionsAction = ReturnType<
+  | typeof startFetchDataAction
+  | typeof failedFetchDataAction
   | typeof updateGroupTransactionsAction
   | typeof updateGroupLatestTransactionsAction
   | typeof fetchGroupAccountAction
+  | typeof fetchGroupYearlyAccountListAction
   | typeof addGroupAccountAction
   | typeof editGroupAccountAction
   | typeof deleteGroupAccountAction
@@ -13,8 +16,10 @@ export type groupTransactionsAction = ReturnType<
 export const WAITING_FETCH_DATA = 'WAITING_FETCH_DATA';
 export const startFetchDataAction = () => {
   return {
-    types: WAITING_FETCH_DATA,
-    payload: true,
+    type: WAITING_FETCH_DATA,
+    payload: {
+      loading: true,
+    },
   };
 };
 

--- a/src/reducks/groupTransactions/actions.ts
+++ b/src/reducks/groupTransactions/actions.ts
@@ -1,4 +1,4 @@
-import { GroupTransactionsList, GroupAccountList } from './types';
+import { GroupTransactionsList, GroupAccountList, GroupYearlyAccountList } from './types';
 
 export type groupTransactionsAction = ReturnType<
   | typeof updateGroupTransactionsAction
@@ -9,6 +9,25 @@ export type groupTransactionsAction = ReturnType<
   | typeof deleteGroupAccountAction
   | typeof searchGroupTransactionsAction
 >;
+
+export const WAITING_FETCH_DATA = 'WAITING_FETCH_DATA';
+export const startFetchDataAction = () => {
+  return {
+    types: WAITING_FETCH_DATA,
+    payload: true,
+  };
+};
+
+export const FAILED_FETCH_DATA = 'FAILED_FETCH_DATA';
+export const failedFetchDataAction = (errorMessage: string) => {
+  return {
+    type: FAILED_FETCH_DATA,
+    payload: {
+      loading: false,
+      errorMessage: errorMessage,
+    },
+  };
+};
 
 export const UPDATE_GROUP_TRANSACTIONS = 'UPDATE_GROUP_TRANSACTIONS';
 export const updateGroupTransactionsAction = (groupTransactionsList: GroupTransactionsList) => {
@@ -33,6 +52,19 @@ export const fetchGroupAccountAction = (groupAccountList: GroupAccountList) => {
   return {
     type: FETCH_GROUP_ACCOUNT,
     payload: groupAccountList,
+  };
+};
+
+export const FETCH_GROUP_YEARLY_ACCOUNT = 'FETCH_GROUP_YEARLY_ACCOUNT';
+export const fetchGroupYearlyAccountListAction = (
+  groupYearlyAccountList: GroupYearlyAccountList
+) => {
+  return {
+    type: FETCH_GROUP_YEARLY_ACCOUNT,
+    payload: {
+      loading: false,
+      groupYearlyAccountList: groupYearlyAccountList,
+    },
   };
 };
 

--- a/src/reducks/groupTransactions/reducers.ts
+++ b/src/reducks/groupTransactions/reducers.ts
@@ -7,6 +7,16 @@ export const groupTransactionsReducer = (
   action: groupTransactionsAction
 ) => {
   switch (action.type) {
+    case Actions.WAITING_FETCH_DATA:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_FETCH_DATA:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.UPDATE_GROUP_TRANSACTIONS:
       return {
         ...state,
@@ -21,6 +31,11 @@ export const groupTransactionsReducer = (
       return {
         ...state,
         groupAccountList: action.payload,
+      };
+    case Actions.FETCH_GROUP_YEARLY_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
       };
     case Actions.ADD_GROUP_ACCOUNT:
       return {

--- a/src/reducks/groupTransactions/selectors.ts
+++ b/src/reducks/groupTransactions/selectors.ts
@@ -19,6 +19,11 @@ export const getGroupAccountList = createSelector(
   (state) => state.groupAccountList
 );
 
+export const getGroupYearlyAccountList = createSelector(
+  [groupTransactionsSelector],
+  (state) => state.groupYearlyAccountList
+);
+
 export const getDeleteAccountMessage = createSelector(
   [groupTransactionsSelector],
   (state) => state.deletedMessage

--- a/src/reducks/groupTransactions/types.ts
+++ b/src/reducks/groupTransactions/types.ts
@@ -67,6 +67,20 @@ export interface GroupAccountList {
   group_accounts_list: GroupAccounts;
 }
 
+export interface YearlyAccount {
+  month: string;
+  calculation_status: string;
+  payment_status: string;
+  receipt_status: string;
+}
+
+export interface YearlyAccounts extends Array<YearlyAccount> {}
+
+export interface GroupYearlyAccountList {
+  Year: string;
+  yearly_accounting_status: YearlyAccounts;
+}
+
 export interface GroupAccountListRes {
   message: string;
   group_id: number;

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -30,6 +30,7 @@ const initialState = {
     notHistoryMessage: '',
   },
   groupTransactions: {
+    loading: false,
     groupLatestTransactionsList: [],
     groupTransactionsList: [],
     groupSearchTransactionsList: [],
@@ -43,6 +44,10 @@ const initialState = {
       group_average_payment_amount: 0,
       group_remaining_amount: 0,
       group_accounts_list: [],
+    },
+    groupYearlyAccountList: {
+      year: '',
+      yearly_accounting_status: [],
     },
   },
   budgets: {

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -2,7 +2,11 @@ import { Categories } from '../categories/types';
 import { GroupCategories } from '../groupCategories/types';
 import { Groups } from '../groups/types';
 import { TransactionsList } from '../transactions/types';
-import { GroupTransactionsList, GroupAccountList } from '../groupTransactions/types';
+import {
+  GroupTransactionsList,
+  GroupAccountList,
+  GroupYearlyAccountList,
+} from '../groupTransactions/types';
 import { StandardBudgetsList, YearlyBudgetsList, CustomBudgetsList } from '../budgets/types';
 import {
   GroupStandardBudgetsList,
@@ -50,6 +54,8 @@ export interface State {
     groupTransactionsList: GroupTransactionsList;
     groupSearchTransactionsList: GroupTransactionsList;
     groupAccountList: GroupAccountList;
+    groupYearlyAccountList: GroupYearlyAccountList;
+    loading: boolean;
     notAccountMessage: string;
     deletedMessage: string;
   };

--- a/test/group-transactions-test/GroupTransactions.test.tsx
+++ b/test/group-transactions-test/GroupTransactions.test.tsx
@@ -16,6 +16,7 @@ import {
   editGroupLatestTransactionsList,
   deleteGroupLatestTransactions,
   fetchGroupAccount,
+  fetchGroupYearlyAccountList,
   addGroupAccount,
   editGroupAccount,
   deleteGroupAccount,
@@ -35,6 +36,7 @@ import groupAccountList from './groupAccountList.json';
 import editGroupAccountList from './editGroupAccoountResponse.json';
 import deleteAccountResponse from './deleteGroupAccountResponse.json';
 import searchGroupTransactionsRes from './fetchSearchGroupTransactionsResponse.json';
+import groupYearlyAccountListRes from './groupYearlyAccountList.json';
 
 const axiosMock = new axiosMockAdapter(axios);
 const middlewares = [thunk];
@@ -674,6 +676,36 @@ describe('async actions groupTransactions', () => {
     axiosMock.onGet(url).reply(200, mockResponse);
 
     await searchGroupTransactions(groupId, params)(store.dispatch);
+    expect(store.getActions()).toEqual(expectActions);
+  });
+
+  it('Get groupYearlyAccountList if fetch succeeds', async () => {
+    const store = mockStore({ groupTransactions: { groupYearlyAccountList: {} } });
+
+    beforeEach(() => {
+      store.clearActions();
+    });
+
+    const groupId = 1;
+    const year = 2020;
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}/account`;
+    const signal = axios.CancelToken.source();
+
+    const mockResponse = groupYearlyAccountListRes;
+
+    const expectActions = [
+      {
+        type: actionTypes.FETCH_GROUP_YEARLY_ACCOUNT,
+        payload: {
+          loading: false,
+          groupYearlyAccountList: mockResponse,
+        },
+      },
+    ];
+
+    axiosMock.onGet(url).reply(200, mockResponse);
+
+    await fetchGroupYearlyAccountList(groupId, year, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectActions);
   });
 });

--- a/test/group-transactions-test/groupYearlyAccountList.json
+++ b/test/group-transactions-test/groupYearlyAccountList.json
@@ -1,0 +1,77 @@
+{
+  "Year": "2020年",
+  "yearly_accounting_status": [
+    {
+      "month": "1月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "2月",
+      "calculation_status": "精算済",
+      "payment_status": "受領待ち: 1件",
+      "receipt_status": "-"
+    },
+    {
+      "month": "3月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "4月",
+      "calculation_status": "未精算",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "5月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "6月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "7月",
+      "calculation_status": "精算済",
+      "payment_status": "-",
+      "receipt_status": "支払待ち: 3件"
+    },
+    {
+      "month": "8月",
+      "calculation_status": "精算済",
+      "payment_status": "-",
+      "receipt_status": "支払待ち: 6件"
+    },
+    {
+      "month": "9月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "10月",
+      "calculation_status": "精算済",
+      "payment_status": "-",
+      "receipt_status": "支払待ち: 6件"
+    },
+    {
+      "month": "11月",
+      "calculation_status": "精算済",
+      "payment_status": "未払い: 1件",
+      "receipt_status": "-"
+    },
+    {
+      "month": "12月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    }
+  ]
+}


### PR DESCRIPTION
- `store / types, initialState`に`groupYearlyAccountList`を追加しました。

- groupYearlyAccountListの`types, actions, reducers, selectors`を`groupTransactions`に追加しました。

- グループの年間精算状況を取得する`fetchGroupAccount function`を`groupTransactions / operations`に追加しました。

確認よろしくお願いします。