### PR TITLE
Modify operations for groupTransactions

### DIFF
--- a/src/containers/account/PayOffBodyContainer.tsx
+++ b/src/containers/account/PayOffBodyContainer.tsx
@@ -5,6 +5,7 @@ import { ApprovedGroupUsers, Groups } from '../../reducks/groups/types';
 import { GroupAccountList, MonthWithoutSplit } from '../../reducks/groupTransactions/types';
 import PayOffBody from '../../components/account/PayOffBody';
 import { editGroupAccount } from '../../reducks/groupTransactions/operations';
+import axios from 'axios';
 
 interface PayOffBodyContainerProps {
   selectYear: string;
@@ -73,11 +74,18 @@ const PayOffBodyContainer = (props: PayOffBodyContainerProps) => {
       selectYear={props.selectYear}
       displayAccountList={displayAccountList}
       groupUserInfo={groupUserInfo}
-      editAccountOperation={(account) =>
+      editAccountOperation={(account) => {
+        const signal = axios.CancelToken.source();
         dispatch(
-          editGroupAccount(account, Number(group_id), props.selectYear, String(props.selectMonth))
-        )
-      }
+          editGroupAccount(
+            account,
+            Number(group_id),
+            props.selectYear,
+            String(props.selectMonth),
+            signal
+          )
+        );
+      }}
     />
   );
 };

--- a/src/containers/home/modal/AddTransactionModalContainer.tsx
+++ b/src/containers/home/modal/AddTransactionModalContainer.tsx
@@ -12,7 +12,6 @@ import {
 import { getYearlyAccountListStatusModals } from '../../../reducks/groupTransactions/selectors';
 import { addTransactions } from '../../../reducks/transactions/operations';
 import {
-  addGroupLatestTransactions,
   addGroupTransactions,
   fetchGroupYearlyAccountListForModal,
 } from '../../../reducks/groupTransactions/operations';
@@ -42,6 +41,7 @@ const AddTransactionModalContainer = (props: AddTransactionModalContainerProps) 
   const dispatch = useDispatch();
   const { group_id } = useParams();
   const pathName = useLocation().pathname.split('/')[1];
+  const groupCurrentPage = useLocation().pathname.split('/')[2];
   const userId = useSelector(getUserId);
   const approvedGroup = useSelector(getApprovedGroups);
   const incomeCategories = useSelector(getIncomeCategories);
@@ -276,6 +276,7 @@ const AddTransactionModalContainer = (props: AddTransactionModalContainerProps) 
       addTransactionDate.addTransactionMonth <= september
         ? '0' + addTransactionDate.addTransactionMonth
         : String(addTransactionDate.addTransactionMonth);
+
     const personalAddTransaction = () => {
       pathName === 'home'
         ? dispatch(addTransactions(personalAddRequestData, year, customMonth, signal))
@@ -292,13 +293,20 @@ const AddTransactionModalContainer = (props: AddTransactionModalContainerProps) 
     };
 
     const groupAddTransaction = () => {
-      async function groupTransaction() {
-        await dispatch(addGroupLatestTransactions(Number(group_id), groupAddRequestData));
-        dispatch(addGroupTransactions(customMonth));
-        props.onClose();
-        resetForm();
-      }
-      groupTransaction();
+      groupCurrentPage === 'home'
+        ? dispatch(addGroupTransactions(group_id, signal, year, customMonth, groupAddRequestData))
+        : dispatch(
+            addGroupTransactions(
+              group_id,
+              signal,
+              addTransactionDate.addTransactionYear,
+              transactionsMonth,
+              groupAddRequestData
+            )
+          );
+
+      props.onClose();
+      resetForm();
     };
 
     return pathName !== 'group' ? personalAddTransaction() : groupAddTransaction();

--- a/src/containers/home/modal/EditTransactionModalContainer.tsx
+++ b/src/containers/home/modal/EditTransactionModalContainer.tsx
@@ -2,12 +2,9 @@ import React, { useEffect, useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router';
 import {
-  deleteGroupLatestTransactions,
   deleteGroupTransactions,
-  editGroupLatestTransactionsList,
   editGroupTransactions,
   fetchGroupYearlyAccountListForModal,
-  fetchLatestGroupTransactionsList,
 } from '../../../reducks/groupTransactions/operations';
 import { deleteTransactions, editTransactions } from '../../../reducks/transactions/operations';
 import { getApprovedGroups } from '../../../reducks/groups/selectors';
@@ -50,6 +47,7 @@ const EditTransactionModalContainer = (props: EditTransactionModalContainerProps
   const transactionId = props.id;
   const { group_id } = useParams();
   const pathName = useLocation().pathname.split('/')[1];
+  const groupCurrentPage = useLocation().pathname.split('/')[2];
   const incomeCategories = useSelector(getIncomeCategories);
   const expenseCategories = useSelector(getExpenseCategories);
   const groupIncomeCategories = useSelector(getGroupIncomeCategories);
@@ -334,18 +332,46 @@ const EditTransactionModalContainer = (props: EditTransactionModalContainerProps
 
   const groupDeleteTransaction = (): void => {
     const signal = axios.CancelToken.source();
-    async function groupTransaction() {
-      dispatch(deleteGroupLatestTransactions(transactionId, Number(group_id)));
-      dispatch(fetchLatestGroupTransactionsList(Number(group_id), signal));
-      dispatch(deleteGroupTransactions(transactionId, Number(group_id)));
-    }
-    groupTransaction();
+
+    groupCurrentPage === 'home'
+      ? dispatch(
+          deleteGroupTransactions(transactionId, Number(group_id), signal, year, customMonth)
+        )
+      : dispatch(
+          deleteGroupTransactions(
+            transactionId,
+            Number(group_id),
+            signal,
+            editTransactionDate.editTransactionYear,
+            transactionsMonth
+          )
+        );
   };
+
   const groupEditTransaction = (): void => {
-    dispatch(editGroupTransactions(transactionId, Number(group_id), groupEditRequestData));
-    dispatch(
-      editGroupLatestTransactionsList(transactionId, Number(group_id), groupEditRequestData)
-    );
+    const signal = axios.CancelToken.source();
+
+    groupCurrentPage === 'home'
+      ? dispatch(
+          editGroupTransactions(
+            Number(group_id),
+            transactionId,
+            signal,
+            year,
+            customMonth,
+            groupEditRequestData
+          )
+        )
+      : dispatch(
+          editGroupTransactions(
+            transactionId,
+            Number(group_id),
+            signal,
+            editTransactionDate.editTransactionYear,
+            transactionsMonth,
+            groupEditRequestData
+          )
+        );
     props.onClose();
   };
 

--- a/src/containers/home/transactionInputForm/InputFormContainer.tsx
+++ b/src/containers/home/transactionInputForm/InputFormContainer.tsx
@@ -13,7 +13,6 @@ import { getYearlyAccountListStatus } from '../../../reducks/groupTransactions/s
 import { fetchGroupCategories } from '../../../reducks/groupCategories/operations';
 import { addTransactions } from '../../../reducks/transactions/operations';
 import {
-  addGroupLatestTransactions,
   addGroupTransactions,
   fetchGroupYearlyAccountList,
 } from '../../../reducks/groupTransactions/operations';
@@ -220,12 +219,11 @@ const InputFormContainer = () => {
   };
 
   const addGroupTransaction = () => {
-    async function addedGroupTransaction() {
-      await dispatch(addGroupLatestTransactions(Number(group_id), groupAddRequestData));
-      dispatch(addGroupTransactions(customMonth));
-      resetInputForm();
-    }
-    addedGroupTransaction();
+    const signal = axios.CancelToken.source();
+    dispatch(
+      addGroupTransactions(Number(group_id), signal, year, customMonth, groupAddRequestData)
+    );
+    resetInputForm();
   };
 
   const unInput =

--- a/src/containers/templates/account/PayOffContainer.tsx
+++ b/src/containers/templates/account/PayOffContainer.tsx
@@ -108,12 +108,18 @@ const PayOffContainer = (props: PayOffContainerProps) => {
       backPageOperation={() =>
         history.replace(`/group/${group_id}/accounting?year=${props.selectedYear}`)
       }
-      addAccountOperation={() =>
-        dispatch(addGroupAccount(Number(group_id), String(props.selectedYear), String(subMonth)))
-      }
-      deleteAccountOperation={() =>
-        dispatch(deleteGroupAccount(Number(group_id), String(props.selectedYear), String(subMonth)))
-      }
+      addAccountOperation={() => {
+        const signal = axios.CancelToken.source();
+        dispatch(
+          addGroupAccount(Number(group_id), String(props.selectedYear), String(subMonth), signal)
+        );
+      }}
+      deleteAccountOperation={() => {
+        const signal = axios.CancelToken.source();
+        dispatch(
+          deleteGroupAccount(Number(group_id), String(props.selectedYear), String(subMonth), signal)
+        );
+      }}
     />
   );
 };

--- a/src/reducks/groupTransactions/actions.ts
+++ b/src/reducks/groupTransactions/actions.ts
@@ -1,57 +1,287 @@
-import {
-  GroupTransactionsList,
-  GroupAccountList,
-  GroupYearlyAccountList,
-  ErrorInfo,
-} from './types';
+import { GroupTransactionsList, GroupAccountList, GroupYearlyAccountList } from './types';
 
 export type groupTransactionsAction = ReturnType<
-  | typeof startFetchDataAction
-  | typeof failedFetchDataAction
-  | typeof updateGroupTransactionsAction
-  | typeof updateGroupLatestTransactionsAction
+  | typeof startFetchGroupTransactionsAction
+  | typeof fetchGroupTransactionsAction
+  | typeof cancelFetchTransactionsAction
+  | typeof failedFetchGroupTransactionsAction
+  | typeof startFetchGroupLatestTransactionsAction
+  | typeof fetchGroupLatestTransactionsAction
+  | typeof cancelFetchGroupLatestTransactionsAction
+  | typeof failedFetchGroupLatestTransactionsAction
+  | typeof startAddGroupTransactionsAction
+  | typeof addGroupTransactionsAction
+  | typeof failedAddGroupTransactionsAction
+  | typeof startEditGroupTransactionsAction
+  | typeof editGroupTransactionsAction
+  | typeof failedEditGroupTransactionsAction
+  | typeof startDeleteGroupTransactionsAction
+  | typeof deleteGroupTransactionsAction
+  | typeof failedDeleteGroupTransactionsAction
+  | typeof startFetchGroupAccountAction
   | typeof fetchGroupAccountAction
+  | typeof cancelFetchGroupAccountAction
+  | typeof failedFetchGroupAccountAction
+  | typeof startFetchGroupYearlyAccountList
   | typeof fetchGroupYearlyAccountListAction
+  | typeof cancelFetchGroupYearlyAccountList
+  | typeof failedFetchGroupYearlyAccountList
+  | typeof startFetchYearlyAccountListForModalAction
   | typeof fetchYearlyAccountListForModalAction
+  | typeof cancelFetchYearlyAccountListForModalAction
+  | typeof failedFetchYearlyAccountListForModalAction
+  | typeof startAddGroupAccountAction
   | typeof addGroupAccountAction
+  | typeof failedAddGroupAccountAction
+  | typeof startEditGroupAccountAction
   | typeof editGroupAccountAction
+  | typeof failedEditGroupAccountAction
+  | typeof startDeleteGroupAccountAction
   | typeof deleteGroupAccountAction
+  | typeof failedDeleteGroupAccountAction
+  | typeof startSearchGroupTransactionsAction
   | typeof searchGroupTransactionsAction
+  | typeof failedSearchGroupTransactionsAction
 >;
 
-export const START_FETCH_DATA = 'START_FETCH_DATA';
-export const startFetchDataAction = () => {
+export const START_FETCH_GROUP_TRANSACTIONS = 'START_FETCH_GROUP_TRANSACTIONS';
+export const startFetchGroupTransactionsAction = () => {
   return {
-    type: START_FETCH_DATA,
+    type: START_FETCH_GROUP_TRANSACTIONS,
     payload: {
-      loading: true,
+      groupTransactionsListLoading: true,
     },
   };
 };
 
-export const FAILED_FETCH_DATA = 'FAILED_FETCH_DATA';
-export const failedFetchDataAction = (groupTransactionsError: ErrorInfo) => {
+export const FETCH_GROUP_TRANSACTIONS = 'FETCH_GROUP_TRANSACTIONS';
+export const fetchGroupTransactionsAction = (groupTransactionsList: GroupTransactionsList) => {
   return {
-    type: FAILED_FETCH_DATA,
-    payload: groupTransactionsError,
+    type: FETCH_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: false,
+      groupTransactionsList: groupTransactionsList,
+    },
   };
 };
 
-export const UPDATE_GROUP_TRANSACTIONS = 'UPDATE_GROUP_TRANSACTIONS';
-export const updateGroupTransactionsAction = (groupTransactionsList: GroupTransactionsList) => {
+export const CANCEL_FETCH_GROUP_TRANSACTIONS = 'CANCEL_FETCH_GROUP_TRANSACTIONS';
+export const cancelFetchTransactionsAction = () => {
   return {
-    type: UPDATE_GROUP_TRANSACTIONS,
-    payload: groupTransactionsList,
+    type: CANCEL_FETCH_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: false,
+    },
   };
 };
 
-export const UPDATE_GROUP_LATEST_TRANSACTIONS = 'UPDATE_GROUP_LATEST_TRANSACTIONS';
-export const updateGroupLatestTransactionsAction = (
+export const FAILED_FETCH_GROUP_TRANSACTIONS = 'FAILED_FETCH_GROUP_TRANSACTIONS';
+export const failedFetchGroupTransactionsAction = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_FETCH_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_FETCH_GROUP_LATEST_TRANSACTIONS = 'START_FETCH_GROUP_LATEST_TRANSACTIONS';
+export const startFetchGroupLatestTransactionsAction = () => {
+  return {
+    type: START_FETCH_GROUP_LATEST_TRANSACTIONS,
+    payload: {
+      groupLatestTransactionsListLoading: true,
+    },
+  };
+};
+
+export const FETCH_GROUP_LATEST_TRANSACTIONS = 'FETCH_GROUP_LATEST_TRANSACTIONS';
+export const fetchGroupLatestTransactionsAction = (
   groupLatestTransactionsList: GroupTransactionsList
 ) => {
   return {
-    type: UPDATE_GROUP_LATEST_TRANSACTIONS,
-    payload: groupLatestTransactionsList,
+    type: FETCH_GROUP_LATEST_TRANSACTIONS,
+    payload: {
+      groupLatestTransactionsListLoading: false,
+      groupLatestTransactionsList: groupLatestTransactionsList,
+    },
+  };
+};
+
+export const CANCEL_FETCH_GROUP_LATEST_TRANSACTIONS = 'CANCEL_FETCH_GROUP_LATEST_TRANSACTIONS';
+export const cancelFetchGroupLatestTransactionsAction = () => {
+  return {
+    type: CANCEL_FETCH_GROUP_LATEST_TRANSACTIONS,
+    payload: {
+      groupLatestTransactionsListLoading: false,
+    },
+  };
+};
+
+export const FAILED_FETCH_GROUP_LATEST_TRANSACTIONS = 'FAILED_FETCH_GROUP_LATEST_TRANSACTIONS';
+export const failedFetchGroupLatestTransactionsAction = (
+  statusCode: number,
+  errorMessage: string
+) => {
+  return {
+    type: FAILED_FETCH_GROUP_LATEST_TRANSACTIONS,
+    payload: {
+      groupLatestTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_ADD_GROUP_TRANSACTIONS = 'START_ADD_GROUP_TRANSACTIONS';
+export const startAddGroupTransactionsAction = () => {
+  return {
+    type: START_ADD_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: true,
+      groupLatestTransactionsListLoading: true,
+    },
+  };
+};
+
+export const ADD_GROUP_TRANSACTIONS = 'ADD_GROUP_TRANSACTIONS';
+export const addGroupTransactionsAction = (
+  groupTransactionsList: GroupTransactionsList,
+  groupLatestTransactionsList: GroupTransactionsList
+) => {
+  return {
+    type: ADD_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: false,
+      groupTransactionsList: groupTransactionsList,
+      groupLatestTransactionsListLoading: false,
+      groupLatestTransactionsList: groupLatestTransactionsList,
+    },
+  };
+};
+
+export const FAILED_ADD_GROUP_TRANSACTIONS = 'FAILED_ADD_GROUP_TRANSACTIONS';
+export const failedAddGroupTransactionsAction = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_ADD_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: false,
+      groupTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+      groupLatestTransactionsListLoading: false,
+      groupLatestTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_EDIT_GROUP_TRANSACTIONS = 'START_EDIT_GROUP_TRANSACTIONS';
+export const startEditGroupTransactionsAction = () => {
+  return {
+    type: START_EDIT_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: true,
+      groupLatestTransactionsListLoading: true,
+    },
+  };
+};
+
+export const EDIT_GROUP_TRANSACTIONS = 'EDIT_GROUP_TRANSACTIONS';
+export const editGroupTransactionsAction = (
+  groupTransactionsList: GroupTransactionsList,
+  groupLatestTransactionsList: GroupTransactionsList
+) => {
+  return {
+    type: EDIT_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: false,
+      groupTransactionsList: groupTransactionsList,
+      groupLatestTransactionsListLoading: false,
+      groupLatestTransactionsList: groupLatestTransactionsList,
+    },
+  };
+};
+
+export const FAILED_EDIT_GROUP_TRANSACTIONS = 'FAILED_EDIT_GROUP_TRANSACTIONS';
+export const failedEditGroupTransactionsAction = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_EDIT_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: false,
+      groupTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+      groupLatestTransactionsListLoading: false,
+      groupLatestTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_DELETE_GROUP_TRANSACTIONS = 'START_DELETE_GROUP_TRANSACTIONS';
+export const startDeleteGroupTransactionsAction = () => {
+  return {
+    type: START_DELETE_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: true,
+      groupLatestTransactionsListLoading: true,
+    },
+  };
+};
+
+export const DELETE_GROUP_TRANSACTIONS = 'DELETE_GROUP_TRANSACTIONS';
+export const deleteGroupTransactionsAction = (
+  groupTransactionsList: GroupTransactionsList,
+  groupLatestTransactionsList: GroupTransactionsList
+) => {
+  return {
+    type: DELETE_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: false,
+      groupTransactionsList: groupTransactionsList,
+      groupLatestTransactionsListLoading: false,
+      groupLatestTransactionsList: groupLatestTransactionsList,
+    },
+  };
+};
+
+export const FAILED_DELETE_GROUP_TRANSACTIONS = 'FAILED_DELETE_GROUP_TRANSACTIONS';
+export const failedDeleteGroupTransactionsAction = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_DELETE_GROUP_TRANSACTIONS,
+    payload: {
+      groupTransactionsListLoading: false,
+      groupTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+      groupLatestTransactionsListLoading: false,
+      groupLatestTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_FETCH_GROUP_ACCOUNT = 'START_FETCH_GROUP_ACCOUNT';
+export const startFetchGroupAccountAction = () => {
+  return {
+    type: START_FETCH_GROUP_ACCOUNT,
+    payload: {
+      groupAccountListLoading: true,
+    },
   };
 };
 
@@ -59,7 +289,44 @@ export const FETCH_GROUP_ACCOUNT = 'FETCH_GROUP_ACCOUNT';
 export const fetchGroupAccountAction = (groupAccountList: GroupAccountList) => {
   return {
     type: FETCH_GROUP_ACCOUNT,
-    payload: groupAccountList,
+    payload: {
+      groupAccountListLoading: false,
+      groupAccountList: groupAccountList,
+    },
+  };
+};
+
+export const CANCEL_FETCH_GROUP_ACCOUNT = 'CANCEL_FETCH_GROUP_ACCOUNT';
+export const cancelFetchGroupAccountAction = () => {
+  return {
+    type: CANCEL_FETCH_GROUP_ACCOUNT,
+    payload: {
+      groupAccountListLoading: false,
+    },
+  };
+};
+
+export const FAILED_FETCH_GROUP_ACCOUNT = 'FAILED_FETCH_GROUP_ACCOUNT';
+export const failedFetchGroupAccountAction = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_FETCH_GROUP_ACCOUNT,
+    payload: {
+      groupAccountListLoading: false,
+      groupAccountListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_FETCH_GROUP_YEARLY_ACCOUNT = 'START_FETCH_GROUP_YEARLY_ACCOUNT';
+export const startFetchGroupYearlyAccountList = () => {
+  return {
+    type: START_FETCH_GROUP_YEARLY_ACCOUNT,
+    payload: {
+      groupYearlyAccountListLoading: true,
+    },
   };
 };
 
@@ -70,8 +337,42 @@ export const fetchGroupYearlyAccountListAction = (
   return {
     type: FETCH_GROUP_YEARLY_ACCOUNT,
     payload: {
-      loading: false,
+      groupYearlyAccountListLoading: false,
       groupYearlyAccountList: groupYearlyAccountList,
+    },
+  };
+};
+
+export const CANCEL_FETCH_GROUP_YEARLY_ACCOUNT = 'CANCEL_FETCH_GROUP_YEARLY_ACCOUNT';
+export const cancelFetchGroupYearlyAccountList = () => {
+  return {
+    type: CANCEL_FETCH_GROUP_YEARLY_ACCOUNT,
+    payload: {
+      groupYearlyAccountListLoading: false,
+    },
+  };
+};
+
+export const FAILED_FETCH_GROUP_YEARLY_ACCOUNT = 'FAILED_FETCH_GROUP_YEARLY_ACCOUNT';
+export const failedFetchGroupYearlyAccountList = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_FETCH_GROUP_YEARLY_ACCOUNT,
+    payload: {
+      groupYearlyAccountListLoading: false,
+      groupYearlyAccountListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_FETCH_YEARLY_ACCOUNT_MODAL = 'START_FETCH_YEARLY_ACCOUNT_MODAL';
+export const startFetchYearlyAccountListForModalAction = () => {
+  return {
+    type: START_FETCH_YEARLY_ACCOUNT_MODAL,
+    payload: {
+      groupYearlyAccountListForModalLoading: true,
     },
   };
 };
@@ -83,17 +384,92 @@ export const fetchYearlyAccountListForModalAction = (
   return {
     type: FETCH_YEARLY_ACCOUNT_MODAL,
     payload: {
-      loading: false,
+      groupYearlyAccountListForModalLoading: false,
       groupYearlyAccountListForModal: groupYearlyAccountListForModal,
     },
   };
 };
 
+export const CANCEL_FETCH_YEARLY_ACCOUNT_MODAL = 'CANCEL_FETCH_YEARLY_ACCOUNT_MODAL';
+export const cancelFetchYearlyAccountListForModalAction = () => {
+  return {
+    type: CANCEL_FETCH_YEARLY_ACCOUNT_MODAL,
+    payload: {
+      groupYearlyAccountListForModalLoading: false,
+    },
+  };
+};
+
+export const FAILED_FETCH_YEARLY_ACCOUNT_MODAL = 'FAILED_FETCH_YEARLY_ACCOUNT_MODAL';
+export const failedFetchYearlyAccountListForModalAction = (
+  statusCode: number,
+  errorMessage: string
+) => {
+  return {
+    type: FAILED_FETCH_YEARLY_ACCOUNT_MODAL,
+    payload: {
+      groupYearlyAccountListForModalLoading: false,
+      groupYearlyAccountListForModalError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_ADD_GROUP_ACCOUNT = 'START_ADD_GROUP_ACCOUNT';
+export const startAddGroupAccountAction = () => {
+  return {
+    type: START_ADD_GROUP_ACCOUNT,
+    payload: {
+      groupAccountListLoading: true,
+      groupYearlyAccountListLoading: true,
+    },
+  };
+};
+
 export const ADD_GROUP_ACCOUNT = 'ADD_GROUP_ACCOUNT';
-export const addGroupAccountAction = (groupAccountList: GroupAccountList) => {
+export const addGroupAccountAction = (
+  groupYearlyAccountList: GroupYearlyAccountList,
+  groupAccountList: GroupAccountList
+) => {
   return {
     type: ADD_GROUP_ACCOUNT,
-    payload: groupAccountList,
+    payload: {
+      groupAccountListLoading: false,
+      groupAccountList: groupAccountList,
+      groupYearlyAccountListLoading: false,
+      groupYearlyAccountList: groupYearlyAccountList,
+    },
+  };
+};
+
+export const FAILED_ADD_GROUP_ACCOUNT = 'FAILED_ADD_GROUP_ACCOUNT';
+export const failedAddGroupAccountAction = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_ADD_GROUP_ACCOUNT,
+    payload: {
+      groupAccountListLoading: false,
+      groupAccountListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+      groupYearlyAccountListLoading: false,
+      groupYearlyAccountListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_EDIT_GROUP_ACCOUNT = 'START_EDIT_GROUP_ACCOUNT';
+export const startEditGroupAccountAction = () => {
+  return {
+    type: START_EDIT_GROUP_ACCOUNT,
+    payload: {
+      groupAccountListLoading: true,
+    },
   };
 };
 
@@ -101,20 +477,81 @@ export const EDIT_GROUP_ACCOUNT = 'EDIT_GROUP_ACCOUNT';
 export const editGroupAccountAction = (groupAccountList: GroupAccountList) => {
   return {
     type: EDIT_GROUP_ACCOUNT,
-    payload: groupAccountList,
+    payload: {
+      groupAccountListLoading: false,
+      groupAccountList: groupAccountList,
+    },
+  };
+};
+
+export const FAILED_EDIT_GROUP_ACCOUNT = 'FAILED_EDIT_GROUP_ACCOUNT';
+export const failedEditGroupAccountAction = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_EDIT_GROUP_ACCOUNT,
+    payload: {
+      groupAccountListLoading: false,
+      groupAccountListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_DELETE_GROUP_ACCOUNT = 'START_DELETE_GROUP_ACCOUNT';
+export const startDeleteGroupAccountAction = () => {
+  return {
+    type: START_DELETE_GROUP_ACCOUNT,
+    payload: {
+      groupAccountListLoading: true,
+      groupYearlyAccountListLoading: true,
+    },
   };
 };
 
 export const DELETE_GROUP_ACCOUNT = 'DELETE_GROUP_ACCOUNT';
 export const deleteGroupAccountAction = (
   groupAccountList: GroupAccountList,
+  groupYearlyAccountList: GroupYearlyAccountList,
   deletedMessage: string
 ) => {
   return {
     type: DELETE_GROUP_ACCOUNT,
     payload: {
-      deletedMessage,
-      groupAccountList,
+      deletedMessage: deletedMessage,
+      groupAccountListLoading: false,
+      groupAccountList: groupAccountList,
+      groupYearlyAccountListLoading: false,
+      groupYearlyAccountList: groupYearlyAccountList,
+    },
+  };
+};
+
+export const FAILED_DELETE_GROUP_ACCOUNT = 'FAILED_DELETE_GROUP_ACCOUNT';
+export const failedDeleteGroupAccountAction = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_DELETE_GROUP_ACCOUNT,
+    payload: {
+      groupAccountListLoading: false,
+      groupAccountListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+      groupYearlyAccountListLoading: false,
+      groupYearlyAccountListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_SEARCH_GROUP_TRANSACTIONS = 'START_SEARCH_GROUP_TRANSACTIONS';
+export const startSearchGroupTransactionsAction = () => {
+  return {
+    type: START_SEARCH_GROUP_TRANSACTIONS,
+    payload: {
+      groupSearchTransactionsListLoading: true,
     },
   };
 };
@@ -127,8 +564,23 @@ export const searchGroupTransactionsAction = (
   return {
     type: SEARCH_GROUP_TRANSACTIONS,
     payload: {
-      groupSearchTransactionsList,
-      notHistoryMessage,
+      groupSearchTransactionsListLoading: false,
+      groupSearchTransactionsList: groupSearchTransactionsList,
+      notHistoryMessage: notHistoryMessage,
+    },
+  };
+};
+
+export const FAILED_SEARCH_GROUP_TRANSACTIONS = 'FAILED_SEARCH_GROUP_TRANSACTIONS';
+export const failedSearchGroupTransactionsAction = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_SEARCH_GROUP_TRANSACTIONS,
+    payload: {
+      groupSearchTransactionsListLoading: true,
+      groupSearchTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
     },
   };
 };

--- a/src/reducks/groupTransactions/reducers.ts
+++ b/src/reducks/groupTransactions/reducers.ts
@@ -7,32 +7,127 @@ export const groupTransactionsReducer = (
   action: groupTransactionsAction
 ) => {
   switch (action.type) {
-    case Actions.START_FETCH_DATA:
+    case Actions.START_FETCH_GROUP_TRANSACTIONS:
       return {
         ...state,
         ...action.payload,
       };
-    case Actions.FAILED_FETCH_DATA:
+    case Actions.FETCH_GROUP_TRANSACTIONS:
       return {
         ...state,
-        groupTransactionsError: action.payload,
+        ...action.payload,
       };
-    case Actions.UPDATE_GROUP_TRANSACTIONS:
+    case Actions.CANCEL_FETCH_GROUP_TRANSACTIONS:
       return {
         ...state,
-        groupTransactionsList: [...action.payload],
+        ...action.payload,
       };
-    case Actions.UPDATE_GROUP_LATEST_TRANSACTIONS:
+    case Actions.FAILED_FETCH_GROUP_TRANSACTIONS:
       return {
         ...state,
-        groupLatestTransactionsList: [...action.payload],
+        ...action.payload,
+      };
+    case Actions.START_FETCH_GROUP_LATEST_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FETCH_GROUP_LATEST_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.CANCEL_FETCH_GROUP_LATEST_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_FETCH_GROUP_LATEST_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_ADD_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.ADD_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_ADD_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_EDIT_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.EDIT_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_DELETE_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.DELETE_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_DELETE_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_FETCH_GROUP_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
       };
     case Actions.FETCH_GROUP_ACCOUNT:
       return {
         ...state,
-        groupAccountList: action.payload,
+        ...action.payload,
+      };
+    case Actions.CANCEL_FETCH_GROUP_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_FETCH_GROUP_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_FETCH_GROUP_YEARLY_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
       };
     case Actions.FETCH_GROUP_YEARLY_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.CANCEL_FETCH_GROUP_YEARLY_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_FETCH_GROUP_YEARLY_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_FETCH_YEARLY_ACCOUNT_MODAL:
       return {
         ...state,
         ...action.payload,
@@ -42,22 +137,67 @@ export const groupTransactionsReducer = (
         ...state,
         ...action.payload,
       };
+    case Actions.CANCEL_FETCH_YEARLY_ACCOUNT_MODAL:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_FETCH_YEARLY_ACCOUNT_MODAL:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_ADD_GROUP_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.ADD_GROUP_ACCOUNT:
       return {
         ...state,
-        groupAccountList: action.payload,
+        ...action.payload,
+      };
+    case Actions.FAILED_ADD_GROUP_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_EDIT_GROUP_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
       };
     case Actions.EDIT_GROUP_ACCOUNT:
       return {
         ...state,
-        groupAccountList: action.payload,
+        ...action.payload,
+      };
+    case Actions.START_DELETE_GROUP_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
       };
     case Actions.DELETE_GROUP_ACCOUNT:
       return {
         ...state,
         ...action.payload,
       };
+    case Actions.FAILED_DELETE_GROUP_ACCOUNT:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_SEARCH_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.SEARCH_GROUP_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_SEARCH_GROUP_TRANSACTIONS:
       return {
         ...state,
         ...action.payload,

--- a/src/reducks/groupTransactions/selectors.ts
+++ b/src/reducks/groupTransactions/selectors.ts
@@ -36,7 +36,7 @@ export const getSearchGroupTransactions = createSelector(
   (state) => state.groupSearchTransactionsList
 );
 
-const errorInfo = (state: State) => state.groupTransactions.groupTransactionsError;
+const errorInfo = (state: State) => state.groupTransactions.groupAccountListError;
 
 export const getStatusNotFoundMessage = createSelector([errorInfo], (errorInfo) => {
   let errorMessage;

--- a/src/reducks/groupTransactions/types.ts
+++ b/src/reducks/groupTransactions/types.ts
@@ -18,12 +18,6 @@ export interface GroupTransactions {
   custom_category_name: string | null;
 }
 
-export interface ErrorInfo {
-  loading: boolean;
-  statusCode: number;
-  errorMessage: string;
-}
-
 export interface YearlyAccountStatus {
   year: string;
   accountedMonth: string[];

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -34,10 +34,24 @@ const initialState = {
     notHistoryMessage: '',
   },
   groupTransactions: {
-    loading: false,
     groupLatestTransactionsList: [],
+    groupLatestTransactionsListLoading: false,
+    groupLatestTransactionsListError: {
+      statusCode: 0,
+      errorMessage: '',
+    },
     groupTransactionsList: [],
+    groupTransactionsListLoading: false,
+    groupTransactionsListError: {
+      statusCode: 0,
+      errorMessage: '',
+    },
     groupSearchTransactionsList: [],
+    groupSearchTransactionsListLoading: false,
+    groupSearchTransactionsListError: {
+      statusCode: 0,
+      errorMessage: '',
+    },
     notHistoryMessage: '',
     deletedMessage: '',
     groupAccountList: {
@@ -48,16 +62,26 @@ const initialState = {
       group_remaining_amount: 0,
       group_accounts_list_by_payer: [],
     },
+    groupAccountListLoading: false,
+    groupAccountListError: {
+      statusCode: 0,
+      errorMessage: '',
+    },
     groupYearlyAccountList: {
       year: '',
       yearly_accounting_status: [],
+    },
+    groupYearlyAccountListLoading: false,
+    groupYearlyAccountListError: {
+      statusCode: 0,
+      errorMessage: '',
     },
     groupYearlyAccountListForModal: {
       year: '',
       yearly_accounting_status: [],
     },
-    groupTransactionsError: {
-      loading: false,
+    groupYearlyAccountListForModalLoading: false,
+    groupYearlyAccountListForModalError: {
       statusCode: 0,
       errorMessage: '',
     },

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -6,7 +6,6 @@ import {
   GroupTransactionsList,
   GroupAccountList,
   GroupYearlyAccountList,
-  ErrorInfo,
 } from '../groupTransactions/types';
 import { StandardBudgetsList, YearlyBudgetsList, CustomBudgetsList } from '../budgets/types';
 import {
@@ -58,14 +57,43 @@ export interface State {
   };
   groupTransactions: {
     groupLatestTransactionsList: GroupTransactionsList;
+    groupLatestTransactionsListLoading: boolean;
+    groupLatestTransactionsListError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     groupTransactionsList: GroupTransactionsList;
+    groupTransactionsListLoading: boolean;
+    groupTransactionsListError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     groupSearchTransactionsList: GroupTransactionsList;
+    groupSearchTransactionsListLoading: boolean;
+    groupSearchTransactionsListError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     groupAccountList: GroupAccountList;
+    groupAccountListLoading: boolean;
+    groupAccountListError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     groupYearlyAccountList: GroupYearlyAccountList;
+    groupYearlyAccountListLoading: boolean;
+    groupYearlyAccountListError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     groupYearlyAccountListForModal: GroupYearlyAccountList;
+    groupYearlyAccountListForModalLoading: boolean;
+    groupYearlyAccountListForModalError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     notAccountMessage: string;
     deletedMessage: string;
-    groupTransactionsError: ErrorInfo;
   };
   budgets: {
     standard_budgets_list: StandardBudgetsList;

--- a/test/group-transactions-test/deletedYearlyAccountList.json
+++ b/test/group-transactions-test/deletedYearlyAccountList.json
@@ -1,0 +1,77 @@
+{
+  "Year": "2020年",
+  "yearly_accounting_status": [
+    {
+      "month": "1月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "2月",
+      "calculation_status": "精算済",
+      "payment_status": "受領待ち: 1件",
+      "receipt_status": "-"
+    },
+    {
+      "month": "3月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "4月",
+      "calculation_status": "未精算",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "5月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "6月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "7月",
+      "calculation_status": "精算済",
+      "payment_status": "-",
+      "receipt_status": "支払待ち: 3件"
+    },
+    {
+      "month": "8月",
+      "calculation_status": "精算済",
+      "payment_status": "-",
+      "receipt_status": "支払待ち: 6件"
+    },
+    {
+      "month": "9月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "10月",
+      "calculation_status": "精算済",
+      "payment_status": "-",
+      "receipt_status": "支払待ち: 6件"
+    },
+    {
+      "month": "11月",
+      "calculation_status": "未精算",
+      "payment_status": "-",
+      "receipt_status": "-"
+    },
+    {
+      "month": "12月",
+      "calculation_status": "-",
+      "payment_status": "-",
+      "receipt_status": "-"
+    }
+  ]
+}


### PR DESCRIPTION
- `groupTransactions`のミドルウェアが肥大化していたのでadd, edit, deleteのロジックの部分を削除し、fetch処理を追加する
   ことで更新後の値をコンポーネントに反映させる形に修正しました。

- loadingの開始`START`、処理の失敗時`FAILED`のactionを追加しました。

- 上記の変更に伴い、`groupTransactions/actions, groupTransactions/reducers, GroupTransactions.test`を修正しました。