### PR TITLE
Modify the id of users in initialState to user_id

### DIFF
--- a/src/assets/modules/generic-btn.scss
+++ b/src/assets/modules/generic-btn.scss
@@ -14,4 +14,10 @@
     color: #fff;
   }
 
+  &:disabled{
+    background-color: white;
+    color: $disable-color;
+    border-color: $disable-color;
+  }
+
 }

--- a/src/assets/variable.scss
+++ b/src/assets/variable.scss
@@ -9,6 +9,7 @@ $month-bar-color: #47a414;
 $week-bar-color: #ffba16;
 $day-bar-color: #f45e36;
 $light-black: #444444;
+$disable-color: #ccc;
 $small-font-size:12px;
 $middle-font-size:14px;
 $medium-font_size:16px;

--- a/src/containers/home/transactionInputForm/InputFormContainer.tsx
+++ b/src/containers/home/transactionInputForm/InputFormContainer.tsx
@@ -227,6 +227,7 @@ const InputFormContainer = () => {
   };
 
   const unInput =
+    displayMessageDecision ||
     amount === '' ||
     !isValidAmountFormat(amount) ||
     initialState.initialAmount === amount ||

--- a/src/containers/templates/budgets/BudgetsContainer.tsx
+++ b/src/containers/templates/budgets/BudgetsContainer.tsx
@@ -37,7 +37,7 @@ const BudgetsContainer = () => {
     };
 
     if (query === '?standard') {
-      style.background = 'linear-gradient(90deg, rgba(245,117,109,1) 0%, rgba(238,62,91,1) 45%)';
+      style.background = '#ff802b';
       style.color = '#fff';
     }
 
@@ -51,7 +51,7 @@ const BudgetsContainer = () => {
     };
 
     if (query === '?yearly') {
-      style.background = 'linear-gradient(90deg, rgba(245,117,109,1) 0%, rgba(238,62,91,1) 45%)';
+      style.background = '#ff802b';
       style.color = '#fff';
     }
 

--- a/src/reducks/groupTasks/selectors.ts
+++ b/src/reducks/groupTasks/selectors.ts
@@ -14,7 +14,7 @@ export const getGroupTasksList = createSelector(
 );
 
 const tasksListForEachUser = (state: State) => state.groupTasks.groupTasksListForEachUser;
-const userId = (state: State) => state.users.id;
+const userId = (state: State) => state.users.user_id;
 
 export const getUserTaskListItem = createSelector(
   [tasksListForEachUser, userId],

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -305,9 +305,15 @@ export const deleteGroupTransactions = (
         }
       );
 
-      const deletedGroupTransactionsList = fetchGroupTransactionsResult.data.transactions_list;
+      const deletedGroupTransactionsList =
+        fetchGroupTransactionsResult.data.transactions_list === undefined
+          ? []
+          : fetchGroupTransactionsResult.data.transactions_list;
+
       const deletedGroupLatestTransactionsList =
-        fetchGroupLatestTransactionsResult.data.transactions_list;
+        fetchGroupLatestTransactionsResult.data.transactions_list === undefined
+          ? []
+          : fetchGroupLatestTransactionsResult.data.transactions_list;
 
       dispatch(
         deleteGroupTransactionsAction(

--- a/src/reducks/groups/operations.ts
+++ b/src/reducks/groups/operations.ts
@@ -53,7 +53,7 @@ export const createGroup = (groupName: string) => {
 
       const user: ApprovedGroupUser = {
         group_id: result.data.group_id,
-        user_id: currentUser.id,
+        user_id: currentUser.user_id,
         user_name: currentUser.name,
         color_code: `#FF0000`,
       };

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -1,6 +1,6 @@
 const initialState = {
   users: {
-    id: '',
+    user_id: '',
     name: '',
     email: '',
     errorMessage: '',

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -25,7 +25,7 @@ import {
 
 export interface State {
   users: {
-    id: string;
+    user_id: string;
     name: string;
     email: string;
     errorMessage: string;

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -273,8 +273,15 @@ export const deleteTransactions = (
         }
       );
 
-      const deletedTransactionsList = fetchTransactionsResult.data.transactions_list;
-      const deletedLatestTransactionsList = fetchLatestTransactionsResult.data.transactions_list;
+      const deletedTransactionsList =
+        fetchTransactionsResult.data.transactions_list === undefined
+          ? []
+          : fetchTransactionsResult.data.transactions_list;
+
+      const deletedLatestTransactionsList =
+        fetchLatestTransactionsResult.data.transactions_list === undefined
+          ? []
+          : fetchLatestTransactionsResult.data.transactions_list;
 
       dispatch(deleteTransactionsActions(deletedTransactionsList, deletedLatestTransactionsList));
     } catch (error) {

--- a/src/reducks/users/selectors.ts
+++ b/src/reducks/users/selectors.ts
@@ -3,7 +3,7 @@ import { State } from '../store/types';
 
 const usersSelector = (state: State) => state.users;
 
-export const getUserId = createSelector([usersSelector], (state) => state.id);
+export const getUserId = createSelector([usersSelector], (state) => state.user_id);
 export const getUserName = createSelector([usersSelector], (state) => state.name);
 export const getEmail = createSelector([usersSelector], (state) => state.email);
 export const getErrorMessage = createSelector([usersSelector], (state) => state.errorMessage);

--- a/src/reducks/users/selectors.ts
+++ b/src/reducks/users/selectors.ts
@@ -4,7 +4,5 @@ import { State } from '../store/types';
 const usersSelector = (state: State) => state.users;
 
 export const getUserId = createSelector([usersSelector], (state) => state.user_id);
-export const getUserName = createSelector([usersSelector], (state) => state.name);
-export const getEmail = createSelector([usersSelector], (state) => state.email);
 export const getErrorMessage = createSelector([usersSelector], (state) => state.errorMessage);
 export const getConflictMessage = createSelector([usersSelector], (state) => state.conflictMessage);

--- a/test/groups-test/Groups.test.tsx
+++ b/test/groups-test/Groups.test.tsx
@@ -32,7 +32,7 @@ const store = mockStore({ users: [], groups: [], router: [] });
 const getState = () => {
   return {
     users: {
-      id: 'furusawa',
+      user_id: 'furusawa',
       name: '古澤',
       email: 'test@gmail.com',
       password: 'password',


### PR DESCRIPTION
- signupのリクエスト, レスポンスのidをuser_idに変更したのに合わせてstoreで管理する`users / id`を`users / user_id`に
   変更しました。

- 家計簿の追加, 編集の際に使用する`GenericButton`にdisabled状態の判別ができるようにstyleを追加しました。

- `transactionsList, latestTransactionsList`の削除の際に、残り1つのtransactionを削除すると
  `transactionsList is not iterable`のエラーが出ていたので残り1つのtransactionを削除した場合は空配列をdispatchする形に
   修正しました。

- 予算画面の標準予算と年間予算の切り替えボタンの色を他の画面と統一するため`BudgetsContainer`の`currentColor`を
   変更しました。