### PR TITLE
Add action for starting loading and failure to transactions

### DIFF
--- a/src/containers/home/modal/AddTransactionModalContainer.tsx
+++ b/src/containers/home/modal/AddTransactionModalContainer.tsx
@@ -249,8 +249,8 @@ const AddTransactionModalContainer = (props: AddTransactionModalContainerProps) 
   const personalAddRequestData: TransactionsReq = {
     transaction_type: transactionsType,
     transaction_date: transactionDate,
-    shop: emptyShop,
-    memo: emptyMemo,
+    shop: emptyShop !== null ? emptyShop.trim() : null,
+    memo: emptyMemo !== null ? emptyMemo.trim() : null,
     amount: Number(amount),
     big_category_id: bigCategoryId,
     medium_category_id: mediumCategoryId,
@@ -260,8 +260,8 @@ const AddTransactionModalContainer = (props: AddTransactionModalContainerProps) 
   const groupAddRequestData: GroupTransactionsReq = {
     transaction_type: transactionsType,
     transaction_date: transactionDate,
-    shop: emptyShop,
-    memo: emptyMemo,
+    shop: emptyShop !== null ? emptyShop.trim() : null,
+    memo: emptyMemo !== null ? emptyMemo.trim() : null,
     amount: Number(amount),
     payment_user_id: paymentUserId,
     big_category_id: bigCategoryId,

--- a/src/containers/home/modal/EditTransactionModalContainer.tsx
+++ b/src/containers/home/modal/EditTransactionModalContainer.tsx
@@ -275,8 +275,8 @@ const EditTransactionModalContainer = (props: EditTransactionModalContainerProps
     medium_category_id: mediumCategoryId,
     custom_category_id: customCategoryId,
     amount: Number(amount),
-    memo: emptyMemo,
-    shop: emptyShop,
+    memo: emptyMemo !== null ? emptyMemo.trim() : null,
+    shop: emptyShop !== null ? emptyShop.trim() : null,
   };
   const groupEditRequestData: GroupTransactionsReq = {
     transaction_date: transactionDate,
@@ -286,8 +286,8 @@ const EditTransactionModalContainer = (props: EditTransactionModalContainerProps
     custom_category_id: customCategoryId,
     amount: Number(amount),
     payment_user_id: paymentUserId,
-    memo: emptyMemo,
-    shop: emptyShop,
+    memo: emptyMemo !== null ? emptyMemo.trim() : null,
+    shop: emptyShop !== null ? emptyShop.trim() : null,
   };
 
   const september = 9;

--- a/src/containers/home/transactionInputForm/InputFormContainer.tsx
+++ b/src/containers/home/transactionInputForm/InputFormContainer.tsx
@@ -192,8 +192,8 @@ const InputFormContainer = () => {
   const personalAddRequestData: TransactionsReq = {
     transaction_type: transactionsType,
     transaction_date: transactionDate,
-    shop: emptyShop,
-    memo: emptyMemo,
+    shop: emptyShop !== null ? emptyShop.trim() : null,
+    memo: emptyMemo !== null ? emptyMemo.trim() : null,
     amount: Number(amount),
     big_category_id: bigCategoryId,
     medium_category_id: mediumCategoryId,
@@ -203,8 +203,8 @@ const InputFormContainer = () => {
   const groupAddRequestData: GroupTransactionsReq = {
     transaction_type: transactionsType,
     transaction_date: transactionDate,
-    shop: emptyShop,
-    memo: emptyMemo,
+    shop: emptyShop !== null ? emptyShop.trim() : null,
+    memo: emptyMemo !== null ? emptyMemo.trim() : null,
     amount: Number(amount),
     payment_user_id: paymentUserId,
     big_category_id: bigCategoryId,

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -44,8 +44,23 @@ const initialState = {
   },
   transactions: {
     latestTransactionsList: [],
+    latestTransactionsListLoading: false,
+    latestTransactionsListError: {
+      statusCode: 0,
+      errorMessage: '',
+    },
     transactionsList: [],
+    transactionsListLoading: false,
+    transactionsListError: {
+      statusCode: 0,
+      errorMessage: '',
+    },
     searchTransactionsList: [],
+    searchTransactionsListLoading: false,
+    searchTransactionsListError: {
+      statusCode: 0,
+      errorMessage: '',
+    },
     noTransactionsMessage: '',
     notHistoryMessage: '',
   },

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -59,8 +59,23 @@ export interface State {
   };
   transactions: {
     latestTransactionsList: TransactionsList;
+    latestTransactionsListLoading: boolean;
+    latestTransactionsListError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     transactionsList: TransactionsList;
+    transactionsListLoading: boolean;
+    transactionsListError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     searchTransactionsList: TransactionsList;
+    searchTransactionsListLoading: boolean;
+    searchTransactionsListError: {
+      statusCode: number;
+      errorMessage: string;
+    };
     noTransactionsMessage: string;
     notHistoryMessage: string;
   };

--- a/src/reducks/transactions/actions.ts
+++ b/src/reducks/transactions/actions.ts
@@ -1,12 +1,36 @@
 import { TransactionsList } from './types';
 export type transactionActions = ReturnType<
+  | typeof startFetchTransactionsActions
   | typeof fetchTransactionsActions
+  | typeof cancelFetchTransactionsActions
+  | typeof failedFetchTransactionsActions
+  | typeof startFetchLatestTransactionsActions
   | typeof fetchLatestTransactionsActions
-  | typeof addTransactionsAction
-  | typeof editTransactionsAction
-  | typeof deleteTransactionsAction
+  | typeof cancelFetchLatestTransactionsActions
+  | typeof failedFetchLatestTransactionsActions
+  | typeof startAddTransactionsActions
+  | typeof addTransactionsActions
+  | typeof failedAddTransactionsActions
+  | typeof startEditTransactionsActions
+  | typeof editTransactionsActions
+  | typeof failedEditTransactionsActions
+  | typeof startDeleteTransactionsActions
+  | typeof deleteTransactionsActions
+  | typeof failedDeleteTransactionsActions
+  | typeof startSearchTransactionsActions
   | typeof searchTransactionsActions
+  | typeof failedSearchTransactionsActions
 >;
+
+export const START_FETCH_TRANSACTIONS = 'START_FETCH_TRANSACTIONS';
+export const startFetchTransactionsActions = () => {
+  return {
+    type: START_FETCH_TRANSACTIONS,
+    payload: {
+      transactionsListLoading: true,
+    },
+  };
+};
 
 export const FETCH_TRANSACTIONS = 'FETCH_TRANSACTIONS';
 export const fetchTransactionsActions = (
@@ -16,8 +40,43 @@ export const fetchTransactionsActions = (
   return {
     type: FETCH_TRANSACTIONS,
     payload: {
-      transactionsList,
-      noTransactionsMessage,
+      transactionsListLoading: false,
+      transactionsList: transactionsList,
+      noTransactionsMessage: noTransactionsMessage,
+    },
+  };
+};
+
+export const CANCEL_FETCH_TRANSACTIONS = 'CANCEL_FETCH_TRANSACTIONS';
+export const cancelFetchTransactionsActions = () => {
+  return {
+    type: CANCEL_FETCH_TRANSACTIONS,
+    payload: {
+      transactionsListLoading: false,
+    },
+  };
+};
+
+export const FAILED_FETCH_TRANSACTIONS = 'FAILED_FETCH_TRANSACTIONS';
+export const failedFetchTransactionsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_FETCH_TRANSACTIONS,
+    payload: {
+      transactionsListLoading: false,
+      transactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_FETCH_LATEST_TRANSACTIONS = 'START_FETCH_LATEST_TRANSACTIONS';
+export const startFetchLatestTransactionsActions = () => {
+  return {
+    type: START_FETCH_LATEST_TRANSACTIONS,
+    payload: {
+      latestTransactionsListLoading: true,
     },
   };
 };
@@ -27,49 +86,186 @@ export const fetchLatestTransactionsActions = (latestTransactionsList: Transacti
   return {
     type: FETCH_LATEST_TRANSACTIONS,
     payload: {
+      latestTransactionsListLoading: false,
       latestTransactionsList: latestTransactionsList,
     },
   };
 };
 
+export const CANCEL_FETCH_LATEST_TRANSACTIONS = 'CANCEL_FETCH_LATEST_TRANSACTIONS';
+export const cancelFetchLatestTransactionsActions = () => {
+  return {
+    type: CANCEL_FETCH_LATEST_TRANSACTIONS,
+    payload: {
+      latestTransactionsListLoading: false,
+    },
+  };
+};
+
+export const FAILED_FETCH_LATEST_TRANSACTIONS = 'FAILED_FETCH_LATEST_TRANSACTIONS';
+export const failedFetchLatestTransactionsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_FETCH_LATEST_TRANSACTIONS,
+    payload: {
+      latestTransactionsListLoading: false,
+      latestTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_ADD_TRANSACTIONS = 'START_ADD_TRANSACTIONS';
+export const startAddTransactionsActions = () => {
+  return {
+    type: START_ADD_TRANSACTIONS,
+    payload: {
+      transactionsListLoading: true,
+      latestTransactionsListLoading: true,
+    },
+  };
+};
+
 export const ADD_TRANSACTIONS = 'ADD_TRANSACTIONS';
-export const addTransactionsAction = (
+export const addTransactionsActions = (
   transactionsList: TransactionsList,
   latestTransactionsList: TransactionsList
 ) => {
   return {
     type: ADD_TRANSACTIONS,
     payload: {
+      transactionsListLoading: false,
+      latestTransactionsListLoading: false,
       transactionsList: transactionsList,
       latestTransactionsList: latestTransactionsList,
     },
   };
 };
 
+export const FAILED_ADD_TRANSACTIONS = 'FAILED_ADD_TRANSACTIONS';
+export const failedAddTransactionsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_ADD_TRANSACTIONS,
+    payload: {
+      transactionsListLoading: false,
+      latestTransactionsListLoading: false,
+
+      transactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+
+      latestTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_EDIT_TRANSACTIONS = 'START_EDIT_TRANSACTIONS';
+export const startEditTransactionsActions = () => {
+  return {
+    type: START_EDIT_TRANSACTIONS,
+    payload: {
+      transactionsListLoading: true,
+      latestTransactionsListLoading: true,
+    },
+  };
+};
+
 export const EDIT_TRANSACTIONS = 'EDIT_TRANSACTIONS';
-export const editTransactionsAction = (
+export const editTransactionsActions = (
   transactionsList: TransactionsList,
   latestTransactionsList: TransactionsList
 ) => {
   return {
     type: EDIT_TRANSACTIONS,
     payload: {
+      transactionsListLoading: false,
+      latestTransactionsListLoading: false,
       transactionsList: transactionsList,
       latestTransactionsList: latestTransactionsList,
     },
   };
 };
 
+export const FAILED_EDIT_TRANSACTIONS = 'FAILED_EDIT_TRANSACTIONS';
+export const failedEditTransactionsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_EDIT_TRANSACTIONS,
+    payload: {
+      transactionsListLoading: false,
+      latestTransactionsListLoading: false,
+
+      transactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+
+      latestTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_DELETE_TRANSACTIONS = 'START_DELETE_TRANSACTIONS';
+export const startDeleteTransactionsActions = () => {
+  return {
+    type: START_DELETE_TRANSACTIONS,
+    payload: {
+      transactionsListLoading: true,
+      latestTransactionsListLoading: true,
+    },
+  };
+};
+
 export const DELETE_TRANSACTIONS = 'DELETE_TRANSACTIONS';
-export const deleteTransactionsAction = (
+export const deleteTransactionsActions = (
   transactionsList: TransactionsList,
   latestTransactionsList: TransactionsList
 ) => {
   return {
     type: DELETE_TRANSACTIONS,
     payload: {
+      transactionsListLoading: false,
+      latestTransactionsListLoading: false,
       transactionsList: transactionsList,
       latestTransactionsList: latestTransactionsList,
+    },
+  };
+};
+
+export const FAILED_DELETE_TRANSACTIONS = 'FAILED_DELETE_TRANSACTIONS';
+export const failedDeleteTransactionsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_DELETE_TRANSACTIONS,
+    payload: {
+      transactionsListLoading: false,
+      latestTransactionsListLoading: false,
+
+      transactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+
+      latestTransactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const START_SEARCH_TRANSACTIONS = 'START_SEARCH_TRANSACTIONS';
+export const startSearchTransactionsActions = () => {
+  return {
+    type: START_SEARCH_TRANSACTIONS,
+    payload: {
+      searchTransactionsListLoading: true,
     },
   };
 };
@@ -82,8 +278,24 @@ export const searchTransactionsActions = (
   return {
     type: SEARCH_TRANSACTIONS,
     payload: {
-      searchTransactionsList,
-      notHistoryMessage,
+      searchTransactionsListLoading: false,
+      searchTransactionsList: searchTransactionsList,
+      notHistoryMessage: notHistoryMessage,
+    },
+  };
+};
+
+export const FAILED_SEARCH_TRANSACTIONS = 'FAILED_SEARCH_TRANSACTIONS';
+export const failedSearchTransactionsActions = (statusCode: number, errorMessage: string) => {
+  return {
+    type: FAILED_SEARCH_TRANSACTIONS,
+    payload: {
+      searchTransactionsListLoading: false,
+
+      transactionsListError: {
+        statusCode: statusCode,
+        errorMessage: errorMessage,
+      },
     },
   };
 };

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -1,10 +1,24 @@
 import {
+  startFetchTransactionsActions,
   fetchTransactionsActions,
+  cancelFetchTransactionsActions,
+  failedFetchTransactionsActions,
+  startFetchLatestTransactionsActions,
   fetchLatestTransactionsActions,
-  addTransactionsAction,
-  editTransactionsAction,
-  deleteTransactionsAction,
+  cancelFetchLatestTransactionsActions,
+  failedFetchLatestTransactionsActions,
+  startAddTransactionsActions,
+  addTransactionsActions,
+  failedAddTransactionsActions,
+  startEditTransactionsActions,
+  editTransactionsActions,
+  failedEditTransactionsActions,
+  startDeleteTransactionsActions,
+  deleteTransactionsActions,
+  failedDeleteTransactionsActions,
+  startSearchTransactionsActions,
   searchTransactionsActions,
+  failedSearchTransactionsActions,
 } from './actions';
 import axios, { CancelTokenSource } from 'axios';
 import { Dispatch, Action } from 'redux';
@@ -16,7 +30,7 @@ import {
   DeleteTransactionRes,
 } from './types';
 import moment from 'moment';
-import { isValidAmountFormat, errorHandling } from '../../lib/validation';
+import { isValidAmountFormat } from '../../lib/validation';
 
 export const fetchTransactionsList = (
   selectYears: {
@@ -26,6 +40,8 @@ export const fetchTransactionsList = (
   signal: CancelTokenSource
 ) => {
   return async (dispatch: Dispatch<Action>) => {
+    dispatch(startFetchTransactionsActions());
+
     try {
       const result = await axios.get<FetchTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${selectYears.selectedYear}-${selectYears.selectedMonth}`,
@@ -48,9 +64,11 @@ export const fetchTransactionsList = (
       }
     } catch (error) {
       if (axios.isCancel(error)) {
-        return;
+        dispatch(cancelFetchTransactionsActions());
       } else {
-        errorHandling(dispatch, error);
+        dispatch(
+          failedFetchTransactionsActions(error.response.status, error.response.data.error.message)
+        );
       }
     }
   };
@@ -58,6 +76,8 @@ export const fetchTransactionsList = (
 
 export const fetchLatestTransactionsList = (signal: CancelTokenSource) => {
   return async (dispatch: Dispatch<Action>) => {
+    dispatch(startFetchLatestTransactionsActions());
+
     try {
       const result = await axios.get<FetchLatestTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/latest`,
@@ -76,9 +96,14 @@ export const fetchLatestTransactionsList = (signal: CancelTokenSource) => {
       }
     } catch (error) {
       if (axios.isCancel(error)) {
-        return;
+        dispatch(cancelFetchLatestTransactionsActions());
       } else {
-        errorHandling(dispatch, error);
+        dispatch(
+          failedFetchLatestTransactionsActions(
+            error.response.status,
+            error.response.data.error.message
+          )
+        );
       }
     }
   };
@@ -104,6 +129,9 @@ export const addTransactions = (
       alert('金額は数字で入力してください。');
       return;
     }
+
+    dispatch(startAddTransactionsActions());
+
     try {
       await axios.post<TransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions`,
@@ -137,9 +165,11 @@ export const addTransactions = (
       const addedTransactionsList = fetchTransactionsResult.data.transactions_list;
       const addedLatestTransactionsList = fetchLatestTransactionsResult.data.transactions_list;
 
-      dispatch(addTransactionsAction(addedTransactionsList, addedLatestTransactionsList));
+      dispatch(addTransactionsActions(addedTransactionsList, addedLatestTransactionsList));
     } catch (error) {
-      errorHandling(dispatch, error);
+      dispatch(
+        failedAddTransactionsActions(error.response.status, error.response.data.error.message)
+      );
     }
   };
 };
@@ -165,6 +195,8 @@ export const editTransactions = (
       alert('金額は数字で入力してください。');
       return;
     }
+
+    dispatch(startEditTransactionsActions());
 
     try {
       await axios.put<TransactionsRes>(
@@ -199,9 +231,11 @@ export const editTransactions = (
       const editedTransactionsList = fetchTransactionsResult.data.transactions_list;
       const editedLatestTransactionsList = fetchLatestTransactionsResult.data.transactions_list;
 
-      dispatch(editTransactionsAction(editedTransactionsList, editedLatestTransactionsList));
+      dispatch(editTransactionsActions(editedTransactionsList, editedLatestTransactionsList));
     } catch (error) {
-      errorHandling(dispatch, error);
+      dispatch(
+        failedEditTransactionsActions(error.response.status, error.response.data.error.message)
+      );
     }
   };
 };
@@ -213,6 +247,8 @@ export const deleteTransactions = (
   editTransactionMonth: string
 ) => {
   return async (dispatch: Dispatch<Action>) => {
+    dispatch(startDeleteTransactionsActions());
+
     try {
       await axios.delete<DeleteTransactionRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${id}`,
@@ -240,9 +276,11 @@ export const deleteTransactions = (
       const deletedTransactionsList = fetchTransactionsResult.data.transactions_list;
       const deletedLatestTransactionsList = fetchLatestTransactionsResult.data.transactions_list;
 
-      dispatch(deleteTransactionsAction(deletedTransactionsList, deletedLatestTransactionsList));
+      dispatch(deleteTransactionsActions(deletedTransactionsList, deletedLatestTransactionsList));
     } catch (error) {
-      errorHandling(dispatch, error);
+      dispatch(
+        failedDeleteTransactionsActions(error.response.status, error.response.data.error.message)
+      );
     }
   };
 };
@@ -261,6 +299,8 @@ export const searchTransactions = (searchRequestData: {
   limit?: string | null;
 }) => {
   return async (dispatch: Dispatch<Action>) => {
+    dispatch(startSearchTransactionsActions());
+
     try {
       const result = await axios.get<FetchTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/search`,
@@ -298,7 +338,9 @@ export const searchTransactions = (searchRequestData: {
         dispatch(searchTransactionsActions(emptySearchTransactionsList, message));
       }
     } catch (error) {
-      errorHandling(dispatch, error);
+      dispatch(
+        failedSearchTransactionsActions(error.response.status, error.response.data.error.message)
+      );
     }
   };
 };

--- a/src/reducks/transactions/reducers.ts
+++ b/src/reducks/transactions/reducers.ts
@@ -7,7 +7,22 @@ export const transactionsReducer = (
   action: transactionActions
 ) => {
   switch (action.type) {
+    case Actions.START_FETCH_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.FETCH_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.CANCEL_FETCH_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_FETCH_LATEST_TRANSACTIONS:
       return {
         ...state,
         ...action.payload,
@@ -17,7 +32,32 @@ export const transactionsReducer = (
         ...state,
         ...action.payload,
       };
+    case Actions.CANCEL_FETCH_LATEST_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_FETCH_LATEST_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_ADD_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.ADD_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_ADD_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_EDIT_TRANSACTIONS:
       return {
         ...state,
         ...action.payload,
@@ -27,12 +67,37 @@ export const transactionsReducer = (
         ...state,
         ...action.payload,
       };
+    case Actions.FAILED_EDIT_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_DELETE_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.DELETE_TRANSACTIONS:
       return {
         ...state,
         ...action.payload,
       };
+    case Actions.FAILED_DELETE_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.START_SEARCH_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
     case Actions.SEARCH_TRANSACTIONS:
+      return {
+        ...state,
+        ...action.payload,
+      };
+    case Actions.FAILED_SEARCH_TRANSACTIONS:
       return {
         ...state,
         ...action.payload,

--- a/test/transactions-test/Transactions.test.ts
+++ b/test/transactions-test/Transactions.test.ts
@@ -29,27 +29,36 @@ const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 process.on('unhandledRejection', console.dir);
 
-describe('async actions fetchTransactionsList', () => {
-  const store = mockStore({ transactionsList: [] });
+const store = mockStore({
+  transactions: { transactionsList: [], latestTransactionsList: [], searchTransactionsList: [] },
+});
 
+describe('async actions transactions', () => {
   beforeEach(() => {
     store.clearActions();
   });
 
-  const years: SelectYears = {
-    selectedYear: '2020',
-    selectedMonth: '11',
-  };
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${years.selectedYear}-${years.selectedMonth}`;
-
   it('Get transactionsList if fetch succeeds', async () => {
+    const years: SelectYears = {
+      selectedYear: '2020',
+      selectedMonth: '11',
+    };
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${years.selectedYear}-${years.selectedMonth}`;
+
     const mockResponse = transactionsList;
     const signal = axios.CancelToken.source();
 
     const expectedAddActions = [
       {
+        type: actionTypes.START_FETCH_TRANSACTIONS,
+        payload: {
+          transactionsListLoading: true,
+        },
+      },
+      {
         type: actionTypes.FETCH_TRANSACTIONS,
         payload: {
+          transactionsListLoading: false,
           transactionsList: mockResponse.transactions_list,
           noTransactionsMessage: '',
         },
@@ -61,25 +70,23 @@ describe('async actions fetchTransactionsList', () => {
     await fetchTransactionsList(years, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAddActions);
   });
-});
-
-describe('async actions fetchLatestTransactionsList', () => {
-  const store = mockStore({ latestTransactionsList: [] });
-
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/latest`;
-
-  beforeEach(() => {
-    store.clearActions();
-  });
 
   it('Get latestTransactionsList if fetch succeeds', async () => {
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/latest`;
     const mockResponse = latestTransactionsList;
     const signal = axios.CancelToken.source();
 
     const expectedActions = [
       {
+        type: actionTypes.START_FETCH_LATEST_TRANSACTIONS,
+        payload: {
+          latestTransactionsListLoading: true,
+        },
+      },
+      {
         type: actionTypes.FETCH_LATEST_TRANSACTIONS,
         payload: {
+          latestTransactionsListLoading: false,
           latestTransactionsList: mockResponse.transactions_list,
         },
       },
@@ -90,46 +97,35 @@ describe('async actions fetchLatestTransactionsList', () => {
     await fetchLatestTransactionsList(signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
-});
-
-describe('async actions addTransactions', () => {
-  const store = mockStore({
-    transactionsList: transactionsList,
-    latestTransactionsList: latestTransactionsList,
-  });
-
-  const year = 2020;
-  const month = '11';
-  const signal = axios.CancelToken.source();
-  const addUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions`;
-  const fetchLatestUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/latest`;
-  const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${month}`;
-
-  beforeEach(() => {
-    store.clearActions();
-  });
-
-  let now: Date;
-  let spiedDate: Date;
-  const originalDate = Date;
-  now = new originalDate('2020-11-07T17:07:31Z');
-  Date.now = jest.fn().mockReturnValue(now.valueOf());
-  const actual = new Date();
-
-  // @ts-ignore
-  spiedDate = jest.spyOn(global, 'Date').mockImplementation((arg) => {
-    if (arg === 0 || arg) {
-      return new originalDate();
-    }
-    return now;
-  });
-
-  afterAll(() => {
-    // @ts-ignore
-    spiedDate.mockRestore();
-  });
 
   it('Add transaction in transactionsList and latestTransactionsList if fetch succeeds', async () => {
+    const year = 2020;
+    const month = '11';
+    const signal = axios.CancelToken.source();
+    const addUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions`;
+    const fetchLatestUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/latest`;
+    const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${month}`;
+
+    let now: Date;
+    let spiedDate: Date;
+    const originalDate = Date;
+    now = new originalDate('2020-11-07T17:07:31Z');
+    Date.now = jest.fn().mockReturnValue(now.valueOf());
+    const actual = new Date();
+
+    // @ts-ignore
+    spiedDate = jest.spyOn(global, 'Date').mockImplementation((arg) => {
+      if (arg === 0 || arg) {
+        return new originalDate();
+      }
+      return now;
+    });
+
+    afterAll(() => {
+      // @ts-ignore
+      spiedDate.mockRestore();
+    });
+
     const requestData: TransactionsReq = {
       transaction_type: 'expense',
       transaction_date: actual,
@@ -147,8 +143,17 @@ describe('async actions addTransactions', () => {
 
     const expectedAddActions = [
       {
+        type: actionTypes.START_ADD_TRANSACTIONS,
+        payload: {
+          transactionsListLoading: true,
+          latestTransactionsListLoading: true,
+        },
+      },
+      {
         type: actionTypes.ADD_TRANSACTIONS,
         payload: {
+          transactionsListLoading: false,
+          latestTransactionsListLoading: false,
           transactionsList: addedTransactionsList.transactions_list,
           latestTransactionsList: addedLatestTransactionsList.transactions_list,
         },
@@ -162,37 +167,6 @@ describe('async actions addTransactions', () => {
     await addTransactions(requestData, year, month, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAddActions);
   });
-});
-
-describe('async actions editTransactions', () => {
-  const store = mockStore({
-    transactionsList: addTransactionsList,
-    latestTransactionsList: addLatestTransaction,
-  });
-
-  let now: Date;
-  let spiedDate: Date;
-  const originalDate = Date;
-  now = new originalDate('2020-07-26T17:00:15Z');
-  Date.now = jest.fn().mockReturnValue(now.valueOf());
-  const actual = new Date();
-
-  // @ts-ignore
-  spiedDate = jest.spyOn(global, 'Date').mockImplementation((arg) => {
-    if (arg === 0 || arg) {
-      return new originalDate();
-    }
-    return now;
-  });
-
-  afterAll(() => {
-    // @ts-ignore
-    spiedDate.mockRestore();
-  });
-
-  beforeEach(() => {
-    store.clearActions();
-  });
 
   it('Edit transaction in transactionsList and latestTransactionsList if fetch succeeds', async () => {
     const year = 2020;
@@ -202,6 +176,26 @@ describe('async actions editTransactions', () => {
     const editUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${id}`;
     const fetchLatestUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/latest`;
     const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${year}-${month}`;
+
+    let now: Date;
+    let spiedDate: Date;
+    const originalDate = Date;
+    now = new originalDate('2020-07-26T17:00:15Z');
+    Date.now = jest.fn().mockReturnValue(now.valueOf());
+    const actual = new Date();
+
+    // @ts-ignore
+    spiedDate = jest.spyOn(global, 'Date').mockImplementation((arg) => {
+      if (arg === 0 || arg) {
+        return new originalDate();
+      }
+      return now;
+    });
+
+    afterAll(() => {
+      // @ts-ignore
+      spiedDate.mockRestore();
+    });
 
     const editResponse = editResTransaction;
     const editedTransactionsList = editTransactionsList;
@@ -220,8 +214,17 @@ describe('async actions editTransactions', () => {
 
     const expectedEditActions = [
       {
+        type: actionTypes.START_EDIT_TRANSACTIONS,
+        payload: {
+          transactionsListLoading: true,
+          latestTransactionsListLoading: true,
+        },
+      },
+      {
         type: actionTypes.EDIT_TRANSACTIONS,
         payload: {
+          transactionsListLoading: false,
+          latestTransactionsListLoading: false,
           transactionsList: editedTransactionsList.transactions_list,
           latestTransactionsList: editedLatestTransactionsList.transactions_list,
         },
@@ -234,16 +237,6 @@ describe('async actions editTransactions', () => {
 
     await editTransactions(130, requestData, year, month, signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedEditActions);
-  });
-});
-
-describe('async actions deleteTransactions', () => {
-  const store = mockStore({
-    transactionsList: editTransactionsList,
-    latestTransactionsList: editLatestTransaction,
-  });
-  beforeEach(() => {
-    store.clearActions();
   });
 
   it('Delete transaction in transactionsList and latestTransactionsList if fetch succeeds', async () => {
@@ -261,8 +254,17 @@ describe('async actions deleteTransactions', () => {
 
     const expectedDeleteActions = [
       {
+        type: actionTypes.START_DELETE_TRANSACTIONS,
+        payload: {
+          transactionsListLoading: true,
+          latestTransactionsListLoading: true,
+        },
+      },
+      {
         type: actionTypes.DELETE_TRANSACTIONS,
         payload: {
+          transactionsListLoading: false,
+          latestTransactionsListLoading: false,
           transactionsList: deletedTransactionsList,
           latestTransactionsList: deletedLatestTransactionsList,
         },
@@ -276,42 +278,40 @@ describe('async actions deleteTransactions', () => {
     await deleteTransactions(130, signal, year, month)(store.dispatch);
     expect(store.getActions()).toEqual(expectedDeleteActions);
   });
-});
 
-it('Get transactionsList  search criteria match in  if fetch succeeds', async () => {
-  const store = mockStore({
-    transactions: {
-      searchTransactionsList: [],
-    },
-  });
-  beforeEach(() => {
-    store.clearActions();
-  });
+  it('Get transactionsList  search criteria match in  if fetch succeeds', async () => {
+    const params = {
+      transaction_type: 'expense',
+      low_amount: 2000,
+      high_amount: 10000,
+      big_category_id: 2,
+      sort: 'transaction_date',
+    };
 
-  const params = {
-    transaction_type: 'expense',
-    low_amount: 2000,
-    high_amount: 10000,
-    big_category_id: 2,
-    sort: 'transaction_date',
-  };
+    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/search`;
 
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/search`;
+    const mockResponse = fetchResSearchTransaction;
 
-  const mockResponse = fetchResSearchTransaction;
-
-  const expectSearchActions = [
-    {
-      type: actionTypes.SEARCH_TRANSACTIONS,
-      payload: {
-        searchTransactionsList: mockResponse.transactions_list,
-        notHistoryMessage: '',
+    const expectSearchActions = [
+      {
+        type: actionTypes.START_SEARCH_TRANSACTIONS,
+        payload: {
+          searchTransactionsListLoading: true,
+        },
       },
-    },
-  ];
+      {
+        type: actionTypes.SEARCH_TRANSACTIONS,
+        payload: {
+          searchTransactionsListLoading: false,
+          searchTransactionsList: mockResponse.transactions_list,
+          notHistoryMessage: '',
+        },
+      },
+    ];
 
-  axiosMock.onGet(url).reply(200, mockResponse);
+    axiosMock.onGet(url).reply(200, mockResponse);
 
-  await searchTransactions(params)(store.dispatch);
-  expect(store.getActions()).toEqual(expectSearchActions);
+    await searchTransactions(params)(store.dispatch);
+    expect(store.getActions()).toEqual(expectSearchActions);
+  });
 });

--- a/test/transactions-test/TransactionsOperations.test.ts
+++ b/test/transactions-test/TransactionsOperations.test.ts
@@ -289,7 +289,6 @@ describe('async actions transactions', () => {
     };
 
     const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/search`;
-
     const mockResponse = fetchResSearchTransaction;
 
     const expectSearchActions = [


### PR DESCRIPTION
- `transactions`にローディング開始の`START`と非同期処理が失敗した際の`FAILE`のactionを追加しました。

- 上記の変更に伴い、`transactions/actions, transactions/reducer, transactions/operations, Transaction.test`を修正しました。