### PR TITLE
Modify operations for groupBudgets and add action for starting loadin…

### DIFF
--- a/src/containers/budgets/AddCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/AddCustomBudgetsContainer.tsx
@@ -78,7 +78,11 @@ const AddCustomBudgetsContainer = (props: AddCustomBudgetsContainerProps) => {
               queryMonth,
               signal,
               customBudgets.map((budget) => {
-                const { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
+                const {
+                  big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+                  last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+                  ...rest
+                } = budget;
                 return {
                   big_category_id: rest.big_category_id,
                   budget: Number(rest.budget),

--- a/src/containers/budgets/AddGroupCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/AddGroupCustomBudgetsContainer.tsx
@@ -87,7 +87,11 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
               Number(group_id),
               signal,
               groupCustomBudgets.map((groupCustomBudget) => {
-                const { big_category_name, last_month_expenses, ...rest } = groupCustomBudget; // eslint-disable-line
+                const {
+                  big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+                  last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+                  ...rest
+                } = groupCustomBudget;
                 return {
                   big_category_id: rest.big_category_id,
                   budget: Number(rest.budget),

--- a/src/containers/budgets/AddGroupCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/AddGroupCustomBudgetsContainer.tsx
@@ -46,10 +46,12 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
   useEffect(() => {
     if (!editing) {
       const signal = axios.CancelToken.source();
+
       fetchEditGroupStandardBudgetsData(signal);
       const interval = setInterval(() => {
         fetchEditGroupStandardBudgetsData(signal);
       }, 3000);
+
       return () => {
         signal.cancel();
         clearInterval(interval);
@@ -77,11 +79,13 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
       }
       addGroupCustomBudgetOperation={() => {
         if (queryMonth != null) {
+          const signal = axios.CancelToken.source();
           dispatch(
             addGroupCustomBudgets(
               String(props.budgetsYear),
               queryMonth,
               Number(group_id),
+              signal,
               groupCustomBudgets.map((groupCustomBudget) => {
                 const { big_category_name, last_month_expenses, ...rest } = groupCustomBudget; // eslint-disable-line
                 return {

--- a/src/containers/budgets/CustomBudgetsContainer.tsx
+++ b/src/containers/budgets/CustomBudgetsContainer.tsx
@@ -72,7 +72,11 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
               queryMonth,
               signal,
               customBudgets.map((budget) => {
-                const { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
+                const {
+                  big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+                  last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+                  ...rest
+                } = budget;
                 return {
                   big_category_id: rest.big_category_id,
                   budget: Number(rest.budget),

--- a/src/containers/budgets/GroupCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupCustomBudgetsContainer.tsx
@@ -75,11 +75,13 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
       }
       editGroupCustomBudgetOperation={() => {
         if (queryMonth != null) {
+          const signal = axios.CancelToken.source();
           dispatch(
             editGroupCustomBudgets(
               String(props.budgetsYear),
               queryMonth,
               Number(group_id),
+              signal,
               groupCustomBudgets.map((groupBudget) => {
                 const { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
                 return {

--- a/src/containers/budgets/GroupCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupCustomBudgetsContainer.tsx
@@ -83,7 +83,11 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
               Number(group_id),
               signal,
               groupCustomBudgets.map((groupBudget) => {
-                const { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
+                const {
+                  big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+                  last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+                  ...rest
+                } = groupBudget;
                 return {
                   big_category_id: rest.big_category_id,
                   budget: Number(rest.budget),

--- a/src/containers/budgets/GroupStandardBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupStandardBudgetsContainer.tsx
@@ -31,10 +31,12 @@ const GroupStandardBudgetsContainer = () => {
   useEffect(() => {
     if (!editing) {
       const signal = axios.CancelToken.source();
+
       fetchGroupStandardBudgetsData(signal);
       const interval = setInterval(() => {
         fetchGroupStandardBudgetsData(signal);
       }, 3000);
+
       return () => {
         signal.cancel();
         clearInterval(interval);
@@ -53,10 +55,12 @@ const GroupStandardBudgetsContainer = () => {
       groupStandardBudgets={groupStandardBudgets}
       setGroupStandardBudgets={setGroupStandardBudgets}
       groupTotalStandardBudget={groupTotalStandardBudget}
-      editGroupStandardBudgetOperation={() =>
+      editGroupStandardBudgetOperation={() => {
+        const signal = axios.CancelToken.source();
         dispatch(
           editGroupStandardBudgets(
             Number(group_id),
+            signal,
             groupStandardBudgets.map((groupBudget) => {
               const { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
               return {
@@ -65,8 +69,8 @@ const GroupStandardBudgetsContainer = () => {
               };
             })
           )
-        )
-      }
+        );
+      }}
     />
   );
 };

--- a/src/containers/budgets/GroupStandardBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupStandardBudgetsContainer.tsx
@@ -62,7 +62,11 @@ const GroupStandardBudgetsContainer = () => {
             Number(group_id),
             signal,
             groupStandardBudgets.map((groupBudget) => {
-              const { big_category_name, last_month_expenses, ...rest } = groupBudget; // eslint-disable-line
+              const {
+                big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+                last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+                ...rest
+              } = groupBudget;
               return {
                 big_category_id: rest.big_category_id,
                 budget: Number(rest.budget),

--- a/src/containers/budgets/GroupYearlyBudgetsRowContainer.tsx
+++ b/src/containers/budgets/GroupYearlyBudgetsRowContainer.tsx
@@ -48,9 +48,10 @@ const GroupYearlyBudgetsRowContainer = (props: GroupYearlyBudgetsRowContainerPro
     <GroupYearlyBudgetsRow
       years={props.budgetsYear}
       groupYearlyBudgets={groupYearlyBudgets}
-      deleteCustomBudgets={(selectYear, selectMonth) =>
-        dispatch(deleteGroupCustomBudgets(selectYear, selectMonth, Number(group_id)))
-      }
+      deleteCustomBudgets={(selectYear, selectMonth) => {
+        const signal = axios.CancelToken.source();
+        dispatch(deleteGroupCustomBudgets(selectYear, selectMonth, Number(group_id), signal));
+      }}
       routingEditBudgets={(routingAddress, selectYear, selectMonth) => {
         if (routingAddress === 'custom') {
           history.push({

--- a/src/containers/budgets/StandardBudgetsContainer.tsx
+++ b/src/containers/budgets/StandardBudgetsContainer.tsx
@@ -40,7 +40,11 @@ const StandardBudgetsContainer = () => {
         dispatch(
           editStandardBudgets(
             budgets.map((budget) => {
-              const { big_category_name, last_month_expenses, ...rest } = budget; // eslint-disable-line
+              const {
+                big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+                last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+                ...rest
+              } = budget;
               return {
                 big_category_id: rest.big_category_id,
                 budget: Number(rest.budget),

--- a/src/reducks/groupBudgets/actions.ts
+++ b/src/reducks/groupBudgets/actions.ts
@@ -1,14 +1,42 @@
 import { GroupStandardBudgetsList, GroupYearlyBudgetsList, GroupCustomBudgetsList } from './types';
 
 export type groupBudgetsActions = ReturnType<
+  | typeof startFetchGroupStandardBudgetsActions
   | typeof fetchGroupStandardBudgetsActions
+  | typeof cancelFetchGroupStandardBudgetsActions
+  | typeof failedFetchGroupStandardBudgetsActions
+  | typeof startEditGroupStandardBudgetsActions
   | typeof editGroupStandardBudgetsActions
-  | typeof fetchGroupYearlyBudgetsActions
+  | typeof failedEditGroupStandardBudgetsActions
+  | typeof copyGroupStandardBudgetsActions
+  | typeof startFetchGroupCustomBudgetsActions
   | typeof fetchGroupCustomBudgetsActions
+  | typeof cancelFetchGroupCustomBudgetsActions
+  | typeof failedFetchGroupCustomBudgetsActions
+  | typeof startAddGroupCustomBudgetsActions
   | typeof addGroupCustomBudgetsActions
+  | typeof failedAddGroupCustomBudgetsActions
+  | typeof startEditGroupCustomBudgetsActions
   | typeof editGroupCustomBudgetsActions
+  | typeof failedEditGroupCustomBudgetsActions
+  | typeof startDeleteGroupCustomBudgetsActions
   | typeof deleteGroupCustomBudgetsActions
+  | typeof failedDeleteGroupCustomBudgetsActions
+  | typeof startFetchGroupYearlyBudgetsActions
+  | typeof fetchGroupYearlyBudgetsActions
+  | typeof cancelFetchGroupYearlyBudgetsActions
+  | typeof failedFetchGroupYearlyBudgetsActions
 >;
+
+export const START_FETCH_GROUP_STANDARD_BUDGETS = 'START_FETCH_GROUP_STANDARD_BUDGETS';
+export const startFetchGroupStandardBudgetsActions = () => {
+  return {
+    type: START_FETCH_GROUP_STANDARD_BUDGETS,
+    payload: {
+      groupStandardBudgetsLoading: true,
+    },
+  };
+};
 
 export const FETCH_GROUP_STANDARD_BUDGETS = 'FETCH_GROUP_STANDARD_BUDGETS';
 export const fetchGroupStandardBudgetsActions = (
@@ -16,7 +44,47 @@ export const fetchGroupStandardBudgetsActions = (
 ) => {
   return {
     type: FETCH_GROUP_STANDARD_BUDGETS,
-    payload: groupStandardBudgetsList,
+    payload: {
+      groupStandardBudgetsLoading: false,
+      groupStandardBudgetsList: groupStandardBudgetsList,
+    },
+  };
+};
+
+export const CANCEL_FETCH_GROUP_STANDARD_BUDGETS = 'CANCEL_FETCH_GROUP_STANDARD_BUDGETS';
+export const cancelFetchGroupStandardBudgetsActions = () => {
+  return {
+    type: CANCEL_FETCH_GROUP_STANDARD_BUDGETS,
+    payload: {
+      groupStandardBudgetsLoading: false,
+    },
+  };
+};
+
+export const FAILED_FETCH_GROUP_STANDARD_BUDGETS = 'FAILED_FETCH_GROUP_STANDARD_BUDGETS';
+export const failedFetchGroupStandardBudgetsActions = (
+  statusCode: number,
+  errorMessage: string
+) => {
+  return {
+    type: FAILED_FETCH_GROUP_STANDARD_BUDGETS,
+    payload: {
+      groupStandardBudgetsLoading: false,
+      groupStandardBudgetsError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_EDIT_GROUP_STANDARD_BUDGETS = 'START_EDIT_GROUP_STANDARD_BUDGETS';
+export const startEditGroupStandardBudgetsActions = () => {
+  return {
+    type: START_EDIT_GROUP_STANDARD_BUDGETS,
+    payload: {
+      groupStandardBudgetsLoading: true,
+    },
   };
 };
 
@@ -26,15 +94,34 @@ export const editGroupStandardBudgetsActions = (
 ) => {
   return {
     type: EDIT_GROUP_STANDARD_BUDGETS,
-    payload: groupStandardBudgetsList,
+    payload: {
+      groupStandardBudgetsLoading: false,
+      groupStandardBudgetsList: groupStandardBudgetsList,
+    },
   };
 };
 
-export const FETCH_GROUP_YEARLY_BUDGETS = 'FETCH_GROUP_YEARLY_BUDGETS';
-export const fetchGroupYearlyBudgetsActions = (groupYearlyBudgetsList: GroupYearlyBudgetsList) => {
+export const FAILED_EDIT_GROUP_STANDARD_BUDGETS = 'FAILED_EDIT_GROUP_STANDARD_BUDGETS';
+export const failedEditGroupStandardBudgetsActions = (statusCode: number, errorMessage: string) => {
   return {
-    type: FETCH_GROUP_YEARLY_BUDGETS,
-    payload: groupYearlyBudgetsList,
+    type: FAILED_EDIT_GROUP_STANDARD_BUDGETS,
+    payload: {
+      groupStandardBudgetsLoading: false,
+      groupStandardBudgetsError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_FETCH_GROUP_CUSTOM_BUDGETS = 'START_FETCH_GROUP_CUSTOM_BUDGETS';
+export const startFetchGroupCustomBudgetsActions = () => {
+  return {
+    type: START_FETCH_GROUP_CUSTOM_BUDGETS,
+    payload: {
+      groupCustomBudgetsLoading: true,
+    },
   };
 };
 
@@ -42,23 +129,118 @@ export const FETCH_GROUP_CUSTOM_BUDGETS = 'FETCH_GROUP_CUSTOM_BUDGETS';
 export const fetchGroupCustomBudgetsActions = (groupCustomBudgetsList: GroupCustomBudgetsList) => {
   return {
     type: FETCH_GROUP_CUSTOM_BUDGETS,
-    payload: groupCustomBudgetsList,
+    payload: {
+      groupCustomBudgetsLoading: false,
+      groupCustomBudgetsList: groupCustomBudgetsList,
+    },
+  };
+};
+
+export const CANCEL_FETCH_GROUP_CUSTOM_BUDGETS = 'CANCEL_FETCH_GROUP_CUSTOM_BUDGETS';
+export const cancelFetchGroupCustomBudgetsActions = () => {
+  return {
+    type: CANCEL_FETCH_GROUP_CUSTOM_BUDGETS,
+    payload: {
+      groupCustomBudgetsLoading: false,
+    },
+  };
+};
+
+export const FAILED_FETCH_GROUP_CUSTOM_BUDGETS = 'FAILED_FETCH_GROUP_CUSTOM_BUDGETS';
+export const failedFetchGroupCustomBudgetsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_FETCH_GROUP_CUSTOM_BUDGETS,
+    payload: {
+      groupCustomBudgetsLoading: false,
+      groupCustomBudgetsError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_ADD_GROUP_CUSTOM_BUDGETS = 'START_ADD_GROUP_CUSTOM_BUDGETS';
+export const startAddGroupCustomBudgetsActions = () => {
+  return {
+    type: START_ADD_GROUP_CUSTOM_BUDGETS,
+    payload: {
+      groupCustomBudgetsLoading: true,
+      groupYearlyBudgetsLoading: true,
+    },
   };
 };
 
 export const ADD_GROUP_CUSTOM_BUDGETS = 'ADD_GROUP_CUSTOM_BUDGETS';
-export const addGroupCustomBudgetsActions = (groupYearlyBudgetsList: GroupYearlyBudgetsList) => {
+export const addGroupCustomBudgetsActions = (
+  groupCustomBudgetsList: GroupCustomBudgetsList,
+  groupYearlyBudgetsList: GroupYearlyBudgetsList
+) => {
   return {
     type: ADD_GROUP_CUSTOM_BUDGETS,
-    payload: groupYearlyBudgetsList,
+    payload: {
+      groupCustomBudgetsLoading: false,
+      groupCustomBudgetsList: groupCustomBudgetsList,
+      groupYearlyBudgetsLoading: false,
+      groupYearlyBudgetsList: groupYearlyBudgetsList,
+    },
+  };
+};
+
+export const FAILED_ADD_GROUP_CUSTOM_BUDGETS = 'FAILED_ADD_GROUP_CUSTOM_BUDGETS';
+export const failedAddGroupCustomBudgetsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_ADD_GROUP_CUSTOM_BUDGETS,
+    payload: {
+      groupCustomBudgetsLoading: false,
+      groupYearlyBudgetsLoading: false,
+      groupCustomBudgetsError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_EDIT_GROUP_CUSTOM_BUDGETS = 'START_EDIT_GROUP_CUSTOM_BUDGETS';
+export const startEditGroupCustomBudgetsActions = () => {
+  return {
+    type: START_EDIT_GROUP_CUSTOM_BUDGETS,
+    payload: {
+      groupCustomBudgetsLoading: true,
+      groupYearlyBudgetsLoading: true,
+    },
   };
 };
 
 export const EDIT_GROUP_CUSTOM_BUDGETS = 'EDIT_GROUP_CUSTOM_BUDGETS';
-export const editGroupCustomBudgetsActions = (groupYearlyBudgetsList: GroupYearlyBudgetsList) => {
+export const editGroupCustomBudgetsActions = (
+  groupCustomBudgetsList: GroupCustomBudgetsList,
+  groupYearlyBudgetsList: GroupYearlyBudgetsList
+) => {
   return {
     type: EDIT_GROUP_CUSTOM_BUDGETS,
-    payload: groupYearlyBudgetsList,
+    payload: {
+      groupCustomBudgetsLoading: false,
+      groupCustomBudgetsList: groupCustomBudgetsList,
+      groupYearlyBudgetsLoading: false,
+      groupYearlyBudgetsList: groupYearlyBudgetsList,
+    },
+  };
+};
+
+export const FAILED_EDIT_GROUP_CUSTOM_BUDGETS = 'FAILED_EDIT_GROUP_CUSTOM_BUDGETS';
+export const failedEditGroupCustomBudgetsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_EDIT_GROUP_CUSTOM_BUDGETS,
+    payload: {
+      groupCustomBudgetsLoading: false,
+      groupYearlyBudgetsLoading: false,
+      groupCustomBudgetsError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
   };
 };
 
@@ -66,7 +248,19 @@ export const COPY_GROUP_STANDARD_BUDGETS = 'COPY_GROUP_STANDARD_BUDGETS';
 export const copyGroupStandardBudgetsActions = (groupCustomBudgetsList: GroupCustomBudgetsList) => {
   return {
     type: COPY_GROUP_STANDARD_BUDGETS,
-    payload: groupCustomBudgetsList,
+    payload: {
+      groupCustomBudgetsList: groupCustomBudgetsList,
+    },
+  };
+};
+
+export const START_DELETE_GROUP_CUSTOM_BUDGETS = 'START_DELETE_GROUP_CUSTOM_BUDGETS';
+export const startDeleteGroupCustomBudgetsActions = () => {
+  return {
+    type: START_DELETE_GROUP_CUSTOM_BUDGETS,
+    payload: {
+      groupYearlyBudgetsLoading: true,
+    },
   };
 };
 
@@ -74,6 +268,68 @@ export const DELETE_GROUP_CUSTOM_BUDGETS = 'DELETE_GROUP_CUSTOM_BUDGETS';
 export const deleteGroupCustomBudgetsActions = (groupYearlyBudgetsList: GroupYearlyBudgetsList) => {
   return {
     type: DELETE_GROUP_CUSTOM_BUDGETS,
-    payload: groupYearlyBudgetsList,
+    payload: {
+      groupYearlyBudgetsLoading: false,
+      groupYearlyBudgetsList: groupYearlyBudgetsList,
+    },
+  };
+};
+
+export const FAILED_DELETE_GROUP_CUSTOM_BUDGETS = 'FAILED_DELETE_GROUP_CUSTOM_BUDGETS';
+export const failedDeleteGroupCustomBudgetsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_DELETE_GROUP_CUSTOM_BUDGETS,
+    payload: {
+      groupYearlyBudgetsLoading: false,
+      groupCustomBudgetsError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_FETCH_GROUP_YEARLY_BUDGETS = 'START_FETCH_GROUP_YEARLY_BUDGETS';
+export const startFetchGroupYearlyBudgetsActions = () => {
+  return {
+    type: START_FETCH_GROUP_YEARLY_BUDGETS,
+    payload: {
+      groupYearlyBudgetsLoading: true,
+    },
+  };
+};
+
+export const FETCH_GROUP_YEARLY_BUDGETS = 'FETCH_GROUP_YEARLY_BUDGETS';
+export const fetchGroupYearlyBudgetsActions = (groupYearlyBudgetsList: GroupYearlyBudgetsList) => {
+  return {
+    type: FETCH_GROUP_YEARLY_BUDGETS,
+    payload: {
+      groupYearlyBudgetsLoading: false,
+      groupYearlyBudgetsList: groupYearlyBudgetsList,
+    },
+  };
+};
+
+export const CANCEL_FETCH_GROUP_YEARLY_BUDGETS = 'CANCEL_FETCH_GROUP_YEARLY_BUDGETS';
+export const cancelFetchGroupYearlyBudgetsActions = () => {
+  return {
+    type: CANCEL_FETCH_GROUP_YEARLY_BUDGETS,
+    payload: {
+      groupYearlyBudgetsLoading: false,
+    },
+  };
+};
+
+export const FAILED_FETCH_GROUP_YEARLY_BUDGETS = 'FAILED_FETCH_GROUP_YEARLY_BUDGETS';
+export const failedFetchGroupYearlyBudgetsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_FETCH_GROUP_YEARLY_BUDGETS,
+    payload: {
+      groupYearlyBudgetsLoading: false,
+      groupYearlyBudgetsError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
   };
 };

--- a/src/reducks/groupBudgets/reducers.ts
+++ b/src/reducks/groupBudgets/reducers.ts
@@ -7,45 +7,130 @@ export const groupBudgetsReducer = (
   action: groupBudgetsActions
 ) => {
   switch (action.type) {
+    case Actions.START_FETCH_GROUP_STANDARD_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.FETCH_GROUP_STANDARD_BUDGETS:
       return {
         ...state,
-        groupStandardBudgetsList: [...action.payload],
+        ...action.payload,
+      };
+    case Actions.CANCEL_FETCH_GROUP_STANDARD_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_FETCH_GROUP_STANDARD_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_EDIT_GROUP_STANDARD_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
       };
     case Actions.EDIT_GROUP_STANDARD_BUDGETS:
       return {
         ...state,
-        groupStandardBudgetsList: [...action.payload],
+        ...action.payload,
+      };
+    case Actions.FAILED_EDIT_GROUP_STANDARD_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_FETCH_GROUP_YEARLY_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
       };
     case Actions.FETCH_GROUP_YEARLY_BUDGETS:
       return {
         ...state,
-        groupYearlyBudgetsList: action.payload,
+        ...action.payload,
+      };
+    case Actions.CANCEL_FETCH_GROUP_YEARLY_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_FETCH_GROUP_YEARLY_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_FETCH_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
       };
     case Actions.FETCH_GROUP_CUSTOM_BUDGETS:
       return {
         ...state,
-        groupCustomBudgetsList: [...action.payload],
+        ...action.payload,
       };
-    case Actions.ADD_GROUP_CUSTOM_BUDGETS:
+    case Actions.CANCEL_FETCH_GROUP_CUSTOM_BUDGETS:
       return {
         ...state,
-        groupYearlyBudgetsList: action.payload,
+        ...action.payload,
       };
-    case Actions.EDIT_GROUP_CUSTOM_BUDGETS:
+    case Actions.FAILED_FETCH_GROUP_CUSTOM_BUDGETS:
       return {
         ...state,
-        groupYearlyBudgetsList: action.payload,
+        ...action.payload,
       };
     case Actions.COPY_GROUP_STANDARD_BUDGETS:
       return {
         ...state,
-        groupCustomBudgetsList: [...action.payload],
+        ...action.payload,
+      };
+    case Actions.START_ADD_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.ADD_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_ADD_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_EDIT_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.EDIT_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_EDIT_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_DELETE_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
       };
     case Actions.DELETE_GROUP_CUSTOM_BUDGETS:
       return {
         ...state,
-        groupYearlyBudgetsList: action.payload,
+        ...action.payload,
+      };
+    case Actions.FAILED_DELETE_GROUP_CUSTOM_BUDGETS:
+      return {
+        ...state,
+        ...action.payload,
       };
     default:
       return state;

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -112,11 +112,26 @@ const initialState = {
   },
   groupBudgets: {
     groupStandardBudgetsList: [],
+    groupStandardBudgetsLoading: false,
+    groupStandardBudgetsError: {
+      statusCode: 0,
+      errorMessage: '',
+    },
     groupCustomBudgetsList: [],
+    groupCustomBudgetsLoading: false,
+    groupCustomBudgetsError: {
+      statusCode: 0,
+      errorMessage: '',
+    },
     groupYearlyBudgetsList: {
       year: '',
       yearly_total_budget: 0,
       monthly_budgets: [],
+    },
+    groupYearlyBudgetsLoading: false,
+    groupYearlyBudgetsError: {
+      statusCode: 0,
+      errorMessage: '',
     },
   },
   groupTasks: {

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -117,8 +117,23 @@ export interface State {
   };
   groupBudgets: {
     groupStandardBudgetsList: GroupStandardBudgetsList;
-    groupYearlyBudgetsList: GroupYearlyBudgetsList;
+    groupStandardBudgetsLoading: boolean;
+    groupStandardBudgetsError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     groupCustomBudgetsList: GroupCustomBudgetsList;
+    groupCustomBudgetsLoading: boolean;
+    groupCustomBudgetsError: {
+      statusCode: number;
+      errorMessage: string;
+    };
+    groupYearlyBudgetsList: GroupYearlyBudgetsList;
+    groupYearlyBudgetsLoading: boolean;
+    groupYearlyBudgetsError: {
+      statusCode: number;
+      errorMessage: string;
+    };
   };
   groupTasks: {
     groupTasksListForEachUser: GroupTasksListForEachUser;

--- a/test/group-budgets-test/GroupBudgets.test.ts
+++ b/test/group-budgets-test/GroupBudgets.test.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as actionTypes from '../../src/reducks/groupBudgets/actions';
 import axios from 'axios';
 import axiosMockAdapter from 'axios-mock-adapter';
@@ -28,50 +27,50 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 process.on('unhandledRejection', console.dir);
 
-describe('async actions fetchGroupStandardBudgets', () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-  const store = mockStore({ groupBudgets: { groupStandardBudgetsList: [] } });
-
-  const groupId = 1;
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`;
-
+describe('async actions groupBudgets', () => {
   it('Get groupStandardBudgetsList if fetch succeeds', async () => {
-    const mockResponse = groupStandardBudgets;
+    beforeEach(() => {
+      store.clearActions();
+    });
+
+    const store = mockStore({ groupBudgets: { groupStandardBudgetsList: [] } });
+    const groupId = 1;
     const signal = axios.CancelToken.source();
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`;
+    const fetchedGroupStandardBudgetsList = groupStandardBudgets;
 
     const expectedActions = [
       {
+        type: actionTypes.START_FETCH_GROUP_STANDARD_BUDGETS,
+        payload: {
+          groupStandardBudgetsLoading: true,
+        },
+      },
+      {
         type: actionTypes.FETCH_GROUP_STANDARD_BUDGETS,
-        payload: mockResponse.standard_budgets,
+        payload: {
+          groupStandardBudgetsLoading: false,
+          groupStandardBudgetsList: fetchedGroupStandardBudgetsList.standard_budgets,
+        },
       },
     ];
 
-    axiosMock.onGet(url).reply(200, mockResponse);
+    axiosMock.onGet(url).reply(200, fetchedGroupStandardBudgetsList);
 
     await fetchGroupStandardBudgets(groupId, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
-});
-
-describe('async actions editGroupStandardBudgets', () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-  const store = mockStore({ groupStandardBudgets });
-
-  const groupId = 1;
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`;
 
   it('Edit groupStandard_budgets if fetch succeeds', async () => {
-    const getState = () => {
-      return {
-        groupBudgets: {
-          groupStandardBudgetsList: groupStandardBudgets.standard_budgets,
-        },
-      };
-    };
+    beforeEach(() => {
+      store.clearActions();
+    });
+    const store = mockStore({ groupStandardBudgets });
+
+    const groupId = 1;
+    const signal = axios.CancelToken.source();
+    const editUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`;
+    const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`;
 
     const mockRequest = {
       standard_budgets: [
@@ -141,105 +140,120 @@ describe('async actions editGroupStandardBudgets', () => {
         },
       ],
     };
-    const mockResponse = groupEditedStandardBudgets;
+    const editedGroupStandardBudgetsList = groupEditedStandardBudgets;
 
     const expectedActions = [
+      {
+        type: actionTypes.START_EDIT_GROUP_STANDARD_BUDGETS,
+        payload: {
+          groupStandardBudgetsLoading: true,
+        },
+      },
       {
         type: actionTypes.EDIT_GROUP_STANDARD_BUDGETS,
-        payload: mockResponse.standard_budgets,
+        payload: {
+          groupStandardBudgetsLoading: false,
+          groupStandardBudgetsList: groupEditedStandardBudgets.standard_budgets,
+        },
       },
     ];
 
-    axiosMock.onPut(url, mockRequest).reply(200, mockResponse);
+    axiosMock.onPut(editUrl, mockRequest).reply(200, editedGroupStandardBudgetsList);
+    axiosMock.onGet(fetchUrl).reply(200, editedGroupStandardBudgetsList);
 
-    await editGroupStandardBudgets(groupId, mockRequest.standard_budgets)(
-      store.dispatch,
-      // @ts-ignore
-      getState
-    );
+    await editGroupStandardBudgets(groupId, signal, mockRequest.standard_budgets)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
-});
-
-describe('async actions getGroupYearlyBudgets', () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-  const store = mockStore({ groupBudgets: { groupYearlyBudgetsList: [] } });
-
-  const date = new Date();
-  const year = date.getFullYear();
-
-  const groupId = 1;
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${year}`;
 
   it('Get groupYearlyBudgets if fetch succeeds', async () => {
-    const mockResponse = groupYearlyBudgets;
+    beforeEach(() => {
+      store.clearActions();
+    });
+    const store = mockStore({ groupBudgets: { groupYearlyBudgetsList: [] } });
+
+    const date = new Date();
+    const year = date.getFullYear();
+
+    const groupId = 1;
     const signal = axios.CancelToken.source();
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${year}`;
+
+    const fetchedGroupYearlyBudgetsList = groupYearlyBudgets;
 
     const expectedActions = [
       {
+        type: actionTypes.START_FETCH_GROUP_YEARLY_BUDGETS,
+        payload: {
+          groupYearlyBudgetsLoading: true,
+        },
+      },
+      {
         type: actionTypes.FETCH_GROUP_YEARLY_BUDGETS,
-        payload: mockResponse,
+        payload: {
+          groupYearlyBudgetsLoading: false,
+          groupYearlyBudgetsList: fetchedGroupYearlyBudgetsList,
+        },
       },
     ];
 
-    axiosMock.onGet(url).reply(200, mockResponse);
+    axiosMock.onGet(url).reply(200, fetchedGroupYearlyBudgetsList);
 
     await fetchGroupYearlyBudgets(groupId, year, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
-});
-
-describe('async actions getGroupCustomBudgets', () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-  const selectYear = '2020';
-  const selectMonth = '01';
-  const store = mockStore({ groupBudgets: { groupCustomBudgetsList: [] } });
-
-  const groupId = 1;
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
 
   it('Get groupCustomBudgets if fetch succeeds', async () => {
-    const mockResponse = groupCustomBudgets;
+    beforeEach(() => {
+      store.clearActions();
+    });
+
+    const selectYear = '2020';
+    const selectMonth = '01';
+    const store = mockStore({ groupBudgets: { groupCustomBudgetsList: [] } });
+
+    const groupId = 1;
     const signal = axios.CancelToken.source();
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+
+    const fetchedGroupCustomBudgesList = groupCustomBudgets;
 
     const expectedActions = [
       {
+        type: actionTypes.START_FETCH_GROUP_CUSTOM_BUDGETS,
+        payload: {
+          groupCustomBudgetsLoading: true,
+        },
+      },
+      {
         type: actionTypes.FETCH_GROUP_CUSTOM_BUDGETS,
-        payload: mockResponse.custom_budgets,
+        payload: {
+          groupCustomBudgetsLoading: false,
+          groupCustomBudgetsList: fetchedGroupCustomBudgesList.custom_budgets,
+        },
       },
     ];
 
-    axiosMock.onGet(url).reply(200, mockResponse);
+    axiosMock.onGet(url).reply(200, fetchedGroupCustomBudgesList);
 
     await fetchGroupCustomBudgets(selectYear, selectMonth, groupId, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
-});
-
-describe('async actions addGroupCustomBudgets', () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-  const groupId = 1;
-  const selectYear = '2020';
-  const selectMonth = '02';
-  const store = mockStore({ groupBudgets: { groupYearlyBudgetsList: groupYearlyBudgets } });
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
-
-  const getState = () => {
-    return {
-      groupBudgets: {
-        groupYearlyBudgetsList: groupYearlyBudgets,
-      },
-    };
-  };
 
   it('Add groupCustomBudgets if fetch succeeds', async () => {
-    const mockResponse = groupAddedCustomBudgets;
+    beforeEach(() => {
+      store.clearActions();
+    });
+
+    const groupId = 1;
+    const selectYear = '2020';
+    const selectMonth = '02';
+    const signal = axios.CancelToken.source();
+    const store = mockStore({ groupBudgets: { groupYearlyBudgetsList: groupYearlyBudgets } });
+    const addUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchCustomUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchYearlyUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${selectYear}`;
+
+    const addedGroupCustomBudgetsList = groupAddedCustomBudgets;
 
     const mockRequest = {
       custom_budgets: [
@@ -312,45 +326,53 @@ describe('async actions addGroupCustomBudgets', () => {
 
     const expectedActions = [
       {
+        type: actionTypes.START_ADD_GROUP_CUSTOM_BUDGETS,
+        payload: {
+          groupCustomBudgetsLoading: true,
+          groupYearlyBudgetsLoading: true,
+        },
+      },
+      {
         type: actionTypes.ADD_GROUP_CUSTOM_BUDGETS,
-        payload: addGroupCustomBudgetPayload,
+        payload: {
+          groupCustomBudgetsLoading: false,
+          groupCustomBudgetsList: addedGroupCustomBudgetsList.custom_budgets,
+          groupYearlyBudgetsLoading: false,
+          groupYearlyBudgetsList: addGroupCustomBudgetPayload,
+        },
       },
     ];
 
-    axiosMock.onPost(url).reply(201, mockResponse);
+    axiosMock.onPost(addUrl).reply(201, addedGroupCustomBudgetsList);
+    axiosMock.onGet(fetchCustomUrl).reply(200, addedGroupCustomBudgetsList);
+    axiosMock.onGet(fetchYearlyUrl).reply(200, addGroupCustomBudgetPayload);
 
     await addGroupCustomBudgets(
       selectYear,
       selectMonth,
       groupId,
+      signal,
       mockRequest.custom_budgets
-      // @ts-ignore
-    )(store.dispatch, getState);
+    )(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
-});
-
-describe('async actions editGroupCustomBudgets', () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-  const selectYear = '2020';
-  const selectMonth = '02';
-  const store = mockStore({
-    groupBudgets: { groupYearlyBudgetsList: addGroupCustomBudgetPayload },
-  });
-
-  const groupId = 1;
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
 
   it('Edit groupCustomBudgets  if fetch succeeds', async () => {
-    const getState = () => {
-      return {
-        groupBudgets: {
-          groupYearlyBudgetsList: addGroupCustomBudgetPayload,
-        },
-      };
-    };
+    beforeEach(() => {
+      store.clearActions();
+    });
+
+    const selectYear = '2020';
+    const selectMonth = '02';
+    const signal = axios.CancelToken.source();
+    const store = mockStore({
+      groupBudgets: { groupYearlyBudgetsList: addGroupCustomBudgetPayload },
+    });
+
+    const groupId = 1;
+    const editUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchCustomUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchYearlyUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${selectYear}`;
 
     const mockRequest = {
       custom_budgets: [
@@ -421,57 +443,63 @@ describe('async actions editGroupCustomBudgets', () => {
       ],
     };
 
-    const mockResponse = groupEditedCustomBudgets;
+    const editedGroupCustomBudgets = groupEditedCustomBudgets;
 
     const expectedActions = [
       {
+        type: actionTypes.START_EDIT_GROUP_CUSTOM_BUDGETS,
+        payload: {
+          groupCustomBudgetsLoading: true,
+          groupYearlyBudgetsLoading: true,
+        },
+      },
+      {
         type: actionTypes.EDIT_GROUP_CUSTOM_BUDGETS,
-        payload: editGroupCustomBudgetPayload,
+        payload: {
+          groupCustomBudgetsLoading: false,
+          groupCustomBudgetsList: editedGroupCustomBudgets.custom_budgets,
+          groupYearlyBudgetsLoading: false,
+          groupYearlyBudgetsList: editGroupCustomBudgetPayload,
+        },
       },
     ];
 
-    axiosMock.onPut(url).reply(200, mockResponse);
+    axiosMock.onPut(editUrl).reply(200, editedGroupCustomBudgets);
+    axiosMock.onGet(fetchCustomUrl).reply(200, editedGroupCustomBudgets);
+    axiosMock.onGet(fetchYearlyUrl).reply(200, editGroupCustomBudgetPayload);
 
     await editGroupCustomBudgets(
       selectYear,
       selectMonth,
       groupId,
+      signal,
       mockRequest.custom_budgets
-      // @ts-ignore
-    )(store.dispatch, getState);
+    )(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
-});
-
-describe('async actions deleteGroupCustomBudgets', () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-  const store = mockStore({
-    groupBudgets: {
-      groupYearlyBudgetsList: groupYearlyBudgets,
-      groupStandardBudgetsList: groupEditedStandardBudgets.standard_budgets,
-    },
-  });
-
-  const selectYear = '2020';
-  const selectMonth = '02';
-  const groupId = 1;
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
 
   it('Delete groupCustomBudgets if fetch succeeds', async () => {
-    const getState = () => {
-      return {
-        groupBudgets: {
-          groupStandardBudgetsList: groupEditedStandardBudgets.standard_budgets,
-          groupYearlyBudgetsList: editGroupCustomBudgetPayload,
-        },
-      };
-    };
+    beforeEach(() => {
+      store.clearActions();
+    });
 
-    const mockResponse = groupDeletedCustomBudgets.message;
+    const store = mockStore({
+      groupBudgets: {
+        groupYearlyBudgetsList: groupYearlyBudgets,
+        groupStandardBudgetsList: groupEditedStandardBudgets.standard_budgets,
+      },
+    });
 
-    const mockPayload = {
+    const selectYear = '2020';
+    const selectMonth = '02';
+    const groupId = 1;
+    const signal = axios.CancelToken.source();
+    const deleteUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchYearlyUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${selectYear}`;
+
+    const deletedGroupCustomBudgetsMessage = groupDeletedCustomBudgets.message;
+
+    const deletedYearlyBudgetsList = {
       year: '2020-01-01T00:00:00Z',
       yearly_total_budget: 1801500,
       monthly_budgets: [
@@ -540,15 +568,24 @@ describe('async actions deleteGroupCustomBudgets', () => {
 
     const expectedActions = [
       {
+        type: actionTypes.START_DELETE_GROUP_CUSTOM_BUDGETS,
+        payload: {
+          groupYearlyBudgetsLoading: true,
+        },
+      },
+      {
         type: actionTypes.DELETE_GROUP_CUSTOM_BUDGETS,
-        payload: mockPayload,
+        payload: {
+          groupYearlyBudgetsLoading: false,
+          groupYearlyBudgetsList: deletedYearlyBudgetsList,
+        },
       },
     ];
 
-    axiosMock.onDelete(url).reply(200, mockResponse);
+    axiosMock.onDelete(deleteUrl).reply(200, deletedGroupCustomBudgetsMessage);
+    axiosMock.onGet(fetchYearlyUrl).reply(200, deletedYearlyBudgetsList);
 
-    // @ts-ignore
-    await deleteGroupCustomBudgets(selectYear, selectMonth, groupId)(store.dispatch, getState);
+    await deleteGroupCustomBudgets(selectYear, selectMonth, groupId, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });


### PR DESCRIPTION
- `groupBudgets`のミドルウェアのが肥大化していたのでadd, edit, deleteのロジックを削除し、fetch処理を追加することで
   更新後の値をコンポーネントに反映させる形に修正しました。

- loadingを開始する`START`、処理の失敗の際の`FAILED`のactionを追加しました。

- 上記の変更に伴い、`groupBudgets/actions, groupBudgets/reducers, groupBudgets/operations, GroupBudgets.test`を修正
   しました。