### PR TITLE
Modify pay off to show multiple recipients

### DIFF
--- a/src/assets/accounting/payoff.scss
+++ b/src/assets/accounting/payoff.scss
@@ -5,7 +5,7 @@
   margin: 0 auto;
 
   &__box-size {
-  width: 50%;
+    width: 50%;
   }
 
   &__background {
@@ -103,7 +103,7 @@
 
   &__account-li {
     list-style: none;
-    margin-left: 35px;
+    margin-left: 25px;
   }
 
   &__sub-title {
@@ -112,5 +112,17 @@
     &__color-red {
       color: $danger-color;
     }
+  }
+
+  &__recipient-field {
+    width: 100%;
+  }
+
+  &__check-box {
+    width: calc((100% - 106px) * 0.2);
+  }
+
+  &__user-name {
+    width: calc((100% - 50px) * 0.4);
   }
 }

--- a/src/assets/variable.scss
+++ b/src/assets/variable.scss
@@ -4,6 +4,7 @@ $display-btn-main_color: #ff802b;
 $display-btn-sub_color: #FFC107;
 $main_background_color: #f5f5f5;
 $danger-color: #E74C3C;
+$link-color: #0000ff;
 $small-font-size:12px;
 $middle-font-size:14px;
 $medium-font_size:16px;

--- a/src/components/account/yearly-account.scss
+++ b/src/components/account/yearly-account.scss
@@ -26,6 +26,7 @@
 
   &__year-position {
     text-align: center;
+    width: 100%;
   }
 
   &__yearly-table {
@@ -54,29 +55,12 @@
   }
 
   &__payoff-link {
-    border-bottom: 1px solid $main_color;
-    color: $main_color;
+    border-bottom: 1px solid $link-color;
+    color: $link-color;
     cursor: pointer;
-    //padding: 0.1em 0.3em;
-    //position: relative;
-    //display: inline-block;
-    //transition: .3s;
-    //
-    //&:hover {
-    //  color: $main_color;
-    //}
+
+    &:hover {
+      opacity: 0.6;
+    }
   }
-  //&__payoff-link::after {
-  //  content: '';
-  //  position: absolute;
-  //  bottom: 0;
-  //  left: 0;
-  //  width: 0;
-  //  height: 1px;
-  //  background-color: $main_color;
-  //  transition: .3s;
-  //}
-  //&__payoff-link:hover::after {
-  //    width: 100%;
-  // }
 }

--- a/src/components/uikit/SelectYears.tsx
+++ b/src/components/uikit/SelectYears.tsx
@@ -80,7 +80,13 @@ const SelectYears = (props: SelectYearsProps) => {
       {props.selectedYear !== year && (
         <button
           className="select-years__display-btn select-years__display-btn--small"
-          onClick={() => props.setSelectedYear(year)}
+          onClick={() => {
+            const currentYearQuery = { ...queryParams, '?year': year };
+            history.push({ search: decodeURIComponent(qs.stringify(currentYearQuery)) });
+
+            setItemYear(year);
+            props.setSelectedYear(year);
+          }}
         >
           今年を表示
         </button>

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -507,17 +507,13 @@ export const editGroupAccount = (
 
       prevGroupAccountList.group_accounts_list_by_payer = prevGroupAccountList.group_accounts_list_by_payer.map(
         (accountByPayer) => {
-          if (prevGroupAccountList.group_id === editedGroupAccount.group_id) {
-            accountByPayer.group_accounts_list = accountByPayer.group_accounts_list.map(
-              (account) => {
-                if (account.payer_user_id === editedGroupAccount.payer_user_id) {
-                  return editedGroupAccount;
-                }
+          accountByPayer.group_accounts_list = accountByPayer.group_accounts_list.map((account) => {
+            if (account.id === editedGroupAccount.id) {
+              return editedGroupAccount;
+            }
 
-                return account;
-              }
-            );
-          }
+            return account;
+          });
 
           return accountByPayer;
         }

--- a/src/reducks/groupTransactions/selectors.ts
+++ b/src/reducks/groupTransactions/selectors.ts
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect';
 import { State } from '../store/types';
 import { incomeTransactionType } from '../../lib/constant';
-import { GroupAccounts } from './types';
 
 const groupTransactionsSelector = (state: State) => state.groupTransactions;
 
@@ -15,14 +14,14 @@ export const getGroupLatestTransactions = createSelector(
   (state) => state.groupLatestTransactionsList
 );
 
-export const getGroupAccountList = createSelector(
-  [groupTransactionsSelector],
-  (state) => state.groupAccountList
-);
-
 export const getGroupYearlyAccountList = createSelector(
   [groupTransactionsSelector],
   (state) => state.groupYearlyAccountList
+);
+
+export const getGroupAccountList = createSelector(
+  [groupTransactionsSelector],
+  (state) => state.groupAccountList
 );
 
 export const getDeleteAccountMessage = createSelector(
@@ -73,14 +72,24 @@ export const getAccountCompleteJudgment = createSelector([groupAccountList], (gr
   return completeAccount;
 });
 
-export const getAccountListByPayer = createSelector([groupAccountList], (groupAccountList) => {
-  const accounts: GroupAccounts = [];
+export const getRemainingTotalAmount = createSelector([groupAccountList], (groupAccountList) => {
+  const remainingAmountList: number[] = [];
 
-  groupAccountList.group_accounts_list_by_payer.map((account) => {
-    accounts.push(...account.group_accounts_list);
-  });
+  for (const groupAccountListByPayer of groupAccountList.group_accounts_list_by_payer) {
+    let remainingAmount = 0;
 
-  return accounts;
+    for (const account of groupAccountListByPayer.group_accounts_list) {
+      if (account.receipt_confirmation) {
+        continue;
+      }
+
+      remainingAmount += account.payment_amount;
+    }
+
+    remainingAmountList.push(remainingAmount);
+  }
+
+  return remainingAmountList;
 });
 
 const groupTransactionsList = (state: State) => state.groupTransactions.groupTransactionsList;

--- a/src/reducks/groupTransactions/types.ts
+++ b/src/reducks/groupTransactions/types.ts
@@ -57,6 +57,7 @@ export interface GroupAccount {
   month: string;
   payer_user_id: string;
   recipient_user_id: string;
+  recipient_user_name: string;
   payment_amount: number;
   payment_confirmation: boolean;
   receipt_confirmation: boolean;
@@ -65,7 +66,8 @@ export interface GroupAccount {
 export interface GroupAccounts extends Array<GroupAccount> {}
 
 export interface GroupAccountByPayer {
-  payer_user_id: number;
+  payer_user_id: string;
+  payer_user_name: string;
   group_accounts_list: GroupAccounts;
 }
 

--- a/src/templates/PayOff.tsx
+++ b/src/templates/PayOff.tsx
@@ -13,8 +13,9 @@ import {
   getGroupAccountList,
   getStatusNotFoundMessage,
   getAccountCompleteJudgment,
-  getAccountListByPayer,
+  getRemainingTotalAmount,
 } from '../reducks/groupTransactions/selectors';
+import { getUserId } from '../reducks/users/selectors';
 import { getApprovedGroups } from '../reducks/groups/selectors';
 import PayOffBody from '../components/account/PayOffBody';
 import { Header } from '../components/header';
@@ -35,8 +36,9 @@ const PayOff = (props: PayOffProps) => {
   const groupAccountList = useSelector(getGroupAccountList);
   const badRequestMessage = useSelector(getStatusNotFoundMessage);
   const completeJudge = useSelector(getAccountCompleteJudgment);
-  const accountListByPayer = useSelector(getAccountListByPayer);
   const approvedGroup = useSelector(getApprovedGroups);
+  const remainingTotalAmount = useSelector(getRemainingTotalAmount);
+  const currentUserId = useSelector(getUserId);
   const searchLocation = useLocation().search;
   const getQuery = () => {
     return new URLSearchParams(searchLocation);
@@ -152,32 +154,34 @@ const PayOff = (props: PayOffProps) => {
                 />
               </div>
               <div className="payoff__spacer-small" />
-              <div className="payoff__amount-list">
-                <div className="payoff__account-form">
-                  合計支払金額
-                  <div className="payoff__amount-position">
-                    {displayAmount(groupAccountList.group_total_payment_amount)
-                      ? groupAccountList.group_total_payment_amount.toLocaleString()
-                      : 0}
+              {currentSelectMonth === subMonth && (
+                <div className="payoff__amount-list">
+                  <div className="payoff__account-form">
+                    合計支払金額
+                    <div className="payoff__amount-position">
+                      {displayAmount(groupAccountList.group_total_payment_amount)
+                        ? groupAccountList.group_total_payment_amount.toLocaleString()
+                        : 0}
+                    </div>
+                  </div>
+                  <div className="payoff__account-form">
+                    1人あたり平均支払金額
+                    <div className="payoff__amount-position">
+                      {displayAmount(groupAccountList.group_average_payment_amount)
+                        ? groupAccountList.group_average_payment_amount.toLocaleString()
+                        : 0}
+                    </div>
+                  </div>
+                  <div className="payoff__account-form">
+                    会計後支払残額
+                    <div className="payoff__amount-position">
+                      {displayAmount(groupAccountList.group_remaining_amount)
+                        ? groupAccountList.group_remaining_amount.toLocaleString()
+                        : 0}
+                    </div>
                   </div>
                 </div>
-                <div className="payoff__account-form">
-                  1人あたり平均支払金額
-                  <div className="payoff__amount-position">
-                    {displayAmount(groupAccountList.group_average_payment_amount)
-                      ? groupAccountList.group_average_payment_amount.toLocaleString()
-                      : 0}
-                  </div>
-                </div>
-                <div className="payoff__account-form">
-                  会計後支払残額
-                  <div className="payoff__amount-position">
-                    {displayAmount(groupAccountList.group_remaining_amount)
-                      ? groupAccountList.group_remaining_amount.toLocaleString()
-                      : 0}
-                  </div>
-                </div>
-              </div>
+              )}
               <p className="payoff__error-message">
                 {currentSelectMonth === subMonth ? '' : message}
               </p>
@@ -188,7 +192,8 @@ const PayOff = (props: PayOffProps) => {
                 selectMonth={subMonth}
                 selectYear={String(props.selectedYear)}
                 completeJudge={completeJudge}
-                accountListByPayer={accountListByPayer}
+                remainingTotalAmount={remainingTotalAmount}
+                currentUserId={currentUserId}
               />
             </div>
           </div>

--- a/src/templates/YearlyAccount.tsx
+++ b/src/templates/YearlyAccount.tsx
@@ -71,10 +71,10 @@ const YearlyAccount = () => {
         {!currentItem && searchLocation.length === queryParamsLength ? (
           <>
             <div className="yearly-account__spacer yearly-account__spacer--large" />
+            <div className="yearly-account__year-position">
+              <SelectYears selectedYear={selectedYear} setSelectedYear={setSelectedYear} />
+            </div>
             <div className="yearly-account__backGround">
-              <div className="yearly-account__year-position">
-                <SelectYears selectedYear={selectedYear} setSelectedYear={setSelectedYear} />
-              </div>
               <div className="yearly-account__spacer--medium" />
               <table className="yearly-account__yearly-table">
                 <tbody>

--- a/test/group-transactions-test/GroupTransactions.test.tsx
+++ b/test/group-transactions-test/GroupTransactions.test.tsx
@@ -534,7 +534,7 @@ describe('async actions groupTransactions', () => {
     };
 
     const groupId = 1;
-    const year = 2020;
+    const year = '2020';
     const customMonth = '11';
     const editAccountId = 14;
     const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMonth}/account/${editAccountId}`;


### PR DESCRIPTION
- 受取人が複数いる場合にまとめて表示できるように`PayOffBody.tsx`の`groupAccount.group_accounts_list.map()`の位置を修正し
   ました。

- 支払人が1人の場合に残支払金額の合計値を表示できるように`groupTransacions / selectors`に`getRemainingTotalAmount`を追加
  しました。

- `recipient_user_id , payer_user_id`の代わりに名前を表示するために`groupTransactions / types`に
   `recipient_user_name, payer_user_id`を追加しました。