### PR TITLE
Modify YearlyBudgets and YearlyBudgetsRow in budgets and groupBudgets

### DIFF
--- a/src/components/budget/EditGroupStandardBudgets.tsx
+++ b/src/components/budget/EditGroupStandardBudgets.tsx
@@ -17,6 +17,7 @@ import TextField from '@material-ui/core/TextField';
 import GenericButton from '../uikit/GenericButton';
 import { getGroupPathYear, getGroupPathMonth } from '../../lib/path';
 import { fetchGroups } from '../../reducks/groups/operations';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 
 const EditGroupStandardBudgets = () => {
   const dispatch = useDispatch();
@@ -61,6 +62,14 @@ const EditGroupStandardBudgets = () => {
     <>
       <div className="budget__spacer budget__spacer--medium" />
       <div className="budget budget__background budget__background__table">
+        <div className="budget__back-btn--position">
+          <button
+            className="budget__back-btn"
+            onClick={() => dispatch(push(`/group/${id}/yearly/budgets`))}
+          >
+            <ChevronLeftIcon />
+          </button>
+        </div>
         <div className="budget__spacer budget__spacer--medium" />
         <div className="budget__total-budget budget__total-budget__position">カスタム予算追加</div>
         <div className="budget__total-budget budget__total-budget__space">{yearsInGroup}</div>

--- a/src/components/budget/EditGroupStandardBudgets.tsx
+++ b/src/components/budget/EditGroupStandardBudgets.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router';
+import { push } from 'connected-react-router';
+import axios, { CancelTokenSource } from 'axios';
 import {
   fetchGroupStandardBudgets,
   addGroupCustomBudgets,
@@ -11,12 +14,9 @@ import {
   getGroupTotalStandardBudget,
 } from '../../reducks/groupBudgets/selectors';
 import TextField from '@material-ui/core/TextField';
-import { push } from 'connected-react-router';
 import GenericButton from '../uikit/GenericButton';
 import { getGroupPathYear, getGroupPathMonth } from '../../lib/path';
 import { fetchGroups } from '../../reducks/groups/operations';
-import axios, { CancelTokenSource } from 'axios';
-import { useParams } from 'react-router';
 
 const EditGroupStandardBudgets = () => {
   const dispatch = useDispatch();
@@ -27,8 +27,8 @@ const EditGroupStandardBudgets = () => {
   const groupCustomBudgetsList = useSelector(getGroupCustomBudgets);
   const groupTotalStandardBudget = useSelector(getGroupTotalStandardBudget);
   const [groupCustomBudgets, setGroupCustomBudgets] = useState<GroupCustomBudgetsList>([]);
-  const unAddCustomBudgets = groupCustomBudgets === groupCustomBudgetsList;
   const [editing, setEditing] = useState<boolean>(false);
+  const unAddCustomBudgets = groupCustomBudgets === groupCustomBudgetsList;
 
   const fetchEditGroupStandardBudgetsData = (signal: CancelTokenSource) => {
     async function fetchGroupBudgets(signal: CancelTokenSource) {
@@ -62,10 +62,10 @@ const EditGroupStandardBudgets = () => {
       <div className="budget__spacer budget__spacer--medium" />
       <div className="budget budget__background budget__background__table">
         <div className="budget__spacer budget__spacer--medium" />
-        <div className="budget__total-budget budget__total-budget__position">標準予算設定</div>
+        <div className="budget__total-budget budget__total-budget__position">カスタム予算追加</div>
         <div className="budget__total-budget budget__total-budget__space">{yearsInGroup}</div>
         <div className="budget__total-budget budget__total-budget__space">
-          総予算 ¥ {groupTotalStandardBudget}
+          総予算 ¥ {groupTotalStandardBudget.toLocaleString()}
         </div>
         <div className="budget__spacer budget__spacer--medium" />
         <table className="budget budget__background__table">

--- a/src/components/budget/GroupCustomBudgets.tsx
+++ b/src/components/budget/GroupCustomBudgets.tsx
@@ -17,6 +17,7 @@ import TextField from '@material-ui/core/TextField';
 import GenericButton from '../uikit/GenericButton';
 import { getGroupPathYear, getGroupPathMonth } from '../../lib/path';
 import './budget.scss';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 
 const GroupCustomBudgets = () => {
   const dispatch = useDispatch();
@@ -57,11 +58,19 @@ const GroupCustomBudgets = () => {
     <>
       <div className="budget__spacer budget__spacer--medium" />
       <div className="budget budget__background budget__background__table">
+        <div className="budget__back-btn--position">
+          <button
+            className="budget__back-btn"
+            onClick={() => dispatch(push(`/group/${id}/yearly/budgets`))}
+          >
+            <ChevronLeftIcon />
+          </button>
+        </div>
         <div className="budget__spacer budget__spacer--medium" />
-        <div className="budget__total-budget budget__total-budget__position">標準予算設定</div>
+        <div className="budget__total-budget budget__total-budget__position">カスタム予算編集</div>
         <div className="budget__total-budget budget__total-budget__space">{yearsInGroup}</div>
         <div className="budget__total-budget budget__total-budget__space">
-          総予算 ¥ {groupTotalCustomBudget}
+          総予算 ¥ {groupTotalCustomBudget.toLocaleString()}
         </div>
         <div className="budget__spacer budget__spacer--medium" />
         <table className="budget budget__background__table">

--- a/src/components/budget/GroupStandardBudgets.tsx
+++ b/src/components/budget/GroupStandardBudgets.tsx
@@ -55,7 +55,7 @@ const GroupStandardBudgets = () => {
         <div className="budget__spacer budget__spacer--medium" />
         <div className="budget__total-budget budget__total-budget__position">標準予算設定</div>
         <div className="budget__total-budget budget__total-budget__space">
-          総予算 ¥ {groupTotalStandardBudget}
+          総予算 ¥ {groupTotalStandardBudget.toLocaleString()}
         </div>
         <div className="budget__spacer budget__spacer--medium" />
         <table className="budget budget__background__table">
@@ -77,7 +77,9 @@ const GroupStandardBudgets = () => {
                   <td className="budget__td" scope="row">
                     {groupBudget.big_category_name}
                   </td>
-                  <td className="budget__td">￥ {groupBudget.last_month_expenses}</td>
+                  <td className="budget__td">
+                    ￥ {groupBudget.last_month_expenses.toLocaleString()}
+                  </td>
                   <td className="budget__td" align="center">
                     <TextField
                       size={'small'}
@@ -101,6 +103,7 @@ const GroupStandardBudgets = () => {
             onClick={() => {
               dispatch(
                 editGroupStandardBudgets(
+                  Number(id),
                   groupStandardBudgets.map((groupBudget) => {
                     const { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
                     return {
@@ -111,6 +114,7 @@ const GroupStandardBudgets = () => {
                 )
               );
               setEditing(false);
+              window.scrollTo(0, 0);
             }}
           />
         </div>

--- a/src/components/budget/YearlyBudgetsRow.tsx
+++ b/src/components/budget/YearlyBudgetsRow.tsx
@@ -1,40 +1,25 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchYearlyBudgets, deleteCustomBudgets } from '../../reducks/budgets/operations';
+import axios from 'axios';
 import { YearlyBudgetsList } from '../../reducks/budgets/types';
-import { State } from '../../reducks/store/types';
-import TableRow from '@material-ui/core/TableRow';
-import TableCell from '@material-ui/core/TableCell';
 import IconButton from '@material-ui/core/IconButton';
 import { push } from 'connected-react-router';
 import CreateIcon from '@material-ui/icons/Create';
 import DeleteIcon from '@material-ui/icons/Delete';
-import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { standardBudgetType } from '../../lib/constant';
 import { getYearlyBudgets } from '../../reducks/budgets/selectors';
 import { getPathTemplateName } from '../../lib/path';
-import axios from 'axios';
-
-const useStyles = makeStyles(() =>
-  createStyles({
-    tableSize: {
-      width: 250,
-      textAlign: 'center',
-    },
-  })
-);
 
 interface YearlyBudgetsRowProps {
   years: number;
 }
 
 const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
-  const classes = useStyles();
   const dispatch = useDispatch();
   const year = props.years;
   const pathName = getPathTemplateName(window.location.pathname);
-  const selector = useSelector((state: State) => state);
-  const yearlyBudgets = getYearlyBudgets(selector);
+  const yearlyBudgets = useSelector(getYearlyBudgets);
   const [yearBudget, setYearBudget] = useState<YearlyBudgetsList>({
     year: '',
     yearly_total_budget: 0,
@@ -67,44 +52,40 @@ const YearlyBudgetsRow = (props: YearlyBudgetsRowProps) => {
       const selectMonth = budget.month.slice(5, 7);
       const lastDate = new Date(year, Number(selectMonth), 0).getDate();
       return (
-        <TableRow key={index}>
-          <TableCell className={classes.tableSize} component="th" scope="row">
+        <tr key={index}>
+          <td className="budget__td" scope="row">
             {selectMonth}月
-          </TableCell>
-          <TableCell className={classes.tableSize}>{budgetsType()}</TableCell>
-          <TableCell className={classes.tableSize} align="center">
+          </td>
+          <td className="budget__td">{budgetsType()}</td>
+          <td className="budget__td" align="center">
             {budget.month}
             {'01'}日〜{budget.month}
             {lastDate}日
-          </TableCell>
-          <TableCell className={classes.tableSize} align="center">
-            ¥{budget.monthly_total_budget}
-          </TableCell>
-          <TableCell className={classes.tableSize} align="center">
+          </td>
+          <td className="budget__td" align="center">
+            ¥ {budget.monthly_total_budget.toLocaleString()}
+          </td>
+          <td className="budget__td" align="center">
             <IconButton
               size={'small'}
               onClick={() => dispatch(push(`${transitingBasePath}/${selectYear}/${selectMonth}`))}
             >
               <CreateIcon color={'primary'} />
             </IconButton>
-            {(() => {
-              if (budgetsType() === 'カスタム') {
-                return (
-                  <IconButton
-                    size={'small'}
-                    onClick={() => {
-                      if (window.confirm('カスタム予算を削除しても良いですか？ ')) {
-                        dispatch(deleteCustomBudgets(selectYear, selectMonth));
-                      }
-                    }}
-                  >
-                    <DeleteIcon color={'primary'} />
-                  </IconButton>
-                );
-              }
-            })()}
-          </TableCell>
-        </TableRow>
+            {budgetsType() === 'カスタム' && (
+              <IconButton
+                size={'small'}
+                onClick={() => {
+                  if (window.confirm('カスタム予算を削除しても良いですか？ ')) {
+                    dispatch(deleteCustomBudgets(selectYear, selectMonth));
+                  }
+                }}
+              >
+                <DeleteIcon color={'primary'} />
+              </IconButton>
+            )}
+          </td>
+        </tr>
       );
     });
   };

--- a/src/components/budget/budget.scss
+++ b/src/components/budget/budget.scss
@@ -101,4 +101,27 @@
     margin: 0 auto;
   }
 
+  &__back-btn {
+    background: linear-gradient(90deg, rgba(245,117,109,1) 0%, rgba(238,62,91,1) 45%);
+    border-radius: 0.2rem;
+    border: none;
+    color: white;
+    cursor: pointer;
+    font-size: 1.8rem;
+    flex-shrink: 0;
+    left: 0;
+    height: 1.8rem;
+
+    &:hover {
+      border-radius: 1.2rem;
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &--position {
+      padding: 8px;
+    }
+  }
 }

--- a/src/components/budget/budget.scss
+++ b/src/components/budget/budget.scss
@@ -1,4 +1,5 @@
 @import "src/assets/variable";
+@import "../uikit/tabs/switch-item-tabs";
 
 .budget {
   border-collapse: collapse;
@@ -28,11 +29,10 @@
 
   }
 
-  &__year-selector {
-    background-color: #fff;
-    display: flex;
+  &__switch-type {
+    width: 30%;
     margin: 0 auto;
-    width: 40%;
+
   }
 
   &__spacer {
@@ -43,7 +43,7 @@
       height: 30px;
     }
 
-    &__small {
+    &--small {
       height: 10px;
     }
   }

--- a/src/components/budget/yearly-budgets.scss
+++ b/src/components/budget/yearly-budgets.scss
@@ -1,0 +1,37 @@
+@import "../../assets/variable";
+@import "./budget";
+
+.yearly-budgets {
+
+  &__yearly-table-position {
+    align-items: center;
+    flex-direction: column;
+    margin: 0 auto;
+  }
+
+  &__background {
+    background-color: white;
+    border: 1px solid rgba(0, 0, 0, 0.3);
+    border-radius: 5px;
+    box-sizing: border-box;
+    height: auto;
+    margin: 40px auto;
+    width: 100%;
+    padding: 20px;
+
+    &__table {
+      border: 1px solid $border_color;
+      margin: 0 auto;
+    }
+
+  }
+
+  &__select-year {
+    text-align: center;
+  }
+
+  &__switch-tabs {
+    width: 30%;
+  }
+
+}

--- a/src/reducks/groupBudgets/operations.ts
+++ b/src/reducks/groupBudgets/operations.ts
@@ -46,7 +46,7 @@ export const fetchGroupStandardBudgets = (groupId: number, signal: CancelTokenSo
   };
 };
 
-export const editGroupStandardBudgets = (groupBudgets: GroupBudgetsReq) => {
+export const editGroupStandardBudgets = (groupId: number, groupBudgets: GroupBudgetsReq) => {
   const data = { standard_budgets: groupBudgets };
   return async (dispatch: Dispatch<Action>, getState: () => State): Promise<void> => {
     const validBudgets = groupBudgets.every((groupBudget) =>
@@ -60,7 +60,7 @@ export const editGroupStandardBudgets = (groupBudgets: GroupBudgetsReq) => {
 
     try {
       const result = await axios.put<GroupStandardBudgetsListRes>(
-        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/1/standard-budgets`,
+        `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`,
         JSON.stringify(data),
         {
           withCredentials: true,

--- a/src/templates/CustomBudgets.tsx
+++ b/src/templates/CustomBudgets.tsx
@@ -1,27 +1,25 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router';
+import { useLocation } from 'react-router';
 import axios from 'axios';
 import { fetchCustomBudgets, editCustomBudgets } from '../reducks/budgets/operations';
 import { getCustomBudgets, getTotalCustomBudget } from '../reducks/budgets/selectors';
 import { CustomBudgetsList } from '../reducks/budgets/types';
 import TextField from '@material-ui/core/TextField';
 import GenericButton from '../components/uikit/GenericButton';
-import ButtonGroup from '@material-ui/core/ButtonGroup';
-import Button from '@material-ui/core/Button';
 import { push } from 'connected-react-router';
-import { getPathYear, getPathMonth, getPathTemplateName } from '../lib/path';
+import { getPathYear, getPathMonth } from '../lib/path';
 import { fetchGroups } from '../reducks/groups/operations';
 import { Header } from '../components/header';
 import GroupCustomBudgets from '../components/budget/GroupCustomBudgets';
 import '../components/budget/budget.scss';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 
 const CustomBudgets = () => {
   const dispatch = useDispatch();
-  const { id } = useParams();
   const selectYear = getPathYear(window.location.pathname);
   const selectMonth = getPathMonth(window.location.pathname);
-  const pathName = getPathTemplateName(window.location.pathname);
+  const pathName = useLocation().pathname.split('/')[1];
   const yearsInPersonal = `${selectYear}年${selectMonth}月`;
   const customBudgetsList = useSelector(getCustomBudgets);
   const totalCustomBudget = useSelector(getTotalCustomBudget);
@@ -58,36 +56,18 @@ const CustomBudgets = () => {
     <>
       <Header />
       <main className="section__container">
-        <div className="budget__switching-btn">
-          <ButtonGroup className="budget__switch-btn--color" size="large" aria-label="budgets-kind">
-            <Button
-              className="budget__switch-btn budget__switch-btn"
-              onClick={() => {
-                {
-                  pathName !== 'group'
-                    ? dispatch(push('/standard/budgets'))
-                    : dispatch(push(`/group/${id}/standard/budgets`));
-                }
-              }}
-            >
-              標準予算
-            </Button>
-            <Button
-              className="budget__switch-btn budget__switch-btn"
-              onClick={() => {
-                pathName !== 'group'
-                  ? dispatch(push('/yearly/budgets'))
-                  : dispatch(push(`/group/${id}/yearly/budgets`));
-              }}
-            >
-              月別カスタム予算
-            </Button>
-          </ButtonGroup>
-        </div>
         {pathName !== 'group' ? (
           <>
             <div className="budget__spacer budget__spacer--medium" />
             <div className="budget budget__background budget__background__table">
+              <div className="budget__back-btn--position">
+                <button
+                  className="budget__back-btn"
+                  onClick={() => dispatch(push('/yearly/budgets'))}
+                >
+                  <ChevronLeftIcon />
+                </button>
+              </div>
               <div className="budget__spacer budget__spacer--medium" />
               <div className="budget__total-budget budget__total-budget__position">
                 カスタム予算編集
@@ -97,7 +77,7 @@ const CustomBudgets = () => {
               </div>
               <div className="budget__spacer budget__spacer--medium" />
               <div className="budget__total-budget budget__total-budget__space">
-                総予算 ¥ {totalCustomBudget}
+                総予算 ¥ {totalCustomBudget.toLocaleString()}
               </div>
               <div className="budget__spacer budget__spacer--medium" />
               <table className="budget budget__background__table">

--- a/src/templates/EditStandardBudgets.tsx
+++ b/src/templates/EditStandardBudgets.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useParams } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 import axios from 'axios';
 import {
   fetchStandardBudgets,
@@ -14,7 +14,7 @@ import ButtonGroup from '@material-ui/core/ButtonGroup';
 import Button from '@material-ui/core/Button';
 import { push } from 'connected-react-router';
 import GenericButton from '../components/uikit/GenericButton';
-import { getPathTemplateName, getPathYear, getPathMonth } from '../lib/path';
+import { getPathYear, getPathMonth } from '../lib/path';
 import EditGroupStandardBudgets from '../components/budget/EditGroupStandardBudgets';
 import { fetchGroups } from '../reducks/groups/operations';
 import { Header } from '../components/header';
@@ -22,10 +22,10 @@ import '../components/budget/budget.scss';
 
 const EditStandardBudgets = () => {
   const dispatch = useDispatch();
+  const { id } = useParams();
+  const pathName = useLocation().pathname.split('/')[1];
   const selectYear = getPathYear(window.location.pathname);
   const selectMonth = getPathMonth(window.location.pathname);
-  const pathName = getPathTemplateName(window.location.pathname);
-  const { id } = useParams();
   const customBudgetsList = useSelector(getCustomBudgets);
   const totalStandardBudget = useSelector(getTotalStandardBudget);
   const [customBudgets, setCustomBudgets] = useState<CustomBudgetsList>([]);
@@ -68,6 +68,7 @@ const EditStandardBudgets = () => {
       <Header />
       <main className="section__container">
         <div className="budget__switching-btn">
+          <div className="budget__spacer budget__spacer--medium" />
           <ButtonGroup className="budget__switch-btn--color" size="large" aria-label="budgets-kind">
             <Button
               className="budget__switch-btn budget__switch-btn"
@@ -105,7 +106,7 @@ const EditStandardBudgets = () => {
                 {yearsInPersonal}
               </div>
               <div className="budget__total-budget budget__total-budget__space">
-                総予算 ¥ {totalStandardBudget}
+                総予算 ¥ {totalStandardBudget.toLocaleString()}
               </div>
               <div className="budget__spacer budget__spacer--medium" />
               <table className="budget budget__background__table">

--- a/src/templates/EditStandardBudgets.tsx
+++ b/src/templates/EditStandardBudgets.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useParams } from 'react-router';
+import { useLocation } from 'react-router';
 import axios from 'axios';
 import {
   fetchStandardBudgets,
@@ -10,11 +10,10 @@ import {
 import { CustomBudgetsList } from '../reducks/budgets/types';
 import { getCustomBudgets, getTotalStandardBudget } from '../reducks/budgets/selectors';
 import TextField from '@material-ui/core/TextField';
-import ButtonGroup from '@material-ui/core/ButtonGroup';
-import Button from '@material-ui/core/Button';
 import { push } from 'connected-react-router';
 import GenericButton from '../components/uikit/GenericButton';
 import { getPathYear, getPathMonth } from '../lib/path';
+import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import EditGroupStandardBudgets from '../components/budget/EditGroupStandardBudgets';
 import { fetchGroups } from '../reducks/groups/operations';
 import { Header } from '../components/header';
@@ -22,7 +21,6 @@ import '../components/budget/budget.scss';
 
 const EditStandardBudgets = () => {
   const dispatch = useDispatch();
-  const { id } = useParams();
   const pathName = useLocation().pathname.split('/')[1];
   const selectYear = getPathYear(window.location.pathname);
   const selectMonth = getPathMonth(window.location.pathname);
@@ -67,37 +65,19 @@ const EditStandardBudgets = () => {
     <>
       <Header />
       <main className="section__container">
-        <div className="budget__switching-btn">
-          <div className="budget__spacer budget__spacer--medium" />
-          <ButtonGroup className="budget__switch-btn--color" size="large" aria-label="budgets-kind">
-            <Button
-              className="budget__switch-btn budget__switch-btn"
-              onClick={() => {
-                {
-                  pathName !== 'group'
-                    ? dispatch(push('/standard/budgets'))
-                    : dispatch(push(`/group/${id}/standard/budgets`));
-                }
-              }}
-            >
-              標準予算
-            </Button>
-            <Button
-              className="budget__switch-btn budget__switch-btn"
-              onClick={() => {
-                pathName !== 'group'
-                  ? dispatch(push('/yearly/budgets'))
-                  : dispatch(push(`/group/${id}/yearly/budgets`));
-              }}
-            >
-              月別カスタム予算
-            </Button>
-          </ButtonGroup>
-        </div>
+        <div className="budget__spacer budget__spacer--medium" />
         {pathName !== 'group' ? (
           <>
             <div className="budget__spacer budget__spacer--medium" />
             <div className="budget budget__background budget__background__table">
+              <div className="budget__back-btn--position">
+                <button
+                  className="budget__back-btn"
+                  onClick={() => dispatch(push('/yearly/budgets'))}
+                >
+                  <ChevronLeftIcon />
+                </button>
+              </div>
               <div className="budget__spacer budget__spacer--medium" />
               <div className="budget__total-budget budget__total-budget__position">
                 カスタム予算追加

--- a/src/templates/StandardBudgets.tsx
+++ b/src/templates/StandardBudgets.tsx
@@ -7,8 +7,6 @@ import { getStandardBudgets, getTotalStandardBudget } from '../reducks/budgets/s
 import { fetchStandardBudgets, editStandardBudgets } from '../reducks/budgets/operations';
 import { fetchGroups } from '../reducks/groups/operations';
 import { StandardBudgetsList } from '../reducks/budgets/types';
-import Button from '@material-ui/core/Button';
-import ButtonGroup from '@material-ui/core/ButtonGroup';
 import TextField from '@material-ui/core/TextField';
 import GenericButton from '../components/uikit/GenericButton';
 import GroupStandardBudgets from '../components/budget/GroupStandardBudgets';
@@ -53,7 +51,10 @@ const StandardBudgets = () => {
 
   const currentPageColor = () => {
     if (path === '/standard/budgets' || path === `/group/${id}/standard/budgets`) {
-      return { backgroundColor: '#ff6600', color: '#fff' };
+      return {
+        background: 'linear-gradient(90deg, rgba(245,117,109,1) 0%, rgba(238,62,91,1) 45%)',
+        color: '#fff',
+      };
     }
   };
 
@@ -61,32 +62,29 @@ const StandardBudgets = () => {
     <>
       <Header />
       <main className="section__container">
-        <div className="budget__switching-btn">
-          <ButtonGroup className="budget__switch-btn--color" size="large" aria-label="budgets-kind">
-            <Button
-              style={currentPageColor()}
-              className="budget__switch-btn budget__switch-btn"
-              onClick={() => {
-                {
-                  pathName !== 'group'
-                    ? dispatch(push('/standard/budgets'))
-                    : dispatch(push(`/group/${id}/standard/budgets`));
-                }
-              }}
-            >
-              標準予算
-            </Button>
-            <Button
-              className="budget__switch-btn budget__switch-btn"
-              onClick={() => {
+        <div className="budget__spacer budget__spacer--medium" />
+        <div className="switch-item-tabs__buttons budget__switch-type" aria-label="budgets-kind">
+          <button
+            style={currentPageColor()}
+            onClick={() => {
+              {
                 pathName !== 'group'
-                  ? dispatch(push('/yearly/budgets'))
-                  : dispatch(push(`/group/${id}/yearly/budgets`));
-              }}
-            >
-              月別カスタム予算
-            </Button>
-          </ButtonGroup>
+                  ? dispatch(push('/standard/budgets'))
+                  : dispatch(push(`/group/${id}/standard/budgets`));
+              }
+            }}
+          >
+            標準予算
+          </button>
+          <button
+            onClick={() => {
+              pathName !== 'group'
+                ? dispatch(push('/yearly/budgets'))
+                : dispatch(push(`/group/${id}/yearly/budgets`));
+            }}
+          >
+            月別カスタム予算
+          </button>
         </div>
         {pathName !== 'group' ? (
           <>
@@ -97,7 +95,7 @@ const StandardBudgets = () => {
                 標準予算設定
               </div>
               <div className="budget__total-budget budget__total-budget__space">
-                総予算 ¥ {totalStandardBudget}
+                総予算 ¥ {totalStandardBudget.toLocaleString()}
               </div>
               <div className="budget__spacer budget__spacer--medium" />
               <table className="budget budget__background__table">
@@ -118,7 +116,9 @@ const StandardBudgets = () => {
                         <td className="budget__td" scope="row">
                           {budget.big_category_name}
                         </td>
-                        <td className="budget__td">￥ {budget.last_month_expenses}</td>
+                        <td className="budget__td">
+                          ￥ {budget.last_month_expenses.toLocaleString()}
+                        </td>
                         <td className="budget__td" align="center">
                           <TextField
                             size={'small'}
@@ -151,6 +151,7 @@ const StandardBudgets = () => {
                         })
                       )
                     );
+                    window.scrollTo(0, 0);
                   }}
                 />
               </div>

--- a/src/templates/YearlyBudgets.tsx
+++ b/src/templates/YearlyBudgets.tsx
@@ -39,8 +39,11 @@ const YearlyBudgets = () => {
 
   useEffect(() => {
     const signal = axios.CancelToken.source();
-    dispatch(fetchStandardBudgets(signal));
-    dispatch(fetchYearlyBudgets(years, signal));
+    if (pathName !== 'group') {
+      dispatch(fetchStandardBudgets(signal));
+      dispatch(fetchYearlyBudgets(years, signal));
+    }
+
     return () => signal.cancel();
   }, []);
 

--- a/src/templates/YearlyBudgets.tsx
+++ b/src/templates/YearlyBudgets.tsx
@@ -1,85 +1,27 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useLocation, useParams } from 'react-router';
 import { push } from 'connected-react-router';
+import axios from 'axios';
 import { fetchStandardBudgets } from '../reducks/budgets/operations';
 import { getYearlyBudgets } from '../reducks/budgets/selectors';
 import { getGroupYearlyBudgets } from '../reducks/groupBudgets/selectors';
 import YearlyBudgetsRow from '../components/budget/YearlyBudgetsRow';
 import GroupYearlyBudgetsRow from '../components/budget/GroupYearlyBudgetsRow';
-import Button from '@material-ui/core/Button';
-import ButtonGroup from '@material-ui/core/ButtonGroup';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
-import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import TableBody from '@material-ui/core/TableBody';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableCell from '@material-ui/core/TableCell';
-import InputLabel from '@material-ui/core/InputLabel';
-import MenuItem from '@material-ui/core/MenuItem';
-import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
-import { State } from '../reducks/store/types';
-import { getPathTemplateName, getPathGroupId } from '../lib/path';
 import { fetchGroups } from '../reducks/groups/operations';
 import { Header } from '../components/header';
-import axios from 'axios';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    mainPosition: {
-      margin: '0 auto',
-      flexDirection: 'column',
-      alignItems: 'center',
-      '& > *': {
-        margin: theme.spacing(1),
-      },
-    },
-    buttonPosition: {
-      margin: '0 auto',
-      marginLeft: '24.5%',
-    },
-    buttonSize: {
-      width: 360,
-      marginTop: 40,
-      backgroundColor: '#fff',
-    },
-    tablePosition: {
-      margin: '0 auto',
-      marginTop: 40,
-      alignItems: 'center',
-      tableLayout: 'fixed',
-      width: '100%',
-    },
-    tableTop: {
-      backgroundColor: '#4db5fa',
-      width: 250,
-    },
-    formControl: {
-      display: 'flex',
-      margin: '0 auto',
-      marginTop: 40,
-      minWidth: 120,
-      width: 720,
-      backgroundColor: '#fff',
-    },
-    muiListItemRoot: {
-      backgroundColor: '#fff',
-    },
-  })
-);
+import { SelectYears } from '../components/uikit/';
+import '../components/budget/yearly-budgets.scss';
 
 const YearlyBudgets = () => {
-  const classes = useStyles();
-  const dispatch = useDispatch();
   const date = new Date();
-  const selector = useSelector((state: State) => state);
-  const totalBudget = getYearlyBudgets(selector).yearly_total_budget;
-  const totalGroupBudget = getGroupYearlyBudgets(selector).yearly_total_budget;
+  const { id } = useParams();
+  const dispatch = useDispatch();
+  const path = useLocation().pathname;
+  const pathName = useLocation().pathname.split('/')[1];
+  const totalBudget = useSelector(getYearlyBudgets).yearly_total_budget;
+  const totalGroupBudget = useSelector(getGroupYearlyBudgets).yearly_total_budget;
   const [years, setYears] = useState<number>(date.getFullYear());
-  const pathName = getPathTemplateName(window.location.pathname);
-  const groupId = getPathGroupId(window.location.pathname);
 
   useEffect(() => {
     if (pathName !== 'group') {
@@ -101,87 +43,77 @@ const YearlyBudgets = () => {
     return () => signal.cancel();
   }, []);
 
-  const handleDateChange = useCallback(
-    (event: React.ChangeEvent<{ value: unknown }>) => {
-      setYears(event.target.value as number);
-    },
-    [setYears]
-  );
+  const currentPageColor = () => {
+    if (path === '/yearly/budgets' || path === `/group/${id}/yearly/budgets`) {
+      return {
+        background: 'linear-gradient(90deg, rgba(245,117,109,1) 0%, rgba(238,62,91,1) 45%)',
+        color: '#fff',
+      };
+    }
+  };
 
   return (
     <>
       <Header />
       <main className="section__container">
-        <div className={classes.mainPosition}>
-          <ButtonGroup className={classes.buttonPosition} size="large" aria-label="budgets-kind">
-            <Button
-              className={classes.buttonSize}
-              onClick={() => {
-                {
+        <div className="yearly-budgets__yearly-table-position">
+          <div className="budget__spacer budget__spacer--medium" />
+          <div>
+            <div
+              className="switch-item-tabs__buttons budget__switch-type "
+              aria-label="budgets-kind"
+            >
+              <button
+                onClick={() => {
+                  {
+                    pathName !== 'group'
+                      ? dispatch(push('/standard/budgets'))
+                      : dispatch(push(`/group/${id}/standard/budgets`));
+                  }
+                }}
+              >
+                標準予算
+              </button>
+              <button
+                style={currentPageColor()}
+                onClick={() => {
                   pathName !== 'group'
-                    ? dispatch(push('/standard/budgets'))
-                    : dispatch(push(`/group/${groupId}/standard/budgets`));
-                }
-              }}
-            >
-              標準予算
-            </Button>
-            <Button
-              className={classes.buttonSize}
-              onClick={() => {
-                pathName !== 'group'
-                  ? dispatch(push('/yearly/budgets'))
-                  : dispatch(push(`/group/${groupId}/yearly/budgets`));
-              }}
-            >
-              月別カスタム予算
-            </Button>
-          </ButtonGroup>
-          <FormControl variant="outlined" className={classes.formControl}>
-            <InputLabel id="years">年</InputLabel>
-            <Select
-              id="years"
-              labelId="yearsList"
-              value={years}
-              onChange={handleDateChange}
-              label="年"
-            >
-              <MenuItem value={years + 1}>{years + 1}</MenuItem>
-              <MenuItem value={years}>{years}</MenuItem>
-              <MenuItem value={years - 1}>{years - 1}</MenuItem>
-            </Select>
-          </FormControl>
-          <h1>総額 ¥ {pathName !== 'group' ? totalBudget : totalGroupBudget}</h1>
-          <TableContainer className={classes.tablePosition} component={Paper}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell className={classes.tableTop} align="center">
-                    月
-                  </TableCell>
-                  <TableCell className={classes.tableTop} align="center">
-                    予算の種類
-                  </TableCell>
-                  <TableCell className={classes.tableTop} align="center">
-                    期間
-                  </TableCell>
-                  <TableCell className={classes.tableTop} align="center">
-                    1ヶ月の予算
-                  </TableCell>
-                  <TableCell className={classes.tableTop} align="center">
-                    操作
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
+                    ? dispatch(push('/yearly/budgets'))
+                    : dispatch(push(`/group/${id}/yearly/budgets`));
+                }}
+              >
+                月別カスタム予算
+              </button>
+            </div>
+          </div>
+          <div className="budget__spacer budget__spacer--small" />
+          <div className="yearly-budgets__select-year">
+            <SelectYears selectedYear={years} setSelectedYear={setYears} />
+          </div>
+          <h2>
+            総額 ¥{' '}
+            {pathName !== 'group'
+              ? totalBudget.toLocaleString()
+              : totalGroupBudget.toLocaleString()}
+          </h2>
+          <div className="yearly-budgets__background">
+            <table className="yearly-budgets__background__table">
+              <tbody>
+                <tr className="budget__th">
+                  <th align="center">月</th>
+                  <th align="center">予算の種類</th>
+                  <th align="center">期間</th>
+                  <th align="center">1ヶ月の予算</th>
+                  <th align="center">操作</th>
+                </tr>
                 {pathName !== 'group' ? (
                   <YearlyBudgetsRow years={years} />
                 ) : (
                   <GroupYearlyBudgetsRow years={years} />
                 )}
-              </TableBody>
-            </Table>
-          </TableContainer>
+              </tbody>
+            </table>
+          </div>
         </div>
       </main>
     </>

--- a/src/templates/YearlyBudgets.tsx
+++ b/src/templates/YearlyBudgets.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router';
 import { push } from 'connected-react-router';
 import axios from 'axios';
-import { fetchStandardBudgets } from '../reducks/budgets/operations';
+import { fetchStandardBudgets, fetchYearlyBudgets } from '../reducks/budgets/operations';
 import { getYearlyBudgets } from '../reducks/budgets/selectors';
 import { getGroupYearlyBudgets } from '../reducks/groupBudgets/selectors';
 import YearlyBudgetsRow from '../components/budget/YearlyBudgetsRow';
@@ -40,6 +40,7 @@ const YearlyBudgets = () => {
   useEffect(() => {
     const signal = axios.CancelToken.source();
     dispatch(fetchStandardBudgets(signal));
+    dispatch(fetchYearlyBudgets(years, signal));
     return () => signal.cancel();
   }, []);
 

--- a/test/group-budgets-test/GroupBudgets.test.tsx
+++ b/test/group-budgets-test/GroupBudgets.test.tsx
@@ -152,7 +152,7 @@ describe('async actions editGroupStandardBudgets', () => {
 
     axiosMock.onPut(url, mockRequest).reply(200, mockResponse);
 
-    await editGroupStandardBudgets(mockRequest.standard_budgets)(
+    await editGroupStandardBudgets(groupId, mockRequest.standard_budgets)(
       store.dispatch,
       // @ts-ignore
       getState


### PR DESCRIPTION
- 仮のgroupIdをセットしていた`editGroupStandardBudgets`関数に編集を行うgroupのidがセットされるように修正しました。

- `YearlyBudgets, YearlyBudgetsRow`で使用していたMaterial-uiの部分をHTMLタグに変更しました。

- `yearly-budgets.scss`ファイルを追加しました。

- `StandardBudgets`に標準予算の更新を行った後にページの最上部に戻る処理を追加しました。

- `EditStandardBudgets, CustomBudgets`に年間予算一覧画面の`YearlyBudgets`に戻るボタンを追加しました。
