### PR TITLE
Modify the display in SelectPayer to user_name

### DIFF
--- a/src/assets/history/daily-history.scss
+++ b/src/assets/history/daily-history.scss
@@ -25,7 +25,7 @@
 
   &__th {
     align-self: center;
-    background-color: $main_color;
+    background-color: $main_background_color;
     border: solid 1px $border_color;
     font-weight: $large-font_weight;
     font-size: $medium-font_size;
@@ -78,6 +78,7 @@
   }
 
   &__search-btn {
-    @include search-btn($main_color);
+    @include search-btn($display-btn-main_color);
+    color: white;
   }
 }

--- a/src/assets/history/history.scss
+++ b/src/assets/history/history.scss
@@ -31,6 +31,11 @@
       border-top-right-radius: $task-border_radius;
       border-bottom-right-radius: $task-border_radius;
     }
+
+    &:hover {
+      background-color: $main_color;
+      color: white;
+    }
   }
 
   &__selector {

--- a/src/assets/home/recent-input.scss
+++ b/src/assets/home/recent-input.scss
@@ -13,12 +13,11 @@
     border-radius: 5px;
     cursor: pointer;
     padding: 3px;
+    width: 240px;
   }
 
   &__recent-text {
     font-size: $medium-font_size;
-    width: 190px;
-    max-width: 250px;
   }
 
   &__category-icon {

--- a/src/assets/mixin/search-btn.scss
+++ b/src/assets/mixin/search-btn.scss
@@ -1,6 +1,7 @@
 @import "../variable";
 
 @mixin search-btn($search-btn-bg-color) {
+  border: 1px solid rgba(0, 0, 0, 0.3);
   background-color: $search-btn-bg-color;
   border-radius: $task-border_radius;
   cursor: pointer;

--- a/src/assets/modules/primaly-btn.scss
+++ b/src/assets/modules/primaly-btn.scss
@@ -1,6 +1,7 @@
 @import "src/assets/variable.scss";
 
 .btn--primary {
+  border: 1px solid rgba(0, 0, 0, 0.3);
   background-color: #ff6600;
   border-radius: 4px;
   color: white;

--- a/src/components/home/GroupRecentInputBody.tsx
+++ b/src/components/home/GroupRecentInputBody.tsx
@@ -81,18 +81,26 @@ const GroupRecentInputBody = (props: RecentInputBodyProps) => {
               <span style={payerColor(payment_user_id)}>￥ {amount.toLocaleString()}</span>
             </dt>
             <dt>
-              {shop !== null && (
+              {shop !== null ? (
                 <>
                   <span className="recent-input__item-font">店名: </span>
                   {shop}
                 </>
+              ) : (
+                <>
+                  <span className="recent-input__item-font">店名: </span> -
+                </>
               )}
             </dt>
             <dt>
-              {memo !== null && (
+              {memo !== null ? (
                 <>
                   <span className="recent-input__item-font">メモ :</span>
                   {memo}
+                </>
+              ) : (
+                <>
+                  <span className="recent-input__item-font">メモ :</span> -
                 </>
               )}
             </dt>

--- a/src/components/home/RecentInputBody.tsx
+++ b/src/components/home/RecentInputBody.tsx
@@ -58,17 +58,25 @@ const RecentInputBody = (props: RecentInputBodyProps) => {
             </dt>
             <dt className="recent-input__recent-text">￥ {amount.toLocaleString()}</dt>
             <dt>
-              {shop !== null && (
+              {shop !== null ? (
                 <>
                   <span className="recent-input__item-font">店名: </span> {shop}
+                </>
+              ) : (
+                <>
+                  <span className="recent-input__item-font">店名: </span> -
                 </>
               )}
             </dt>
             <dt>
-              {memo !== null && (
+              {memo !== null ? (
                 <>
                   <span className="recent-input__item-font">メモ: </span>
                   {memo}
+                </>
+              ) : (
+                <>
+                  <span className="recent-input__item-font">メモ: </span> -
                 </>
               )}
             </dt>

--- a/src/components/uikit/SelectPayer.tsx
+++ b/src/components/uikit/SelectPayer.tsx
@@ -51,7 +51,7 @@ const SelectPayer = (props: SelectPayerProps) => {
           ? paymentUsers().map((paymentUser) => {
               return (
                 <MenuItem key={paymentUser.user_id} value={paymentUser.user_id}>
-                  {paymentUser.user_id}
+                  {paymentUser.user_name}
                 </MenuItem>
               );
             })


### PR DESCRIPTION
- グループ画面で家計簿追加を行う際に支払人を選択する`SelectPayer`でuser_idを表示していましが、user_nameを表示する形に
  修正しました。

- 最新10件のtransactionを表示する`RecentInputBody`に店名, メモが空の場合は`-`を表示する形に修正しました。
