### PR TITLE
Add fetch month shopping list

### DIFF
--- a/src/reducks/shoppingList/actions.ts
+++ b/src/reducks/shoppingList/actions.ts
@@ -84,8 +84,10 @@ export const failedFetchDataAction = (statusCode: number, errorMessage: string) 
     type: FAILED_FETCH_DATA,
     payload: {
       loading: false,
-      statusCode: statusCode,
-      message: errorMessage,
+      error: {
+        statusCode: statusCode,
+        message: errorMessage,
+      },
     },
   };
 };

--- a/src/reducks/shoppingList/actions.ts
+++ b/src/reducks/shoppingList/actions.ts
@@ -79,12 +79,13 @@ export const fetchMonthlyShoppingListByCategoriesAction = (
 };
 
 export const FAILED_FETCH_DATA = 'FAILED_FETCH_DATA';
-export const failedFetchDataAction = (errorMessage: string) => {
+export const failedFetchDataAction = (statusCode: number, errorMessage: string) => {
   return {
     type: FAILED_FETCH_DATA,
     payload: {
       loading: false,
-      errorMessage: errorMessage,
+      statusCode: statusCode,
+      message: errorMessage,
     },
   };
 };

--- a/src/reducks/shoppingList/actions.ts
+++ b/src/reducks/shoppingList/actions.ts
@@ -62,6 +62,22 @@ export const fetchMonthlyShoppingListAction = (
   };
 };
 
+export const FETCH_MONTHLY_SHOPPING_LIST_BY_CATEGORIES =
+  'FETCH_MONTHLY_SHOPPING_LIST_BY_CATEGORIES';
+export const fetchMonthlyShoppingListByCategoriesAction = (
+  regularShoppingList: RegularShoppingList,
+  monthlyShoppingListByCategories: ShoppingListByCategories
+) => {
+  return {
+    type: FETCH_MONTHLY_SHOPPING_LIST_BY_CATEGORIES,
+    payload: {
+      loading: false,
+      regularShoppingList: regularShoppingList,
+      monthlyShoppingListByCategories: monthlyShoppingListByCategories,
+    },
+  };
+};
+
 export const FAILED_FETCH_DATA = 'FAILED_FETCH_DATA';
 export const failedFetchDataAction = (errorMessage: string) => {
   return {

--- a/src/reducks/shoppingList/actions.ts
+++ b/src/reducks/shoppingList/actions.ts
@@ -1,9 +1,10 @@
-import { RegularShoppingList, ShoppingList } from './types';
+import { RegularShoppingList, ShoppingList, ShoppingListByCategories } from './types';
 export type ShoppingListActions = ReturnType<
   | typeof waitingFetchDataAction
   | typeof fetchTodayShoppingListAction
-  | typeof failedFetchDataAction
+  | typeof fetchTodayShoppingListByCategoriesAction
   | typeof fetchMonthlyShoppingListAction
+  | typeof failedFetchDataAction
 >;
 
 export const WAITING_FETCH_DATA = 'WAITING_FETCH_DATA';
@@ -27,6 +28,21 @@ export const fetchTodayShoppingListAction = (
       loading: false,
       regularShoppingList: regularShoppingList,
       todayShoppingList: todayShoppingList,
+    },
+  };
+};
+
+export const FETCH_TODAY_SHOPPING_LIST_BY_CATEGORIES = 'FETCH_TODAY_SHOPPING_LIST_BY_CATEGORIES';
+export const fetchTodayShoppingListByCategoriesAction = (
+  regularShoppingList: RegularShoppingList,
+  todayShoppingListByCategories: ShoppingListByCategories
+) => {
+  return {
+    type: FETCH_TODAY_SHOPPING_LIST_BY_CATEGORIES,
+    payload: {
+      loading: false,
+      regularShoppingList: regularShoppingList,
+      todayShoppingListByCategories: todayShoppingListByCategories,
     },
   };
 };

--- a/src/reducks/shoppingList/actions.ts
+++ b/src/reducks/shoppingList/actions.ts
@@ -1,12 +1,15 @@
 import { RegularShoppingList, ShoppingList } from './types';
 export type ShoppingListActions = ReturnType<
-  typeof startFetchDataAction | typeof fetchTodayShoppingListAction | typeof failedFetchDataAction
+  | typeof waitingFetchDataAction
+  | typeof fetchTodayShoppingListAction
+  | typeof failedFetchDataAction
+  | typeof fetchMonthlyShoppingListAction
 >;
 
-export const START_FETCH_DATA = 'START_FETCH_DATA';
-export const startFetchDataAction = () => {
+export const WAITING_FETCH_DATA = 'WAITING_FETCH_DATA';
+export const waitingFetchDataAction = () => {
   return {
-    type: START_FETCH_DATA,
+    type: WAITING_FETCH_DATA,
     payload: {
       loading: true,
     },
@@ -24,6 +27,21 @@ export const fetchTodayShoppingListAction = (
       loading: false,
       regularShoppingList: regularShoppingList,
       todayShoppingList: todayShoppingList,
+    },
+  };
+};
+
+export const FETCH_MONTHLY_SHOPPING_LIST = 'FETCH_MONTHLY_SHOPPING_LIST';
+export const fetchMonthlyShoppingListAction = (
+  regularShoppingList: RegularShoppingList,
+  monthlyShoppingList: ShoppingList
+) => {
+  return {
+    type: FETCH_MONTHLY_SHOPPING_LIST,
+    payload: {
+      loading: false,
+      regularShoppingList: regularShoppingList,
+      monthlyShoppingList: monthlyShoppingList,
     },
   };
 };

--- a/src/reducks/shoppingList/operations.ts
+++ b/src/reducks/shoppingList/operations.ts
@@ -1,6 +1,7 @@
 import { Action, Dispatch } from 'redux';
 import axios, { CancelTokenSource } from 'axios';
 import {
+  FetchMonthlyShoppingListByCategoriesRes,
   FetchMonthlyShoppingListRes,
   FetchTodayShoppingListByCategoriesRes,
   FetchTodayShoppingListRes,
@@ -11,6 +12,7 @@ import {
 import {
   failedFetchDataAction,
   fetchMonthlyShoppingListAction,
+  fetchMonthlyShoppingListByCategoriesAction,
   fetchTodayShoppingListAction,
   fetchTodayShoppingListByCategoriesAction,
 } from './actions';
@@ -101,6 +103,43 @@ export const fetchMonthlyShoppingList = (
       const monthlyShoppingList: ShoppingList = result.data.shopping_list;
 
       dispatch(fetchMonthlyShoppingListAction(regularShoppingList, monthlyShoppingList));
+    } catch (error) {
+      if (axios.isCancel(error)) {
+        return;
+      } else {
+        dispatch(failedFetchDataAction(error.response.data.error.message));
+        if (error.response.status === 401) {
+          dispatch(push('/login'));
+        }
+      }
+    }
+  };
+};
+
+export const fetchMonthlyShoppingListByCategories = (
+  year: string,
+  month: string,
+  signal: CancelTokenSource
+) => {
+  return async (dispatch: Dispatch<Action>) => {
+    try {
+      const result = await axios.get<FetchMonthlyShoppingListByCategoriesRes>(
+        `${process.env.REACT_APP_TODO_API_HOST}/shopping-list/${year}-${month}/categories`,
+        {
+          cancelToken: signal.token,
+          withCredentials: true,
+        }
+      );
+      const regularShoppingList: RegularShoppingList = result.data.regular_shopping_list;
+      const monthlyShoppingListByCategories: ShoppingListByCategories =
+        result.data.shopping_list_by_categories;
+
+      dispatch(
+        fetchMonthlyShoppingListByCategoriesAction(
+          regularShoppingList,
+          monthlyShoppingListByCategories
+        )
+      );
     } catch (error) {
       if (axios.isCancel(error)) {
         return;

--- a/src/reducks/shoppingList/operations.ts
+++ b/src/reducks/shoppingList/operations.ts
@@ -16,7 +16,6 @@ import {
   fetchTodayShoppingListAction,
   fetchTodayShoppingListByCategoriesAction,
 } from './actions';
-import { push } from 'connected-react-router';
 
 export const fetchTodayShoppingList = (
   year: string,
@@ -41,10 +40,7 @@ export const fetchTodayShoppingList = (
       if (axios.isCancel(error)) {
         return;
       } else {
-        dispatch(failedFetchDataAction(error.response.data.error.message));
-        if (error.response.status === 401) {
-          dispatch(push('/login'));
-        }
+        dispatch(failedFetchDataAction(error.response.status, error.response.data.error.message));
       }
     }
   };
@@ -76,10 +72,7 @@ export const fetchTodayShoppingListByCategories = (
       if (axios.isCancel(error)) {
         return;
       } else {
-        dispatch(failedFetchDataAction(error.response.data.error.message));
-        if (error.response.status === 401) {
-          dispatch(push('/login'));
-        }
+        dispatch(failedFetchDataAction(error.response.status, error.response.data.error.message));
       }
     }
   };
@@ -107,10 +100,7 @@ export const fetchMonthlyShoppingList = (
       if (axios.isCancel(error)) {
         return;
       } else {
-        dispatch(failedFetchDataAction(error.response.data.error.message));
-        if (error.response.status === 401) {
-          dispatch(push('/login'));
-        }
+        dispatch(failedFetchDataAction(error.response.status, error.response.data.error.message));
       }
     }
   };
@@ -144,10 +134,7 @@ export const fetchMonthlyShoppingListByCategories = (
       if (axios.isCancel(error)) {
         return;
       } else {
-        dispatch(failedFetchDataAction(error.response.data.error.message));
-        if (error.response.status === 401) {
-          dispatch(push('/login'));
-        }
+        dispatch(failedFetchDataAction(error.response.status, error.response.data.error.message));
       }
     }
   };

--- a/src/reducks/shoppingList/operations.ts
+++ b/src/reducks/shoppingList/operations.ts
@@ -2,14 +2,17 @@ import { Action, Dispatch } from 'redux';
 import axios, { CancelTokenSource } from 'axios';
 import {
   FetchMonthlyShoppingListRes,
+  FetchTodayShoppingListByCategoriesRes,
   FetchTodayShoppingListRes,
   RegularShoppingList,
   ShoppingList,
+  ShoppingListByCategories,
 } from './types';
 import {
   failedFetchDataAction,
   fetchMonthlyShoppingListAction,
   fetchTodayShoppingListAction,
+  fetchTodayShoppingListByCategoriesAction,
 } from './actions';
 import { push } from 'connected-react-router';
 
@@ -32,6 +35,41 @@ export const fetchTodayShoppingList = (
       const todayShoppingList: ShoppingList = result.data.shopping_list;
 
       dispatch(fetchTodayShoppingListAction(regularShoppingList, todayShoppingList));
+    } catch (error) {
+      if (axios.isCancel(error)) {
+        return;
+      } else {
+        dispatch(failedFetchDataAction(error.response.data.error.message));
+        if (error.response.status === 401) {
+          dispatch(push('/login'));
+        }
+      }
+    }
+  };
+};
+
+export const fetchTodayShoppingListByCategories = (
+  year: string,
+  month: string,
+  date: string,
+  signal: CancelTokenSource
+) => {
+  return async (dispatch: Dispatch<Action>) => {
+    try {
+      const result = await axios.get<FetchTodayShoppingListByCategoriesRes>(
+        `${process.env.REACT_APP_TODO_API_HOST}/shopping-list/${year}-${month}-${date}/categories`,
+        {
+          cancelToken: signal.token,
+          withCredentials: true,
+        }
+      );
+      const regularShoppingList: RegularShoppingList = result.data.regular_shopping_list;
+      const todayShoppingListByCategories: ShoppingListByCategories =
+        result.data.shopping_list_by_categories;
+
+      dispatch(
+        fetchTodayShoppingListByCategoriesAction(regularShoppingList, todayShoppingListByCategories)
+      );
     } catch (error) {
       if (axios.isCancel(error)) {
         return;

--- a/src/reducks/shoppingList/operations.ts
+++ b/src/reducks/shoppingList/operations.ts
@@ -1,7 +1,16 @@
 import { Action, Dispatch } from 'redux';
 import axios, { CancelTokenSource } from 'axios';
-import { FetchTodayShoppingListRes, RegularShoppingList, ShoppingList } from './types';
-import { failedFetchDataAction, fetchTodayShoppingListAction } from './actions';
+import {
+  FetchMonthlyShoppingListRes,
+  FetchTodayShoppingListRes,
+  RegularShoppingList,
+  ShoppingList,
+} from './types';
+import {
+  failedFetchDataAction,
+  fetchMonthlyShoppingListAction,
+  fetchTodayShoppingListAction,
+} from './actions';
 import { push } from 'connected-react-router';
 
 export const fetchTodayShoppingList = (
@@ -23,6 +32,37 @@ export const fetchTodayShoppingList = (
       const todayShoppingList: ShoppingList = result.data.shopping_list;
 
       dispatch(fetchTodayShoppingListAction(regularShoppingList, todayShoppingList));
+    } catch (error) {
+      if (axios.isCancel(error)) {
+        return;
+      } else {
+        dispatch(failedFetchDataAction(error.response.data.error.message));
+        if (error.response.status === 401) {
+          dispatch(push('/login'));
+        }
+      }
+    }
+  };
+};
+
+export const fetchMonthlyShoppingList = (
+  year: string,
+  month: string,
+  signal: CancelTokenSource
+) => {
+  return async (dispatch: Dispatch<Action>) => {
+    try {
+      const result = await axios.get<FetchMonthlyShoppingListRes>(
+        `${process.env.REACT_APP_TODO_API_HOST}/shopping-list/${year}-${month}/daily`,
+        {
+          cancelToken: signal.token,
+          withCredentials: true,
+        }
+      );
+      const regularShoppingList: RegularShoppingList = result.data.regular_shopping_list;
+      const monthlyShoppingList: ShoppingList = result.data.shopping_list;
+
+      dispatch(fetchMonthlyShoppingListAction(regularShoppingList, monthlyShoppingList));
     } catch (error) {
       if (axios.isCancel(error)) {
         return;

--- a/src/reducks/shoppingList/reducers.ts
+++ b/src/reducks/shoppingList/reducers.ts
@@ -27,6 +27,11 @@ export const shoppingListReducers = (
         ...state,
         ...action.payload,
       };
+    case Actions.FETCH_MONTHLY_SHOPPING_LIST_BY_CATEGORIES:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.FAILED_FETCH_DATA:
       return {
         ...state,

--- a/src/reducks/shoppingList/reducers.ts
+++ b/src/reducks/shoppingList/reducers.ts
@@ -7,12 +7,17 @@ export const shoppingListReducers = (
   action: ShoppingListActions
 ) => {
   switch (action.type) {
-    case Actions.START_FETCH_DATA:
+    case Actions.WAITING_FETCH_DATA:
       return {
         ...state,
         ...action.payload,
       };
     case Actions.FETCH_TODAY_SHOPPING_LIST:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FETCH_MONTHLY_SHOPPING_LIST:
       return {
         ...state,
         ...action.payload,

--- a/src/reducks/shoppingList/reducers.ts
+++ b/src/reducks/shoppingList/reducers.ts
@@ -17,6 +17,11 @@ export const shoppingListReducers = (
         ...state,
         ...action.payload,
       };
+    case Actions.FETCH_TODAY_SHOPPING_LIST_BY_CATEGORIES:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.FETCH_MONTHLY_SHOPPING_LIST:
       return {
         ...state,

--- a/src/reducks/shoppingList/types.ts
+++ b/src/reducks/shoppingList/types.ts
@@ -69,3 +69,8 @@ export interface FetchTodayShoppingListRes {
   regular_shopping_list: RegularShoppingList;
   shopping_list: ShoppingList;
 }
+
+export interface FetchMonthlyShoppingListRes {
+  regular_shopping_list: RegularShoppingList;
+  shopping_list: ShoppingList;
+}

--- a/src/reducks/shoppingList/types.ts
+++ b/src/reducks/shoppingList/types.ts
@@ -70,6 +70,11 @@ export interface FetchTodayShoppingListRes {
   shopping_list: ShoppingList;
 }
 
+export interface FetchTodayShoppingListByCategoriesRes {
+  regular_shopping_list: RegularShoppingList;
+  shopping_list_by_categories: ShoppingListByCategories;
+}
+
 export interface FetchMonthlyShoppingListRes {
   regular_shopping_list: RegularShoppingList;
   shopping_list: ShoppingList;

--- a/src/reducks/shoppingList/types.ts
+++ b/src/reducks/shoppingList/types.ts
@@ -79,3 +79,8 @@ export interface FetchMonthlyShoppingListRes {
   regular_shopping_list: RegularShoppingList;
   shopping_list: ShoppingList;
 }
+
+export interface FetchMonthlyShoppingListByCategoriesRes {
+  regular_shopping_list: RegularShoppingList;
+  shopping_list_by_categories: ShoppingListByCategories;
+}

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -75,7 +75,10 @@ const initialState = {
     todayShoppingListByCategories: [],
     monthlyShoppingList: [],
     monthlyShoppingListByCategories: [],
-    errorMessage: '',
+    error: {
+      statusCode: 0,
+      message: '',
+    },
   },
   todoList: {
     expiredTodoList: [],

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -75,7 +75,10 @@ export interface State {
     monthlyShoppingList: ShoppingList;
     monthlyShoppingListByCategories: ShoppingListByCategories;
     expiredShoppingList: ShoppingList;
-    errorMessage: string;
+    error: {
+      statusCode: number;
+      message: string;
+    };
   };
   todoList: {
     expiredTodoList: TodoList;

--- a/test/shopping-list-test/ShoppingList.test.ts
+++ b/test/shopping-list-test/ShoppingList.test.ts
@@ -1,12 +1,11 @@
-import React from 'react';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import MockAdapter from 'axios-mock-adapter';
 import {
-  fetchMonthlyShoppingList,
-  fetchMonthlyShoppingListByCategories,
   fetchTodayShoppingList,
   fetchTodayShoppingListByCategories,
+  fetchMonthlyShoppingList,
+  fetchMonthlyShoppingListByCategories,
 } from '../../src/reducks/shoppingList/operations';
 import axios from 'axios';
 import * as ShoppingListActions from '../../src/reducks/shoppingList/actions';

--- a/test/shopping-list-test/ShoppingList.test.tsx
+++ b/test/shopping-list-test/ShoppingList.test.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import MockAdapter from 'axios-mock-adapter';
-import { fetchTodayShoppingList } from '../../src/reducks/shoppingList/operations';
+import {
+  fetchMonthlyShoppingList,
+  fetchTodayShoppingList,
+} from '../../src/reducks/shoppingList/operations';
 import axios from 'axios';
 import * as ShoppingListActions from '../../src/reducks/shoppingList/actions';
 import fetchTodayShoppingListResponse from './fetchTodayShoppingListResponse.json';
+import fetchMonthlyShoppingListResponse from './fetchMonthlyShoppingListResponse.json';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -240,6 +244,71 @@ describe('async actions shoppingList', () => {
 
     // @ts-ignore
     await fetchTodayShoppingList(year, month, date, signal)(store.dispatch);
+    expect(store.getActions()).toEqual(expectedAction);
+  });
+
+  it('get monthlyShoppingList and regularShoppingList if fetch succeeds', async () => {
+    const year = '2020';
+    const month = '12';
+    const url = `${process.env.REACT_APP_TODO_API_HOST}/shopping-list/${year}-${month}/daily`;
+    const signal = axios.CancelToken.source();
+
+    const mockResponse = JSON.stringify(fetchMonthlyShoppingListResponse);
+
+    const expectedAction = [
+      {
+        type: ShoppingListActions.FETCH_MONTHLY_SHOPPING_LIST,
+        payload: {
+          loading: false,
+          regularShoppingList: [
+            {
+              id: 1,
+              posted_date: '2020-12-23T17:10:11Z',
+              updated_date: '2020-12-23T17:10:11Z',
+              expected_purchase_date: '2020/12/24(木)',
+              cycle_type: 'monthly',
+              cycle: null,
+              purchase: '携帯料金',
+              shop: 'auショップ',
+              amount: 5000,
+              big_category_id: 9,
+              big_category_name: '通信費',
+              medium_category_id: 51,
+              medium_category_name: '携帯電話',
+              custom_category_id: null,
+              custom_category_name: null,
+              transaction_auto_add: true,
+            },
+          ],
+          monthlyShoppingList: [
+            {
+              id: 1,
+              posted_date: '2020-12-23T17:10:11Z',
+              updated_date: '2020-12-23T17:10:11Z',
+              expected_purchase_date: '2020/12/24(木)',
+              complete_flag: false,
+              purchase: '携帯料金',
+              shop: 'auショップ',
+              amount: 5000,
+              big_category_id: 9,
+              big_category_name: '通信費',
+              medium_category_id: 51,
+              medium_category_name: '携帯電話',
+              custom_category_id: null,
+              custom_category_name: null,
+              regular_shopping_list_id: 2,
+              transaction_auto_add: true,
+              related_transaction_data: null,
+            },
+          ],
+        },
+      },
+    ];
+
+    axiosMock.onGet(url).reply(200, mockResponse);
+
+    // @ts-ignore
+    await fetchMonthlyShoppingList(year, month, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAction);
   });
 });

--- a/test/shopping-list-test/ShoppingList.test.tsx
+++ b/test/shopping-list-test/ShoppingList.test.tsx
@@ -4,6 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import MockAdapter from 'axios-mock-adapter';
 import {
   fetchMonthlyShoppingList,
+  fetchMonthlyShoppingListByCategories,
   fetchTodayShoppingList,
   fetchTodayShoppingListByCategories,
 } from '../../src/reducks/shoppingList/operations';
@@ -12,6 +13,7 @@ import * as ShoppingListActions from '../../src/reducks/shoppingList/actions';
 import fetchTodayShoppingListResponse from './fetchTodayShoppingListResponse.json';
 import fetchTodayShoppingListByCategoriesResponse from './fetchTodayShoppingListByCategoriesResponse.json';
 import fetchMonthlyShoppingListResponse from './fetchMonthlyShoppingListResponse.json';
+import fetchMonthlyShoppingListByCategoriesResponse from './fetchMonthlyShoppingListByCategoriesResponse.json';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -382,6 +384,76 @@ describe('async actions shoppingList', () => {
 
     // @ts-ignore
     await fetchMonthlyShoppingList(year, month, signal)(store.dispatch);
+    expect(store.getActions()).toEqual(expectedAction);
+  });
+
+  it('get monthlyShoppingListByCategories and regularShoppingList if fetch succeeds', async () => {
+    const year = '2020';
+    const month = '12';
+    const url = `${process.env.REACT_APP_TODO_API_HOST}/shopping-list/${year}-${month}/categories`;
+    const signal = axios.CancelToken.source();
+
+    const mockResponse = JSON.stringify(fetchMonthlyShoppingListByCategoriesResponse);
+
+    const expectedAction = [
+      {
+        type: ShoppingListActions.FETCH_MONTHLY_SHOPPING_LIST_BY_CATEGORIES,
+        payload: {
+          loading: false,
+          regularShoppingList: [
+            {
+              id: 1,
+              posted_date: '2020-12-23T17:10:11Z',
+              updated_date: '2020-12-23T17:10:11Z',
+              expected_purchase_date: '2020/12/24(木)',
+              cycle_type: 'monthly',
+              cycle: null,
+              purchase: '携帯料金',
+              shop: 'auショップ',
+              amount: 5000,
+              big_category_id: 9,
+              big_category_name: '通信費',
+              medium_category_id: 51,
+              medium_category_name: '携帯電話',
+              custom_category_id: null,
+              custom_category_name: null,
+              transaction_auto_add: true,
+            },
+          ],
+          monthlyShoppingListByCategories: [
+            {
+              big_category_name: '通信費',
+              shopping_list: [
+                {
+                  id: 1,
+                  posted_date: '2020-12-23T17:10:11Z',
+                  updated_date: '2020-12-23T17:10:11Z',
+                  expected_purchase_date: '2020/12/24(木)',
+                  complete_flag: false,
+                  purchase: '携帯料金',
+                  shop: 'auショップ',
+                  amount: 5000,
+                  big_category_id: 9,
+                  big_category_name: '通信費',
+                  medium_category_id: 51,
+                  medium_category_name: '携帯電話',
+                  custom_category_id: null,
+                  custom_category_name: null,
+                  regular_shopping_list_id: 2,
+                  transaction_auto_add: true,
+                  related_transaction_data: null,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ];
+
+    axiosMock.onGet(url).reply(200, mockResponse);
+
+    // @ts-ignore
+    await fetchMonthlyShoppingListByCategories(year, month, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAction);
   });
 });

--- a/test/shopping-list-test/ShoppingList.test.tsx
+++ b/test/shopping-list-test/ShoppingList.test.tsx
@@ -5,10 +5,12 @@ import MockAdapter from 'axios-mock-adapter';
 import {
   fetchMonthlyShoppingList,
   fetchTodayShoppingList,
+  fetchTodayShoppingListByCategories,
 } from '../../src/reducks/shoppingList/operations';
 import axios from 'axios';
 import * as ShoppingListActions from '../../src/reducks/shoppingList/actions';
 import fetchTodayShoppingListResponse from './fetchTodayShoppingListResponse.json';
+import fetchTodayShoppingListByCategoriesResponse from './fetchTodayShoppingListByCategoriesResponse.json';
 import fetchMonthlyShoppingListResponse from './fetchMonthlyShoppingListResponse.json';
 
 const middlewares = [thunk];
@@ -244,6 +246,77 @@ describe('async actions shoppingList', () => {
 
     // @ts-ignore
     await fetchTodayShoppingList(year, month, date, signal)(store.dispatch);
+    expect(store.getActions()).toEqual(expectedAction);
+  });
+
+  it('get todayShoppingListByCategories and regularShoppingList if fetch succeeds', async () => {
+    const year = '2020';
+    const month = '12';
+    const date = '24';
+    const url = `${process.env.REACT_APP_TODO_API_HOST}/shopping-list/${year}-${month}-${date}/categories`;
+    const signal = axios.CancelToken.source();
+
+    const mockResponse = JSON.stringify(fetchTodayShoppingListByCategoriesResponse);
+
+    const expectedAction = [
+      {
+        type: ShoppingListActions.FETCH_TODAY_SHOPPING_LIST_BY_CATEGORIES,
+        payload: {
+          loading: false,
+          regularShoppingList: [
+            {
+              id: 1,
+              posted_date: '2020-12-23T17:10:11Z',
+              updated_date: '2020-12-23T17:10:11Z',
+              expected_purchase_date: '2020/12/24(木)',
+              cycle_type: 'monthly',
+              cycle: null,
+              purchase: '携帯料金',
+              shop: 'auショップ',
+              amount: 5000,
+              big_category_id: 9,
+              big_category_name: '通信費',
+              medium_category_id: 51,
+              medium_category_name: '携帯電話',
+              custom_category_id: null,
+              custom_category_name: null,
+              transaction_auto_add: true,
+            },
+          ],
+          todayShoppingListByCategories: [
+            {
+              big_category_name: '通信費',
+              shopping_list: [
+                {
+                  id: 1,
+                  posted_date: '2020-12-23T17:10:11Z',
+                  updated_date: '2020-12-23T17:10:11Z',
+                  expected_purchase_date: '2020/12/24(木)',
+                  complete_flag: false,
+                  purchase: '携帯料金',
+                  shop: 'auショップ',
+                  amount: 5000,
+                  big_category_id: 9,
+                  big_category_name: '通信費',
+                  medium_category_id: 51,
+                  medium_category_name: '携帯電話',
+                  custom_category_id: null,
+                  custom_category_name: null,
+                  regular_shopping_list_id: 2,
+                  transaction_auto_add: true,
+                  related_transaction_data: null,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ];
+
+    axiosMock.onGet(url).reply(200, mockResponse);
+
+    // @ts-ignore
+    await fetchTodayShoppingListByCategories(year, month, date, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAction);
   });
 

--- a/test/shopping-list-test/fetchMonthlyShoppingListByCategoriesResponse.json
+++ b/test/shopping-list-test/fetchMonthlyShoppingListByCategoriesResponse.json
@@ -1,0 +1,48 @@
+{
+  "regular_shopping_list": [
+    {
+      "id": 1,
+      "posted_date": "2020-12-23T17:10:11Z",
+      "updated_date": "2020-12-23T17:10:11Z",
+      "expected_purchase_date": "2020/12/24(木)",
+      "cycle_type": "monthly",
+      "cycle": null,
+      "purchase": "携帯料金",
+      "shop": "auショップ",
+      "amount": 5000,
+      "big_category_id": 9,
+      "big_category_name": "通信費",
+      "medium_category_id": 51,
+      "medium_category_name": "携帯電話",
+      "custom_category_id": null,
+      "custom_category_name": null,
+      "transaction_auto_add": true
+    }
+  ],
+  "shopping_list_by_categories": [
+    {
+      "big_category_name": "通信費",
+      "shopping_list": [
+        {
+          "id": 1,
+          "posted_date": "2020-12-23T17:10:11Z",
+          "updated_date": "2020-12-23T17:10:11Z",
+          "expected_purchase_date": "2020/12/24(木)",
+          "complete_flag": false,
+          "purchase": "携帯料金",
+          "shop": "auショップ",
+          "amount": 5000,
+          "big_category_id": 9,
+          "big_category_name": "通信費",
+          "medium_category_id": 51,
+          "medium_category_name": "携帯電話",
+          "custom_category_id": null,
+          "custom_category_name": null,
+          "regular_shopping_list_id": 2,
+          "transaction_auto_add": true,
+          "related_transaction_data": null
+        }
+      ]
+    }
+  ]
+}

--- a/test/shopping-list-test/fetchMonthlyShoppingListResponse.json
+++ b/test/shopping-list-test/fetchMonthlyShoppingListResponse.json
@@ -1,0 +1,43 @@
+{
+  "regular_shopping_list": [
+    {
+      "id": 1,
+      "posted_date": "2020-12-23T17:10:11Z",
+      "updated_date": "2020-12-23T17:10:11Z",
+      "expected_purchase_date": "2020/12/24(木)",
+      "cycle_type": "monthly",
+      "cycle": null,
+      "purchase": "携帯料金",
+      "shop": "auショップ",
+      "amount": 5000,
+      "big_category_id": 9,
+      "big_category_name": "通信費",
+      "medium_category_id": 51,
+      "medium_category_name": "携帯電話",
+      "custom_category_id": null,
+      "custom_category_name": null,
+      "transaction_auto_add": true
+    }
+  ],
+  "shopping_list": [
+    {
+      "id": 1,
+      "posted_date": "2020-12-23T17:10:11Z",
+      "updated_date": "2020-12-23T17:10:11Z",
+      "expected_purchase_date": "2020/12/24(木)",
+      "complete_flag": false,
+      "purchase": "携帯料金",
+      "shop": "auショップ",
+      "amount": 5000,
+      "big_category_id": 9,
+      "big_category_name": "通信費",
+      "medium_category_id": 51,
+      "medium_category_name": "携帯電話",
+      "custom_category_id": null,
+      "custom_category_name": null,
+      "regular_shopping_list_id": 2,
+      "transaction_auto_add": true,
+      "related_transaction_data": null
+    }
+  ]
+}

--- a/test/shopping-list-test/fetchTodayShoppingListByCategoriesResponse.json
+++ b/test/shopping-list-test/fetchTodayShoppingListByCategoriesResponse.json
@@ -1,0 +1,48 @@
+{
+  "regular_shopping_list": [
+    {
+      "id": 1,
+      "posted_date": "2020-12-23T17:10:11Z",
+      "updated_date": "2020-12-23T17:10:11Z",
+      "expected_purchase_date": "2020/12/24(木)",
+      "cycle_type": "monthly",
+      "cycle": null,
+      "purchase": "携帯料金",
+      "shop": "auショップ",
+      "amount": 5000,
+      "big_category_id": 9,
+      "big_category_name": "通信費",
+      "medium_category_id": 51,
+      "medium_category_name": "携帯電話",
+      "custom_category_id": null,
+      "custom_category_name": null,
+      "transaction_auto_add": true
+    }
+  ],
+  "shopping_list_by_categories": [
+    {
+      "big_category_name": "通信費",
+      "shopping_list": [
+        {
+          "id": 1,
+          "posted_date": "2020-12-23T17:10:11Z",
+          "updated_date": "2020-12-23T17:10:11Z",
+          "expected_purchase_date": "2020/12/24(木)",
+          "complete_flag": false,
+          "purchase": "携帯料金",
+          "shop": "auショップ",
+          "amount": 5000,
+          "big_category_id": 9,
+          "big_category_name": "通信費",
+          "medium_category_id": 51,
+          "medium_category_name": "携帯電話",
+          "custom_category_id": null,
+          "custom_category_name": null,
+          "regular_shopping_list_id": 2,
+          "transaction_auto_add": true,
+          "related_transaction_data": null
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- バックエンドへのリクエストに関してですが、URL内の動的に変わる値は、バックエンドが修正してから、クエリパラメータでの定義へ変更しようと思います。
- 「月の買い物リスト」を取得する`fetchMonthlyShoppingList()`を追加しました。 01b4df7
- 「今日のカテゴリー別の買い物リスト」を取得する`fetchTodayShoppingListByCategories()`を追加しました。 8da6354
- 「月のカテゴリー別の買い物リスト」を取得する`fetchMonthlyShoppingListByCategories()`を追加しました。 ff4a8fd