### PR TITLE
Modify operations for categories

### DIFF
--- a/src/components/uikit/BigCategroyInput.tsx
+++ b/src/components/uikit/BigCategroyInput.tsx
@@ -26,6 +26,7 @@ import {
 import CreateIcon from '@material-ui/icons/Create';
 import DeleteIcon from '@material-ui/icons/Delete';
 import '../../assets/modules/category-input.scss';
+import axios from 'axios';
 
 interface BigCategoryInputProps {
   kind: string;
@@ -132,6 +133,7 @@ const BigCategoryInput = React.forwardRef(
                                           className="category-input__icon-add"
                                           type={'button'}
                                           onClick={(event) => {
+                                            const signal = axios.CancelToken.source();
                                             event.stopPropagation();
                                             document.removeEventListener(
                                               'click',
@@ -141,7 +143,8 @@ const BigCategoryInput = React.forwardRef(
                                               editCustomCategories(
                                                 incomeAssociatedCategory.id,
                                                 editCustomCategoryName,
-                                                incomeAssociatedCategory.big_category_id
+                                                incomeAssociatedCategory.big_category_id,
+                                                signal
                                               ),
                                               editGroupCustomCategories(
                                                 incomeAssociatedCategory.id,
@@ -194,6 +197,7 @@ const BigCategoryInput = React.forwardRef(
                                         className="category-input__icon-delete"
                                         type={'button'}
                                         onClick={(event) => {
+                                          const signal = axios.CancelToken.source();
                                           event.stopPropagation();
                                           if (
                                             window.confirm('カスタムカテゴリーを削除しますか？')
@@ -201,7 +205,8 @@ const BigCategoryInput = React.forwardRef(
                                             operationSwitching(
                                               deleteCustomCategories(
                                                 incomeAssociatedCategory.id,
-                                                incomeAssociatedCategory.big_category_id
+                                                incomeAssociatedCategory.big_category_id,
+                                                signal
                                               ),
                                               deleteGroupCustomCategories(
                                                 incomeAssociatedCategory.id,
@@ -259,9 +264,14 @@ const BigCategoryInput = React.forwardRef(
                                   disabled={customCategoryName === ''}
                                   className="category-input__add-icon-btn category-input__add-icon-btn--plus-icon"
                                   onClick={(event) => {
+                                    const signal = axios.CancelToken.source();
                                     event.stopPropagation();
                                     operationSwitching(
-                                      addCustomCategories(customCategoryName, incomeCategory.id),
+                                      addCustomCategories(
+                                        customCategoryName,
+                                        incomeCategory.id,
+                                        signal
+                                      ),
                                       addGroupCustomCategories(
                                         customCategoryName,
                                         incomeCategory.id
@@ -330,6 +340,7 @@ const BigCategoryInput = React.forwardRef(
                                           className="category-input__icon-add"
                                           type={'button'}
                                           onClick={(event) => {
+                                            const signal = axios.CancelToken.source();
                                             event.stopPropagation();
                                             document.removeEventListener(
                                               'click',
@@ -339,7 +350,8 @@ const BigCategoryInput = React.forwardRef(
                                               editCustomCategories(
                                                 expenseAssociatedCategory.id,
                                                 editCustomCategoryName,
-                                                expenseAssociatedCategory.big_category_id
+                                                expenseAssociatedCategory.big_category_id,
+                                                signal
                                               ),
                                               editGroupCustomCategories(
                                                 expenseAssociatedCategory.id,
@@ -391,6 +403,7 @@ const BigCategoryInput = React.forwardRef(
                                         className="category-input__icon-delete"
                                         type={'button'}
                                         onClick={(event) => {
+                                          const signal = axios.CancelToken.source();
                                           event.stopPropagation();
                                           if (
                                             window.confirm('カスタムカテゴリーを削除しますか？')
@@ -398,7 +411,8 @@ const BigCategoryInput = React.forwardRef(
                                             operationSwitching(
                                               deleteCustomCategories(
                                                 expenseAssociatedCategory.id,
-                                                expenseAssociatedCategory.big_category_id
+                                                expenseAssociatedCategory.big_category_id,
+                                                signal
                                               ),
                                               deleteGroupCustomCategories(
                                                 expenseAssociatedCategory.id,
@@ -459,9 +473,14 @@ const BigCategoryInput = React.forwardRef(
                                   disabled={customCategoryName === ''}
                                   className="category-input__add-icon-btn category-input__add-icon-btn--plus-icon"
                                   onClick={(event) => {
+                                    const signal = axios.CancelToken.source();
                                     event.stopPropagation();
                                     operationSwitching(
-                                      addCustomCategories(customCategoryName, expenseCategory.id),
+                                      addCustomCategories(
+                                        customCategoryName,
+                                        expenseCategory.id,
+                                        signal
+                                      ),
                                       addGroupCustomCategories(
                                         customCategoryName,
                                         expenseCategory.id

--- a/src/components/uikit/GenericButton.tsx
+++ b/src/components/uikit/GenericButton.tsx
@@ -11,7 +11,12 @@ type GenericButtonProps = {
 const GenericButton = (props: GenericButtonProps) => {
   return (
     <div>
-      <button className="generic-btn" onClick={() => props.onClick()} disabled={props.disabled}>
+      <button
+        type="button"
+        className="generic-btn"
+        onClick={() => props.onClick()}
+        disabled={props.disabled}
+      >
         {props.label}
       </button>
     </div>

--- a/src/components/uikit/MediumCategoryInput.tsx
+++ b/src/components/uikit/MediumCategoryInput.tsx
@@ -20,6 +20,7 @@ import {
 import CreateIcon from '@material-ui/icons/Create';
 import DeleteIcon from '@material-ui/icons/Delete';
 import '../../assets/modules/category-input.scss';
+import axios from 'axios';
 
 interface MediumCategoryInputProps {
   kind: string;
@@ -105,6 +106,7 @@ const MediumCategoryInput = React.forwardRef(
                                 className="category-input__icon-add"
                                 type={'button'}
                                 onClick={(event) => {
+                                  const signal = axios.CancelToken.source();
                                   event.stopPropagation();
                                   document.removeEventListener(
                                     'click',
@@ -114,7 +116,8 @@ const MediumCategoryInput = React.forwardRef(
                                     editCustomCategories(
                                       incomeAssociated.id,
                                       editCustomCategoryName,
-                                      incomeAssociated.big_category_id
+                                      incomeAssociated.big_category_id,
+                                      signal
                                     ),
                                     editGroupCustomCategories(
                                       incomeAssociated.id,
@@ -160,12 +163,14 @@ const MediumCategoryInput = React.forwardRef(
                               className="category-input__icon-delete"
                               type={'button'}
                               onClick={(event) => {
+                                const signal = axios.CancelToken.source();
                                 event.stopPropagation();
                                 if (window.confirm('カスタムカテゴリーを削除しますか？')) {
                                   operationSwitching(
                                     deleteCustomCategories(
                                       incomeAssociated.id,
-                                      incomeAssociated.big_category_id
+                                      incomeAssociated.big_category_id,
+                                      signal
                                     ),
                                     deleteGroupCustomCategories(
                                       incomeAssociated.id,
@@ -216,9 +221,10 @@ const MediumCategoryInput = React.forwardRef(
                         disabled={customCategoryName === ''}
                         className="category-input__add-icon-btn category-input__add-icon-btn--plus-icon"
                         onClick={(event) => {
+                          const signal = axios.CancelToken.source();
                           event.stopPropagation();
                           operationSwitching(
-                            addCustomCategories(customCategoryName, props.bigCategoryId),
+                            addCustomCategories(customCategoryName, props.bigCategoryId, signal),
                             addGroupCustomCategories(customCategoryName, props.bigCategoryId)
                           );
                           setCustomCategoryName('');
@@ -259,6 +265,7 @@ const MediumCategoryInput = React.forwardRef(
                                 className="category-input__icon-add"
                                 type={'button'}
                                 onClick={() => {
+                                  const signal = axios.CancelToken.source();
                                   document.removeEventListener(
                                     'click',
                                     props.onClickCloseMediumCategoryMenu
@@ -267,7 +274,8 @@ const MediumCategoryInput = React.forwardRef(
                                     editCustomCategories(
                                       expenseAssociated.id,
                                       editCustomCategoryName,
-                                      expenseAssociated.big_category_id
+                                      expenseAssociated.big_category_id,
+                                      signal
                                     ),
                                     editGroupCustomCategories(
                                       expenseAssociated.id,
@@ -313,12 +321,14 @@ const MediumCategoryInput = React.forwardRef(
                               className="category-input__icon-delete"
                               type={'button'}
                               onClick={(event) => {
+                                const signal = axios.CancelToken.source();
                                 event.stopPropagation();
                                 if (window.confirm('カスタムカテゴリーを削除しますか？')) {
                                   operationSwitching(
                                     deleteCustomCategories(
                                       expenseAssociated.id,
-                                      expenseAssociated.big_category_id
+                                      expenseAssociated.big_category_id,
+                                      signal
                                     ),
                                     deleteGroupCustomCategories(
                                       expenseAssociated.id,
@@ -368,9 +378,10 @@ const MediumCategoryInput = React.forwardRef(
                         disabled={customCategoryName === ''}
                         className="category-input__add-icon-btn category-input__add-icon-btn--plus-icon"
                         onClick={(event) => {
+                          const signal = axios.CancelToken.source();
                           event.stopPropagation();
                           operationSwitching(
-                            addCustomCategories(customCategoryName, props.bigCategoryId),
+                            addCustomCategories(customCategoryName, props.bigCategoryId, signal),
                             addGroupCustomCategories(customCategoryName, props.bigCategoryId)
                           );
                           setCustomCategoryName('');

--- a/src/containers/home/modal/AddTransactionModalContainer.tsx
+++ b/src/containers/home/modal/AddTransactionModalContainer.tsx
@@ -180,7 +180,7 @@ const AddTransactionModalContainer = (props: AddTransactionModalContainerProps) 
   useEffect(() => {
     const signal = axios.CancelToken.source();
 
-    if (pathName !== 'group' && !incomeCategories.length && !expenseCategories.length) {
+    if (pathName !== 'group') {
       dispatch(fetchCategories(signal));
     }
 

--- a/src/containers/home/recentTransaction/GroupRecentInputBodyContainer.tsx
+++ b/src/containers/home/recentTransaction/GroupRecentInputBodyContainer.tsx
@@ -25,8 +25,6 @@ const GroupRecentInputBodyContainer = () => {
   };
 
   const payerColor = (payerUserId: string): React.CSSProperties => {
-    let color = '';
-
     if (currentGroup) {
       if (currentGroup.approved_users_list) {
         const approvedUser = currentGroup.approved_users_list.find(
@@ -34,12 +32,11 @@ const GroupRecentInputBodyContainer = () => {
         );
 
         if (approvedUser) {
-          color = approvedUser.color_code;
+          return { borderBottom: `2px solid ${approvedUser.color_code}` };
         }
       }
     }
-
-    return { borderBottom: `2px solid ${color}` };
+    return { borderBottom: 0 };
   };
 
   return (

--- a/src/containers/home/transactionInputForm/InputFormContainer.tsx
+++ b/src/containers/home/transactionInputForm/InputFormContainer.tsx
@@ -10,7 +10,6 @@ import {
   getGroupIncomeCategories,
 } from '../../../reducks/groupCategories/selectors';
 import { getYearlyAccountListStatus } from '../../../reducks/groupTransactions/selectors';
-import { fetchCategories } from '../../../reducks/categories/operations';
 import { fetchGroupCategories } from '../../../reducks/groupCategories/operations';
 import { addLatestTransactions, addTransactions } from '../../../reducks/transactions/operations';
 import {
@@ -72,21 +71,17 @@ const InputFormContainer = () => {
   }
 
   const displayMessage = () => {
-    const displayMessageConditions = {
-      canDisplayMessage: false,
-    };
-
     if (pathName === 'group') {
       if (accountingStatus.year === addTransactionDate.addTransactionYear + '年') {
         for (const account of accountingStatus.accountedMonth) {
           if (account === addTransactionDate.addTransactionMonth + '月') {
-            displayMessageConditions.canDisplayMessage = true;
+            return true;
           }
         }
       }
     }
 
-    return displayMessageConditions;
+    return false;
   };
 
   const displayMessageDecision = displayMessage();
@@ -106,14 +101,6 @@ const InputFormContainer = () => {
     setBigCategory(initialState.initialBigCategory);
     setAssociatedCategory('');
   }, [transactionsType]);
-
-  useEffect(() => {
-    if (pathName !== 'group' && !incomeCategories.length && !expenseCategories.length) {
-      const signal = axios.CancelToken.source();
-      dispatch(fetchCategories(signal));
-      return () => signal.cancel();
-    }
-  }, [pathName]);
 
   useEffect(() => {
     if (pathName === 'group') {
@@ -264,7 +251,7 @@ const InputFormContainer = () => {
     <InputForm
       unInput={unInput}
       addTransactionMonth={addTransactionDate.addTransactionMonth}
-      displayMessageDecision={displayMessageDecision.canDisplayMessage}
+      displayMessageDecision={displayMessageDecision}
       group_id={Number(group_id)}
       pathName={pathName}
       approvedGroups={approvedGroups}

--- a/src/reducks/categories/actions.ts
+++ b/src/reducks/categories/actions.ts
@@ -1,24 +1,89 @@
 import { Categories } from './types';
 export type categoriesActions = ReturnType<
-  typeof updateIncomeCategoriesAction | typeof updateExpenseCategoriesAction
+  | typeof fetchIncomeCategoryActions
+  | typeof fetchExpenseCategoryActions
+  | typeof failedFetchCategoriesActions
+  | typeof addIncomeCustomCategoryActions
+  | typeof addExpenseCustomCategoryActions
+  | typeof editIncomeCustomCategoryActions
+  | typeof editExpenseCustomCategoryActions
+  | typeof deleteIncomeCustomCategoryActions
+  | typeof deleteExpenseCustomCategoryActions
 >;
 
-export const UPDATE_INCOME_CATEGORIES = 'UPDATE_INCOME_CATEGORIES';
-export const updateIncomeCategoriesAction = (
-  incomeCategories: Categories
-): { type: string; payload: Categories } => {
+export const FETCH_INCOME_CATEGORIES = 'FETCH_INCOME_CATEGORIES';
+export const fetchIncomeCategoryActions = (incomeCategories: Categories) => {
   return {
-    type: UPDATE_INCOME_CATEGORIES,
+    type: FETCH_INCOME_CATEGORIES,
     payload: incomeCategories,
   };
 };
 
-export const UPDATE_EXPENSE_CATEGORIES = 'UPDATE_EXPENSE_CATEGORIES';
-export const updateExpenseCategoriesAction = (
-  expenseCategories: Categories
-): { type: string; payload: Categories } => {
+export const FETCH_EXPENSE_CATEGORIES = 'FETCH_EXPENSE_CATEGORIES';
+export const fetchExpenseCategoryActions = (expenseCategories: Categories) => {
   return {
-    type: UPDATE_EXPENSE_CATEGORIES,
+    type: FETCH_EXPENSE_CATEGORIES,
+    payload: expenseCategories,
+  };
+};
+
+export const FAILED_FETCH_CATEGORIES = 'FAILED_FETCH_CATEGORIES';
+export const failedFetchCategoriesActions = (statusCode: string, errorMessage: string) => {
+  return {
+    type: FAILED_FETCH_CATEGORIES,
+    payload: {
+      categoriesError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const ADD_INCOME_CUSTOM_CATEGORY = 'ADD_INCOME_CUSTOM_CATEGORY';
+export const addIncomeCustomCategoryActions = (incomeCategories: Categories) => {
+  return {
+    type: ADD_INCOME_CUSTOM_CATEGORY,
+    payload: incomeCategories,
+  };
+};
+
+export const ADD_EXPENSE_CUSTOM_CATEGORY = 'ADD_EXPENSE_CUSTOM_CATEGORY';
+export const addExpenseCustomCategoryActions = (expenseCategories: Categories) => {
+  return {
+    type: ADD_EXPENSE_CUSTOM_CATEGORY,
+    payload: expenseCategories,
+  };
+};
+
+export const EDIT_INCOME_CUSTOM_CATEGORY = 'EDIT_INCOME_CUSTOM_CATEGORY';
+export const editIncomeCustomCategoryActions = (incomeCategories: Categories) => {
+  return {
+    type: EDIT_INCOME_CUSTOM_CATEGORY,
+    payload: incomeCategories,
+  };
+};
+
+export const EDIT_EXPENSE_CUSTOM_CATEGORY = 'EDIT_EXPENSE_CUSTOM_CATEGORY';
+export const editExpenseCustomCategoryActions = (expenseCategories: Categories) => {
+  return {
+    type: EDIT_EXPENSE_CUSTOM_CATEGORY,
+    payload: expenseCategories,
+  };
+};
+
+export const DELETE_INCOME_CUSTOM_CATEGORY = 'DELETE_INCOME_CUSTOM_CATEGORY';
+export const deleteIncomeCustomCategoryActions = (incomeCategories: Categories) => {
+  return {
+    type: DELETE_INCOME_CUSTOM_CATEGORY,
+    payload: incomeCategories,
+  };
+};
+
+export const DELETE_EXPENSE_CUSTOM_CATEGORY = 'DELETE_EXPENSE_CUSTOM_CATEGORY';
+export const deleteExpenseCustomCategoryActions = (expenseCategories: Categories) => {
+  return {
+    type: DELETE_EXPENSE_CUSTOM_CATEGORY,
     payload: expenseCategories,
   };
 };

--- a/src/reducks/categories/reducers.ts
+++ b/src/reducks/categories/reducers.ts
@@ -1,27 +1,50 @@
 import * as Actions from './actions';
 import { categoriesActions } from './actions';
 import initialState from '../store/initialState';
-import { Category } from './types';
 
-export const categoriesReducer = (
-  state = initialState.categories,
-  action: categoriesActions
-):
-  | {
-      incomeList: Category[];
-      expenseList: never[];
-    }
-  | {
-      expenseList: Category[];
-      incomeList: never[];
-    } => {
+export const categoriesReducer = (state = initialState.categories, action: categoriesActions) => {
   switch (action.type) {
-    case Actions.UPDATE_INCOME_CATEGORIES:
+    case Actions.FETCH_INCOME_CATEGORIES:
       return {
         ...state,
         incomeList: [...action.payload],
       };
-    case Actions.UPDATE_EXPENSE_CATEGORIES:
+    case Actions.FETCH_EXPENSE_CATEGORIES:
+      return {
+        ...state,
+        expenseList: [...action.payload],
+      };
+    case Actions.FAILED_FETCH_CATEGORIES:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.ADD_INCOME_CUSTOM_CATEGORY:
+      return {
+        ...state,
+        incomeList: [...action.payload],
+      };
+    case Actions.ADD_EXPENSE_CUSTOM_CATEGORY:
+      return {
+        ...state,
+        expenseList: [...action.payload],
+      };
+    case Actions.EDIT_INCOME_CUSTOM_CATEGORY:
+      return {
+        ...state,
+        incomeList: [...action.payload],
+      };
+    case Actions.EDIT_EXPENSE_CUSTOM_CATEGORY:
+      return {
+        ...state,
+        expenseList: [...action.payload],
+      };
+    case Actions.DELETE_INCOME_CUSTOM_CATEGORY:
+      return {
+        ...state,
+        incomeList: [...action.payload],
+      };
+    case Actions.DELETE_EXPENSE_CUSTOM_CATEGORY:
       return {
         ...state,
         expenseList: [...action.payload],

--- a/src/reducks/categories/selectors.ts
+++ b/src/reducks/categories/selectors.ts
@@ -11,3 +11,8 @@ export const getExpenseCategories = createSelector(
   [categoriesSelector],
   (state) => state.expenseList
 );
+
+export const getCategoriesError = createSelector(
+  [categoriesSelector],
+  (state) => state.categoriesError
+);

--- a/src/reducks/categories/types.ts
+++ b/src/reducks/categories/types.ts
@@ -16,36 +16,29 @@ export interface AssociatedCategory {
 export type AssociatedCategories = Array<AssociatedCategory>;
 export type Categories = Array<Category>;
 
-export interface fetchCategoriesRes {
+export interface CategoriesError {
+  statusCode: number;
+  errorMessage: string;
+}
+
+export interface FetchCategoriesRes {
   income_categories_list: [];
   expense_categories_list: [];
 }
 
-export interface addCustomReq {
+export interface CrudCustomCategoryReq {
   name: string;
   big_category_id: number;
 }
 
-export interface addCustomRes {
+export interface CrudCustomCategoryRes {
   category_type: string;
   id: number;
   name: string;
   big_category_id: number;
 }
 
-export interface editCustomReq {
-  name: string;
-  big_category_id: number;
-}
-
-export interface editCustomRes {
-  category_type: string;
-  id: number;
-  name: string;
-  big_category_id: number;
-}
-
-export interface deleteCustomRes {
+export interface DeletedMessage {
   message: string;
 }
 

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -15,13 +15,11 @@ const initialState = {
     message: '',
   },
   categories: {
-    category: {
-      incomeList: [],
-      expenseList: [],
-      categoriesError: {
-        statusCode: 0,
-        errorMessage: '',
-      },
+    incomeList: [],
+    expenseList: [],
+    categoriesError: {
+      statusCode: 0,
+      errorMessage: '',
     },
   },
   groupCategories: {

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -15,8 +15,14 @@ const initialState = {
     message: '',
   },
   categories: {
-    incomeList: [],
-    expenseList: [],
+    category: {
+      incomeList: [],
+      expenseList: [],
+      categoriesError: {
+        statusCode: 0,
+        errorMessage: '',
+      },
+    },
   },
   groupCategories: {
     groupIncomeList: [],

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -1,4 +1,4 @@
-import { Categories } from '../categories/types';
+import { Categories, CategoriesError } from '../categories/types';
 import { GroupCategories } from '../groupCategories/types';
 import { Groups } from '../groups/types';
 import { TransactionsList } from '../transactions/types';
@@ -43,6 +43,7 @@ export interface State {
   categories: {
     incomeList: Categories;
     expenseList: Categories;
+    categoriesError: CategoriesError;
   };
   groupCategories: {
     groupIncomeList: GroupCategories;

--- a/test/categories-test/Categories.test.ts
+++ b/test/categories-test/Categories.test.ts
@@ -36,11 +36,11 @@ describe('async actions getCategories', () => {
 
     const expectedActions = [
       {
-        type: actionTypes.UPDATE_INCOME_CATEGORIES,
+        type: actionTypes.FETCH_INCOME_CATEGORIES,
         payload: mockResponse.income_categories_list,
       },
       {
-        type: actionTypes.UPDATE_EXPENSE_CATEGORIES,
+        type: actionTypes.FETCH_EXPENSE_CATEGORIES,
         payload: mockResponse.expense_categories_list,
       },
     ];
@@ -54,92 +54,74 @@ describe('async actions getCategories', () => {
 
 describe('async actions addCustomCategories', () => {
   const store = mockStore({ categories });
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories/custom-categories`;
+  const addUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories/custom-categories`;
+  const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories`;
+  const signal = axios.CancelToken.source();
 
   beforeEach(() => {
     store.clearActions();
   });
 
   it('Add customCategory in income_categories_list if fetch succeeds', async () => {
-    const getState = () => {
-      return {
-        categories: {
-          incomeList: categories.income_categories_list,
-        },
-      };
-    };
     const reqIncomeCategory = {
       name: '失業手当',
       big_category_id: 1,
     };
 
-    const mockIncomeResponse = addResponse.categories.incomeResponse;
+    const mockAddIncomeResponse = addResponse.categories.incomeResponse;
 
-    const mockIncomeList = addCategories.income_categories_list;
+    const mockFetchIncomeList = addCategories.income_categories_list;
 
     const expectedIncomeActions = [
       {
-        type: actionTypes.UPDATE_INCOME_CATEGORIES,
-        payload: mockIncomeList,
+        type: actionTypes.ADD_INCOME_CUSTOM_CATEGORY,
+        payload: mockFetchIncomeList,
       },
     ];
 
-    axiosMock.onPost(url, reqIncomeCategory).reply(201, mockIncomeResponse);
+    axiosMock.onPost(addUrl, reqIncomeCategory).reply(201, mockAddIncomeResponse);
+    axiosMock.onGet(fetchUrl).reply(200, addCategories);
 
     // @ts-ignore
-    await addCustomCategories('失業手当', 1)(store.dispatch, getState);
+    await addCustomCategories('失業手当', 1, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedIncomeActions);
   });
 
   it('Add customCategory in expense_categories_list if fetch succeeds', async () => {
-    const getState = () => {
-      return {
-        categories: {
-          expenseList: categories.expense_categories_list,
-        },
-      };
-    };
-
     const reqExpenseCategory = {
       name: '調味料',
       big_category_id: 2,
     };
 
-    const mockExpenseResponse = addResponse.categories.expenseResponse;
+    const mockAddExpenseResponse = addResponse.categories.expenseResponse;
 
-    const mockExpenseList = addCategories.expense_categories_list;
+    const mockFetchExpenseList = addCategories.expense_categories_list;
 
     const expectedExpenseActions = [
       {
-        type: actionTypes.UPDATE_EXPENSE_CATEGORIES,
-        payload: mockExpenseList,
+        type: actionTypes.ADD_EXPENSE_CUSTOM_CATEGORY,
+        payload: mockFetchExpenseList,
       },
     ];
 
-    axiosMock.onPost(url, reqExpenseCategory).reply(201, mockExpenseResponse);
+    axiosMock.onPost(addUrl, reqExpenseCategory).reply(201, mockAddExpenseResponse);
+    axiosMock.onGet(fetchUrl).reply(200, addCategories);
 
     // @ts-ignore
-    await addCustomCategories('調味料', 2)(store.dispatch, getState);
+    await addCustomCategories('調味料', 2, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedExpenseActions);
   });
 });
 
 describe('async actions editCustomCategories', () => {
   const store = mockStore({ addCategories });
+  const signal = axios.CancelToken.source();
 
   beforeEach(() => {
     store.clearActions();
   });
 
   it('Edit customCategory in income_categories_list if fetch succeeds', async () => {
-    const getState = () => {
-      return {
-        categories: {
-          incomeList: addCategories.income_categories_list,
-        },
-      };
-    };
-
     const reqIncomeCategory = {
       name: '株配当金',
       big_category_id: 1,
@@ -148,33 +130,27 @@ describe('async actions editCustomCategories', () => {
     const mockIncomeResponse = editResponse.categories.incomeResponse;
 
     const id = mockIncomeResponse.id;
-    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories/custom-categories/${id}`;
+    const editUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories/custom-categories/${id}`;
+    const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories`;
 
     const mockIncomeList = editCategories.income_categories_list;
 
     const expectedIncomeActions = [
       {
-        type: actionTypes.UPDATE_INCOME_CATEGORIES,
+        type: actionTypes.EDIT_INCOME_CUSTOM_CATEGORY,
         payload: mockIncomeList,
       },
     ];
 
-    axiosMock.onPut(url, reqIncomeCategory).reply(200, mockIncomeResponse);
+    axiosMock.onPut(editUrl, reqIncomeCategory).reply(200, mockIncomeResponse);
+    axiosMock.onGet(fetchUrl).reply(200, editCategories);
 
     // @ts-ignore
-    await editCustomCategories(16, '株配当金', 1)(store.dispatch, getState);
+    await editCustomCategories(16, '株配当金', 1, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedIncomeActions);
   });
 
   it('Edit customCategory in expense_categories_list if fetch succeeds', async () => {
-    const getState = () => {
-      return {
-        categories: {
-          expenseList: addCategories.expense_categories_list,
-        },
-      };
-    };
-
     const reqExpenseCategory = {
       name: '牛肉ブロック',
       big_category_id: 2,
@@ -183,27 +159,30 @@ describe('async actions editCustomCategories', () => {
     const mockExpenseResponse = editResponse.categories.expenseResponse;
 
     const id = mockExpenseResponse.id;
-    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories/custom-categories/${id}`;
+    const editUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories/custom-categories/${id}`;
+    const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories`;
 
     const mockExpenseList = editCategories.expense_categories_list;
 
     const expectedExpenseActions = [
       {
-        type: actionTypes.UPDATE_EXPENSE_CATEGORIES,
+        type: actionTypes.EDIT_EXPENSE_CUSTOM_CATEGORY,
         payload: mockExpenseList,
       },
     ];
 
-    axiosMock.onPut(url, reqExpenseCategory).reply(200, mockExpenseResponse);
+    axiosMock.onPut(editUrl, reqExpenseCategory).reply(200, mockExpenseResponse);
+    axiosMock.onGet(fetchUrl).reply(200, editCategories);
 
     // @ts-ignore
-    await editCustomCategories(17, '牛肉ブロック', 2)(store.dispatch, getState);
+    await editCustomCategories(17, '牛肉ブロック', 2, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedExpenseActions);
   });
 });
 
 describe('async actions deleteCustomCategories', () => {
   const store = mockStore({ editCategories });
+  const signal = axios.CancelToken.source();
 
   beforeEach(() => {
     store.clearActions();
@@ -214,61 +193,45 @@ describe('async actions deleteCustomCategories', () => {
   const deleteCategories = JSON.parse(JSON.stringify(categories));
 
   it('Delete customCategory in income_categories_list if fetch succeeds', async () => {
-    const getState = () => {
-      return {
-        categories: {
-          incomeList: editCategories.income_categories_list,
-        },
-      };
-    };
-
     const id = 16;
-    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories/custom-categories/${id}`;
+    const deleteUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories/custom-categories/${id}`;
+    const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories`;
 
     const mockIncomeList = deleteCategories.income_categories_list;
 
     const expectedIncomeActions = [
       {
-        type: actionTypes.UPDATE_INCOME_CATEGORIES,
+        type: actionTypes.DELETE_INCOME_CUSTOM_CATEGORY,
         payload: mockIncomeList,
       },
     ];
 
-    axiosMock.onDelete(url).reply(200, mockResponse);
-    window.alert = jest.fn(() => mockResponse);
+    axiosMock.onDelete(deleteUrl).reply(200, mockResponse);
+    axiosMock.onGet(fetchUrl).reply(200, deleteCategories);
 
     // @ts-ignore
-    await deleteCustomCategories(16, 1)(store.dispatch, getState);
+    await deleteCustomCategories(16, 1, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedIncomeActions);
-    expect(window.alert).toHaveBeenCalled();
   });
 
   it('Delete customCategory in expense_categories_list if fetch succeeds', async () => {
-    const getState = () => {
-      return {
-        categories: {
-          expenseList: editCategories.expense_categories_list,
-        },
-      };
-    };
-
     const id = 17;
     const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories/custom-categories/${id}`;
+    const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/categories`;
 
     const mockExpenseList = deleteCategories.expense_categories_list;
     const expectedExpenseActions = [
       {
-        type: actionTypes.UPDATE_EXPENSE_CATEGORIES,
+        type: actionTypes.DELETE_EXPENSE_CUSTOM_CATEGORY,
         payload: mockExpenseList,
       },
     ];
 
     axiosMock.onDelete(url).reply(200, mockResponse);
-    window.alert = jest.fn(() => mockResponse);
+    axiosMock.onGet(fetchUrl).reply(200, deleteCategories);
 
     // @ts-ignore
-    await deleteCustomCategories(17, 2)(store.dispatch, getState);
+    await deleteCustomCategories(17, 2, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedExpenseActions);
-    expect(window.alert).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- `categories / operations`に処理を書いておりミドルウェアが肥大化していたのでCRUDのみの形に修正し、add, edit, deleteの処理
   の後にfetch処理を追加しadd, edit, deleteのロジックを記述しないで済むように修正しました。

- 上記の変更に伴い、`actions, reducers, Categories.test`を修正しました。

