### PR TITLE
Modify the START action for transactions, groupTransactions, budgets,…

### DIFF
--- a/src/containers/modules/BigCategoryListContainer.tsx
+++ b/src/containers/modules/BigCategoryListContainer.tsx
@@ -25,6 +25,8 @@ import {
   getGroupExpenseCategories,
   getGroupIncomeCategories,
 } from '../../reducks/groupCategories/selectors';
+import { resetCategoriesErrorActions } from '../../reducks/categories/actions';
+import { resetGroupCategoriesErrorActions } from '../../reducks/groupCategories/actions';
 
 interface BigCategoryListContainerProps {
   transactionType: string;
@@ -67,10 +69,14 @@ const BigCategoryListContainer = (props: BigCategoryListContainerProps) => {
     if (pathName !== 'group') {
       if (categoriesErrorMessage.length) {
         alert(categoriesErrorMessage);
+
+        dispatch(resetCategoriesErrorActions());
       }
     } else {
       if (groupCategoriesErrorMessage.length) {
         alert(groupCategoriesErrorMessage);
+
+        dispatch(resetGroupCategoriesErrorActions());
       }
     }
   }, [categoriesErrorMessage, groupCategoriesErrorMessage]);

--- a/src/reducks/budgets/actions.ts
+++ b/src/reducks/budgets/actions.ts
@@ -33,6 +33,11 @@ export const startFetchStandardBudgetsAction = () => {
     type: START_FETCH_STANDARD_BUDGETS,
     payload: {
       standardBudgetsLoading: true,
+
+      standardBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -78,6 +83,11 @@ export const startEditStandardBudgetsAction = () => {
     type: START_EDIT_STANDARD_BUDGETS,
     payload: {
       standardBudgetsLoading: true,
+
+      standardBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -113,6 +123,11 @@ export const startFetchCustomBudgetsActions = () => {
     type: START_FETCH_CUSTOM_BUDGETS,
     payload: {
       customBudgetsLoading: true,
+
+      customBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -159,6 +174,11 @@ export const startAddCustomBudgetsActions = () => {
     payload: {
       customBudgetsLoading: true,
       yearlyBudgetsLoading: true,
+
+      customBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -201,6 +221,11 @@ export const startEditCustomBudgetsActions = () => {
     payload: {
       customBudgetsLoading: true,
       yearlyBudgetsLoading: true,
+
+      customBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -242,6 +267,11 @@ export const startDeleteCustomBudgetsActions = () => {
     type: START_DELETE_CUSTOM_BUDGETS,
     payload: {
       yearlyBudgetsLoading: true,
+
+      yearlyBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -287,6 +317,11 @@ export const startFetchYearlyBudgetsActions = () => {
     type: START_FETCH_YEARLY_BUDGETS,
     payload: {
       yearlyBudgetsLoading: true,
+
+      yearlyBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };

--- a/src/reducks/budgets/operations.ts
+++ b/src/reducks/budgets/operations.ts
@@ -205,7 +205,7 @@ export const addCustomBudgets = (
         }
       );
 
-      const fetchCustomBudgetsResult = await axios.get<fetchCustomBudgetsRes>(
+      const fetchCustomBudgetsResult = axios.get<fetchCustomBudgetsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`,
         {
           cancelToken: signal.token,
@@ -213,7 +213,7 @@ export const addCustomBudgets = (
         }
       );
 
-      const fetchYearlyBudgetsResult = await axios.get<YearlyBudgetsList>(
+      const fetchYearlyBudgetsResult = axios.get<YearlyBudgetsList>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/${selectYear}`,
         {
           cancelToken: signal.token,
@@ -221,10 +221,15 @@ export const addCustomBudgets = (
         }
       );
 
-      const addedCustomBudgetsList = fetchCustomBudgetsResult.data.custom_budgets;
-      const addedYearlyBudgetsList = fetchYearlyBudgetsResult.data;
+      const addedCustomBudgetsList = await fetchCustomBudgetsResult;
+      const addedYearlyBudgetsList = await fetchYearlyBudgetsResult;
 
-      dispatch(addCustomBudgetsActions(addedCustomBudgetsList, addedYearlyBudgetsList));
+      dispatch(
+        addCustomBudgetsActions(
+          addedCustomBudgetsList.data.custom_budgets,
+          addedYearlyBudgetsList.data
+        )
+      );
     } catch (error) {
       dispatch(
         failedAddCustomBudgetsActions(error.response.status, error.response.data.error.message)
@@ -258,7 +263,7 @@ export const editCustomBudgets = (
         }
       );
 
-      const fetchCustomBudgetsResult = await axios.get<fetchCustomBudgetsRes>(
+      const fetchCustomBudgetsResult = axios.get<fetchCustomBudgetsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`,
         {
           cancelToken: signal.token,
@@ -266,7 +271,7 @@ export const editCustomBudgets = (
         }
       );
 
-      const fetchYearlyBudgetsResult = await axios.get<YearlyBudgetsList>(
+      const fetchYearlyBudgetsResult = axios.get<YearlyBudgetsList>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/${selectYear}`,
         {
           cancelToken: signal.token,
@@ -274,10 +279,15 @@ export const editCustomBudgets = (
         }
       );
 
-      const editedCustomBudgetsList = fetchCustomBudgetsResult.data.custom_budgets;
-      const editedYearlyBudgetsList = fetchYearlyBudgetsResult.data;
+      const editedCustomBudgetsList = await fetchCustomBudgetsResult;
+      const editedYearlyBudgetsList = await fetchYearlyBudgetsResult;
 
-      dispatch(editCustomBudgetsActions(editedCustomBudgetsList, editedYearlyBudgetsList));
+      dispatch(
+        editCustomBudgetsActions(
+          editedCustomBudgetsList.data.custom_budgets,
+          editedYearlyBudgetsList.data
+        )
+      );
     } catch (error) {
       dispatch(
         failedEditCustomBudgetsActions(error.response.status, error.response.data.error.message)
@@ -302,7 +312,7 @@ export const deleteCustomBudgets = (
         }
       );
 
-      const fetchYearlyBudgetsResult = await axios.get<YearlyBudgetsList>(
+      const fetchYearlyBudgetsResult = axios.get<YearlyBudgetsList>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/${selectYear}`,
         {
           cancelToken: signal.token,
@@ -310,9 +320,9 @@ export const deleteCustomBudgets = (
         }
       );
 
-      const deletedYearlyBudgetsList = fetchYearlyBudgetsResult.data;
+      const deletedYearlyBudgetsList = await fetchYearlyBudgetsResult;
 
-      dispatch(deleteCustomBudgetsActions(deletedYearlyBudgetsList));
+      dispatch(deleteCustomBudgetsActions(deletedYearlyBudgetsList.data));
     } catch (error) {
       dispatch(
         failedDeleteCustomBudgetsActions(error.response.status, error.response.data.error.message)

--- a/src/reducks/categories/actions.ts
+++ b/src/reducks/categories/actions.ts
@@ -17,6 +17,7 @@ export type categoriesActions = ReturnType<
   | typeof deleteIncomeCustomCategoryActions
   | typeof deleteExpenseCustomCategoryActions
   | typeof failedDeleteCustomCategoryActions
+  | typeof resetCategoriesErrorActions
 >;
 
 export const START_FETCH_CATEGORIES = 'START_FETCH_CATEGORIES';
@@ -241,6 +242,19 @@ export const failedDeleteCustomCategoryActions = (statusCode: number, errorMessa
       categoriesError: {
         statusCode: statusCode,
         errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const RESET_CATEGORIES_ERROR = 'RESET_CATEGORIES_ERROR';
+export const resetCategoriesErrorActions = () => {
+  return {
+    type: RESET_CATEGORIES_ERROR,
+    payload: {
+      categoriesError: {
+        statusCode: null,
+        errorMessage: '',
       },
     },
   };

--- a/src/reducks/categories/reducers.ts
+++ b/src/reducks/categories/reducers.ts
@@ -89,6 +89,11 @@ export const categoriesReducer = (state = initialState.categories, action: categ
         ...state,
         ...action.payload,
       };
+    case Actions.RESET_CATEGORIES_ERROR:
+      return {
+        ...state,
+        ...action.payload,
+      };
     default:
       return state;
   }

--- a/src/reducks/groupBudgets/actions.ts
+++ b/src/reducks/groupBudgets/actions.ts
@@ -34,6 +34,11 @@ export const startFetchGroupStandardBudgetsActions = () => {
     type: START_FETCH_GROUP_STANDARD_BUDGETS,
     payload: {
       groupStandardBudgetsLoading: true,
+
+      groupStandardBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -84,6 +89,11 @@ export const startEditGroupStandardBudgetsActions = () => {
     type: START_EDIT_GROUP_STANDARD_BUDGETS,
     payload: {
       groupStandardBudgetsLoading: true,
+
+      groupStandardBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -121,6 +131,11 @@ export const startFetchGroupCustomBudgetsActions = () => {
     type: START_FETCH_GROUP_CUSTOM_BUDGETS,
     payload: {
       groupCustomBudgetsLoading: true,
+
+      groupCustomBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -167,6 +182,11 @@ export const startAddGroupCustomBudgetsActions = () => {
     payload: {
       groupCustomBudgetsLoading: true,
       groupYearlyBudgetsLoading: true,
+
+      groupCustomBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -209,6 +229,11 @@ export const startEditGroupCustomBudgetsActions = () => {
     payload: {
       groupCustomBudgetsLoading: true,
       groupYearlyBudgetsLoading: true,
+
+      groupCustomBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -260,6 +285,11 @@ export const startDeleteGroupCustomBudgetsActions = () => {
     type: START_DELETE_GROUP_CUSTOM_BUDGETS,
     payload: {
       groupYearlyBudgetsLoading: true,
+
+      groupCustomBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -295,6 +325,11 @@ export const startFetchGroupYearlyBudgetsActions = () => {
     type: START_FETCH_GROUP_YEARLY_BUDGETS,
     payload: {
       groupYearlyBudgetsLoading: true,
+
+      groupYearlyBudgetsError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };

--- a/src/reducks/groupBudgets/operations.ts
+++ b/src/reducks/groupBudgets/operations.ts
@@ -95,7 +95,7 @@ export const editGroupStandardBudgets = (
         }
       );
 
-      const fetchResult = await axios.get<GroupStandardBudgetsListRes>(
+      const fetchResult = axios.get<GroupStandardBudgetsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`,
         {
           cancelToken: signal.token,
@@ -103,9 +103,11 @@ export const editGroupStandardBudgets = (
         }
       );
 
-      const editedGroupStandardBudgetsList = fetchResult.data.standard_budgets;
+      const editedGroupStandardBudgetsList = await fetchResult;
 
-      dispatch(editGroupStandardBudgetsActions(editedGroupStandardBudgetsList));
+      dispatch(
+        editGroupStandardBudgetsActions(editedGroupStandardBudgetsList.data.standard_budgets)
+      );
     } catch (error) {
       dispatch(
         failedEditGroupStandardBudgetsActions(
@@ -234,7 +236,7 @@ export const addGroupCustomBudgets = (
         }
       );
 
-      const fetchCustomResult = await axios.get<GroupCustomBudgetsListRes>(
+      const fetchCustomResult = axios.get<GroupCustomBudgetsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`,
         {
           cancelToken: signal.token,
@@ -242,7 +244,7 @@ export const addGroupCustomBudgets = (
         }
       );
 
-      const fetchYearlyResult = await axios.get<GroupYearlyBudgetsList>(
+      const fetchYearlyResult = axios.get<GroupYearlyBudgetsList>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${selectYear}`,
         {
           cancelToken: signal.token,
@@ -250,11 +252,14 @@ export const addGroupCustomBudgets = (
         }
       );
 
-      const addedGroupCustomBudgetsList = fetchCustomResult.data.custom_budgets;
-      const addedGroupYearlyBudgetsList = fetchYearlyResult.data;
+      const addedGroupCustomBudgetsList = await fetchCustomResult;
+      const addedGroupYearlyBudgetsList = await fetchYearlyResult;
 
       dispatch(
-        addGroupCustomBudgetsActions(addedGroupCustomBudgetsList, addedGroupYearlyBudgetsList)
+        addGroupCustomBudgetsActions(
+          addedGroupCustomBudgetsList.data.custom_budgets,
+          addedGroupYearlyBudgetsList.data
+        )
       );
     } catch (error) {
       dispatch(
@@ -293,7 +298,7 @@ export const editGroupCustomBudgets = (
         }
       );
 
-      const fetchCustomResult = await axios.get<GroupCustomBudgetsListRes>(
+      const fetchCustomResult = axios.get<GroupCustomBudgetsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`,
         {
           cancelToken: signal.token,
@@ -301,7 +306,7 @@ export const editGroupCustomBudgets = (
         }
       );
 
-      const fetchYearlyResult = await axios.get<GroupYearlyBudgetsList>(
+      const fetchYearlyResult = axios.get<GroupYearlyBudgetsList>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${selectYear}`,
         {
           cancelToken: signal.token,
@@ -309,11 +314,14 @@ export const editGroupCustomBudgets = (
         }
       );
 
-      const editedGroupCustomBudgetsList = fetchCustomResult.data.custom_budgets;
-      const editedGroupYearlyBudgetsList = fetchYearlyResult.data;
+      const editedGroupCustomBudgetsList = await fetchCustomResult;
+      const editedGroupYearlyBudgetsList = await fetchYearlyResult;
 
       dispatch(
-        editGroupCustomBudgetsActions(editedGroupCustomBudgetsList, editedGroupYearlyBudgetsList)
+        editGroupCustomBudgetsActions(
+          editedGroupCustomBudgetsList.data.custom_budgets,
+          editedGroupYearlyBudgetsList.data
+        )
       );
     } catch (error) {
       dispatch(
@@ -343,7 +351,7 @@ export const deleteGroupCustomBudgets = (
         }
       );
 
-      const fetchYearlyResult = await axios.get<GroupYearlyBudgetsList>(
+      const fetchYearlyResult = axios.get<GroupYearlyBudgetsList>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${selectYear}`,
         {
           cancelToken: signal.token,
@@ -351,9 +359,9 @@ export const deleteGroupCustomBudgets = (
         }
       );
 
-      const deletedGroupYearlyBudgetsList = fetchYearlyResult.data;
+      const deletedGroupYearlyBudgetsList = await fetchYearlyResult;
 
-      dispatch(deleteGroupCustomBudgetsActions(deletedGroupYearlyBudgetsList));
+      dispatch(deleteGroupCustomBudgetsActions(deletedGroupYearlyBudgetsList.data));
     } catch (error) {
       dispatch(
         failedDeleteGroupCustomBudgetsActions(

--- a/src/reducks/groupCategories/actions.ts
+++ b/src/reducks/groupCategories/actions.ts
@@ -18,6 +18,7 @@ export type groupCategoriesActions = ReturnType<
   | typeof deleteIncomeCategory
   | typeof deleteExpenseCategory
   | typeof failedDeleteGroupCategories
+  | typeof resetGroupCategoriesErrorActions
 >;
 
 export const START_FETCH_GROUP_CATEGORIES = 'START_FETCH_GROUP_CATEGORIES';
@@ -242,6 +243,19 @@ export const failedDeleteGroupCategories = (statusCode: number, errorMessage: st
       groupCategoriesError: {
         statusCode: statusCode,
         errorMessage: errorMessage,
+      },
+    },
+  };
+};
+
+export const RESET_GROUP_CATEGORIES_ERROR = 'RESET_GROUP_CATEGORIES_ERROR';
+export const resetGroupCategoriesErrorActions = () => {
+  return {
+    type: RESET_GROUP_CATEGORIES_ERROR,
+    payload: {
+      groupCategoriesError: {
+        statusCode: null,
+        errorMessage: '',
       },
     },
   };

--- a/src/reducks/groupCategories/reducers.ts
+++ b/src/reducks/groupCategories/reducers.ts
@@ -92,6 +92,11 @@ export const groupCategoriesReducer = (
         ...state,
         ...action.payload,
       };
+    case Actions.RESET_GROUP_CATEGORIES_ERROR:
+      return {
+        ...state,
+        ...action.payload,
+      };
     default:
       return state;
   }

--- a/src/reducks/groupTransactions/actions.ts
+++ b/src/reducks/groupTransactions/actions.ts
@@ -50,6 +50,11 @@ export const startFetchGroupTransactionsAction = () => {
     type: START_FETCH_GROUP_TRANSACTIONS,
     payload: {
       groupTransactionsListLoading: true,
+
+      groupTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -94,6 +99,11 @@ export const startFetchGroupLatestTransactionsAction = () => {
     type: START_FETCH_GROUP_LATEST_TRANSACTIONS,
     payload: {
       groupLatestTransactionsListLoading: true,
+
+      groupLatestTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -144,6 +154,16 @@ export const startAddGroupTransactionsAction = () => {
     payload: {
       groupTransactionsListLoading: true,
       groupLatestTransactionsListLoading: true,
+
+      groupTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
+
+      groupLatestTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -190,6 +210,16 @@ export const startEditGroupTransactionsAction = () => {
     payload: {
       groupTransactionsListLoading: true,
       groupLatestTransactionsListLoading: true,
+
+      groupTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
+
+      groupLatestTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -236,6 +266,16 @@ export const startDeleteGroupTransactionsAction = () => {
     payload: {
       groupTransactionsListLoading: true,
       groupLatestTransactionsListLoading: true,
+
+      groupTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
+
+      groupLatestTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -424,6 +464,16 @@ export const startAddGroupAccountAction = () => {
     payload: {
       groupAccountListLoading: true,
       groupYearlyAccountListLoading: true,
+
+      groupAccountListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
+
+      groupYearlyAccountListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -469,6 +519,11 @@ export const startEditGroupAccountAction = () => {
     type: START_EDIT_GROUP_ACCOUNT,
     payload: {
       groupAccountListLoading: true,
+
+      groupAccountListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -505,6 +560,16 @@ export const startDeleteGroupAccountAction = () => {
     payload: {
       groupAccountListLoading: true,
       groupYearlyAccountListLoading: true,
+
+      groupAccountListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
+
+      groupYearlyAccountListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -552,6 +617,11 @@ export const startSearchGroupTransactionsAction = () => {
     type: START_SEARCH_GROUP_TRANSACTIONS,
     payload: {
       groupSearchTransactionsListLoading: true,
+
+      groupSearchTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };

--- a/src/reducks/groupTransactions/operations.ts
+++ b/src/reducks/groupTransactions/operations.ts
@@ -171,7 +171,7 @@ export const addGroupTransactions = (
         }
       );
 
-      const fetchGroupTransactionsResult = await axios.get<FetchGroupTransactionsRes>(
+      const fetchGroupTransactionsResult = axios.get<FetchGroupTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${addTransactionYear}-${addTransactionMonth}`,
         {
           cancelToken: signal.token,
@@ -179,7 +179,7 @@ export const addGroupTransactions = (
         }
       );
 
-      const fetchGroupLatestTransactionsResult = await axios.get<GroupLatestTransactionsListRes>(
+      const fetchGroupLatestTransactionsResult = axios.get<GroupLatestTransactionsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/latest`,
         {
           cancelToken: signal.token,
@@ -187,12 +187,14 @@ export const addGroupTransactions = (
         }
       );
 
-      const addedGroupTransactionsList = fetchGroupTransactionsResult.data.transactions_list;
-      const addedGroupLatestTransactionsList =
-        fetchGroupLatestTransactionsResult.data.transactions_list;
+      const addedGroupTransactionsList = await fetchGroupTransactionsResult;
+      const addedGroupLatestTransactionsList = await fetchGroupLatestTransactionsResult;
 
       dispatch(
-        addGroupTransactionsAction(addedGroupTransactionsList, addedGroupLatestTransactionsList)
+        addGroupTransactionsAction(
+          addedGroupTransactionsList.data.transactions_list,
+          addedGroupLatestTransactionsList.data.transactions_list
+        )
       );
     } catch (error) {
       dispatch(
@@ -240,7 +242,7 @@ export const editGroupTransactions = (
         }
       );
 
-      const fetchGroupTransactionsResult = await axios.get<FetchGroupTransactionsRes>(
+      const fetchGroupTransactionsResult = axios.get<FetchGroupTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${editTransactionYear}-${editTransactionMonth}`,
         {
           cancelToken: signal.token,
@@ -248,7 +250,7 @@ export const editGroupTransactions = (
         }
       );
 
-      const fetchGroupLatestTransactionsResult = await axios.get<GroupLatestTransactionsListRes>(
+      const fetchGroupLatestTransactionsResult = axios.get<GroupLatestTransactionsListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/latest`,
         {
           cancelToken: signal.token,
@@ -256,12 +258,14 @@ export const editGroupTransactions = (
         }
       );
 
-      const editedGroupTransactionsList = fetchGroupTransactionsResult.data.transactions_list;
-      const editedGroupLatestTransactionsList =
-        fetchGroupLatestTransactionsResult.data.transactions_list;
+      const editedGroupTransactionsList = await fetchGroupTransactionsResult;
+      const editedGroupLatestTransactionsList = await fetchGroupLatestTransactionsResult;
 
       dispatch(
-        editGroupTransactionsAction(editedGroupTransactionsList, editedGroupLatestTransactionsList)
+        editGroupTransactionsAction(
+          editedGroupTransactionsList.data.transactions_list,
+          editedGroupLatestTransactionsList.data.transactions_list
+        )
       );
     } catch (error) {
       dispatch(
@@ -289,7 +293,7 @@ export const deleteGroupTransactions = (
         }
       );
 
-      const fetchGroupTransactionsResult = await axios.get<FetchGroupTransactionsRes>(
+      const fetchGroupTransactionsResult = axios.get<FetchGroupTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${editTransactionYear}-${editTransactionMonth}`,
         {
           cancelToken: signal.token,
@@ -306,14 +310,14 @@ export const deleteGroupTransactions = (
       );
 
       const deletedGroupTransactionsList =
-        fetchGroupTransactionsResult.data.transactions_list === undefined
+        (await fetchGroupTransactionsResult).data.transactions_list === undefined
           ? []
-          : fetchGroupTransactionsResult.data.transactions_list;
+          : (await fetchGroupTransactionsResult).data.transactions_list;
 
       const deletedGroupLatestTransactionsList =
-        fetchGroupLatestTransactionsResult.data.transactions_list === undefined
+        (await fetchGroupLatestTransactionsResult).data.transactions_list === undefined
           ? []
-          : fetchGroupLatestTransactionsResult.data.transactions_list;
+          : (await fetchGroupLatestTransactionsResult).data.transactions_list;
 
       dispatch(
         deleteGroupTransactionsAction(
@@ -448,7 +452,7 @@ export const addGroupAccount = (
         }
       );
 
-      const fetchAccountResult = await axios.get<GroupAccountListRes>(
+      const fetchAccountResult = axios.get<GroupAccountListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMonth}/account`,
         {
           cancelToken: signal.token,
@@ -456,7 +460,7 @@ export const addGroupAccount = (
         }
       );
 
-      const fetchYearlyAccountResult = await axios.get<GroupYearlyAccountList>(
+      const fetchYearlyAccountResult = axios.get<GroupYearlyAccountList>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}/account`,
         {
           cancelToken: signal.token,
@@ -464,10 +468,10 @@ export const addGroupAccount = (
         }
       );
 
-      const addedGroupAccountList = fetchAccountResult.data;
-      const addedGroupYearlyAccountList = fetchYearlyAccountResult.data;
+      const addedGroupAccountList = await fetchAccountResult;
+      const addedGroupYearlyAccountList = await fetchYearlyAccountResult;
 
-      dispatch(addGroupAccountAction(addedGroupYearlyAccountList, addedGroupAccountList));
+      dispatch(addGroupAccountAction(addedGroupYearlyAccountList.data, addedGroupAccountList.data));
     } catch (error) {
       dispatch(
         failedAddGroupAccountAction(error.response.status, error.response.data.error.message)
@@ -493,7 +497,7 @@ export const editGroupAccount = (
         { withCredentials: true }
       );
 
-      const fetchAccountResult = await axios.get<GroupAccountListRes>(
+      const fetchAccountResult = axios.get<GroupAccountListRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}-${customMonth}/account`,
         {
           cancelToken: signal.token,
@@ -501,9 +505,9 @@ export const editGroupAccount = (
         }
       );
 
-      const editedAccountList = fetchAccountResult.data;
+      const editedAccountList = await fetchAccountResult;
 
-      dispatch(editGroupAccountAction(editedAccountList));
+      dispatch(editGroupAccountAction(editedAccountList.data));
     } catch (error) {
       dispatch(
         failedEditGroupAccountAction(error.response.status, error.response.data.error.message)
@@ -529,7 +533,7 @@ export const deleteGroupAccount = (
         }
       );
 
-      const fetchYearlyAccountResult = await axios.get<GroupYearlyAccountList>(
+      const fetchYearlyAccountResult = axios.get<GroupYearlyAccountList>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/transactions/${year}/account`,
         {
           cancelToken: signal.token,
@@ -537,7 +541,7 @@ export const deleteGroupAccount = (
         }
       );
       const deletedMessage = result.data.message;
-      const deletedYearlyAccountList = fetchYearlyAccountResult.data;
+      const deletedYearlyAccountList = await fetchYearlyAccountResult;
       const emptyGroupAccountList: GroupAccountList = {
         group_id: 0,
         month: '',
@@ -548,7 +552,11 @@ export const deleteGroupAccount = (
       };
 
       dispatch(
-        deleteGroupAccountAction(emptyGroupAccountList, deletedYearlyAccountList, deletedMessage)
+        deleteGroupAccountAction(
+          emptyGroupAccountList,
+          deletedYearlyAccountList.data,
+          deletedMessage
+        )
       );
     } catch (error) {
       dispatch(

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -20,7 +20,7 @@ const initialState = {
     incomeCategoriesLoading: false,
     expenseCategoriesLoading: false,
     categoriesError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
   },
@@ -30,7 +30,7 @@ const initialState = {
     groupIncomeCategoriesLoading: false,
     groupExpenseCategoriesLoading: false,
     groupCategoriesError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
   },
@@ -38,19 +38,19 @@ const initialState = {
     latestTransactionsList: [],
     latestTransactionsListLoading: false,
     latestTransactionsListError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     transactionsList: [],
     transactionsListLoading: false,
     transactionsListError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     searchTransactionsList: [],
     searchTransactionsListLoading: false,
     searchTransactionsListError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     noTransactionsMessage: '',
@@ -60,19 +60,19 @@ const initialState = {
     groupLatestTransactionsList: [],
     groupLatestTransactionsListLoading: false,
     groupLatestTransactionsListError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     groupTransactionsList: [],
     groupTransactionsListLoading: false,
     groupTransactionsListError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     groupSearchTransactionsList: [],
     groupSearchTransactionsListLoading: false,
     groupSearchTransactionsListError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     notHistoryMessage: '',
@@ -87,7 +87,7 @@ const initialState = {
     },
     groupAccountListLoading: false,
     groupAccountListError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     groupYearlyAccountList: {
@@ -96,7 +96,7 @@ const initialState = {
     },
     groupYearlyAccountListLoading: false,
     groupYearlyAccountListError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     groupYearlyAccountListForModal: {
@@ -105,7 +105,7 @@ const initialState = {
     },
     groupYearlyAccountListForModalLoading: false,
     groupYearlyAccountListForModalError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
   },
@@ -113,23 +113,23 @@ const initialState = {
     standard_budgets_list: [],
     standardBudgetsLoading: false,
     standardBudgetsError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     yearly_budgets_list: {
       year: '',
-      yearly_total_budget: 0,
+      yearly_total_budget: null,
       monthly_budgets: [],
     },
     yearlyBudgetsLoading: false,
     yearlyBudgetsError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     custom_budgets_list: [],
     customBudgetsLoading: false,
     customBudgetsError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
   },
@@ -137,23 +137,23 @@ const initialState = {
     groupStandardBudgetsList: [],
     groupStandardBudgetsLoading: false,
     groupStandardBudgetsError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     groupCustomBudgetsList: [],
     groupCustomBudgetsLoading: false,
     groupCustomBudgetsError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
     groupYearlyBudgetsList: {
       year: '',
-      yearly_total_budget: 0,
+      yearly_total_budget: null,
       monthly_budgets: [],
     },
     groupYearlyBudgetsLoading: false,
     groupYearlyBudgetsError: {
-      statusCode: 0,
+      statusCode: null,
       errorMessage: '',
     },
   },

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -45,7 +45,7 @@ export interface State {
     incomeCategoriesLoading: boolean;
     expenseCategoriesLoading: boolean;
     categoriesError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
   };
@@ -55,7 +55,7 @@ export interface State {
     groupIncomeCategoriesLoading: boolean;
     groupExpenseCategoriesLoading: boolean;
     groupCategoriesError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
   };
@@ -63,19 +63,19 @@ export interface State {
     latestTransactionsList: TransactionsList;
     latestTransactionsListLoading: boolean;
     latestTransactionsListError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     transactionsList: TransactionsList;
     transactionsListLoading: boolean;
     transactionsListError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     searchTransactionsList: TransactionsList;
     searchTransactionsListLoading: boolean;
     searchTransactionsListError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     noTransactionsMessage: string;
@@ -85,37 +85,37 @@ export interface State {
     groupLatestTransactionsList: GroupTransactionsList;
     groupLatestTransactionsListLoading: boolean;
     groupLatestTransactionsListError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     groupTransactionsList: GroupTransactionsList;
     groupTransactionsListLoading: boolean;
     groupTransactionsListError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     groupSearchTransactionsList: GroupTransactionsList;
     groupSearchTransactionsListLoading: boolean;
     groupSearchTransactionsListError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     groupAccountList: GroupAccountList;
     groupAccountListLoading: boolean;
     groupAccountListError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     groupYearlyAccountList: GroupYearlyAccountList;
     groupYearlyAccountListLoading: boolean;
     groupYearlyAccountListError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     groupYearlyAccountListForModal: GroupYearlyAccountList;
     groupYearlyAccountListForModalLoading: boolean;
     groupYearlyAccountListForModalError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     notAccountMessage: string;
@@ -125,19 +125,19 @@ export interface State {
     standard_budgets_list: StandardBudgetsList;
     standardBudgetsLoading: boolean;
     standardBudgetsError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     yearly_budgets_list: YearlyBudgetsList;
     yearlyBudgetsLoading: boolean;
     yearlyBudgetsError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     custom_budgets_list: CustomBudgetsList;
     customBudgetsLoading: boolean;
     customBudgetsError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
   };
@@ -145,19 +145,19 @@ export interface State {
     groupStandardBudgetsList: GroupStandardBudgetsList;
     groupStandardBudgetsLoading: boolean;
     groupStandardBudgetsError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     groupCustomBudgetsList: GroupCustomBudgetsList;
     groupCustomBudgetsLoading: boolean;
     groupCustomBudgetsError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
     groupYearlyBudgetsList: GroupYearlyBudgetsList;
     groupYearlyBudgetsLoading: boolean;
     groupYearlyBudgetsError: {
-      statusCode: number;
+      statusCode: number | null;
       errorMessage: string;
     };
   };

--- a/src/reducks/transactions/actions.ts
+++ b/src/reducks/transactions/actions.ts
@@ -28,6 +28,11 @@ export const startFetchTransactionsActions = () => {
     type: START_FETCH_TRANSACTIONS,
     payload: {
       transactionsListLoading: true,
+
+      transactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -77,6 +82,11 @@ export const startFetchLatestTransactionsActions = () => {
     type: START_FETCH_LATEST_TRANSACTIONS,
     payload: {
       latestTransactionsListLoading: true,
+
+      latestTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -123,6 +133,16 @@ export const startAddTransactionsActions = () => {
     payload: {
       transactionsListLoading: true,
       latestTransactionsListLoading: true,
+
+      transactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
+
+      latestTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -171,6 +191,16 @@ export const startEditTransactionsActions = () => {
     payload: {
       transactionsListLoading: true,
       latestTransactionsListLoading: true,
+
+      transactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
+
+      latestTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -219,6 +249,16 @@ export const startDeleteTransactionsActions = () => {
     payload: {
       transactionsListLoading: true,
       latestTransactionsListLoading: true,
+
+      transactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
+
+      latestTransactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };
@@ -266,6 +306,11 @@ export const startSearchTransactionsActions = () => {
     type: START_SEARCH_TRANSACTIONS,
     payload: {
       searchTransactionsListLoading: true,
+
+      transactionsListError: {
+        statusCode: null,
+        errorMessage: '',
+      },
     },
   };
 };

--- a/src/reducks/transactions/operations.ts
+++ b/src/reducks/transactions/operations.ts
@@ -146,7 +146,7 @@ export const addTransactions = (
         }
       );
 
-      const fetchTransactionsResult = await axios.get<FetchTransactionsRes>(
+      const fetchTransactionsResult = axios.get<FetchTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${addTransactionYear}-${addTransactionMonth}`,
         {
           cancelToken: signal.token,
@@ -154,7 +154,7 @@ export const addTransactions = (
         }
       );
 
-      const fetchLatestTransactionsResult = await axios.get<FetchLatestTransactionsRes>(
+      const fetchLatestTransactionsResult = axios.get<FetchLatestTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/latest`,
         {
           cancelToken: signal.token,
@@ -162,10 +162,15 @@ export const addTransactions = (
         }
       );
 
-      const addedTransactionsList = fetchTransactionsResult.data.transactions_list;
-      const addedLatestTransactionsList = fetchLatestTransactionsResult.data.transactions_list;
+      const addedTransactionsList = await fetchTransactionsResult;
+      const addedLatestTransactionsList = await fetchLatestTransactionsResult;
 
-      dispatch(addTransactionsActions(addedTransactionsList, addedLatestTransactionsList));
+      dispatch(
+        addTransactionsActions(
+          addedTransactionsList.data.transactions_list,
+          addedLatestTransactionsList.data.transactions_list
+        )
+      );
     } catch (error) {
       dispatch(
         failedAddTransactionsActions(error.response.status, error.response.data.error.message)
@@ -212,7 +217,7 @@ export const editTransactions = (
         }
       );
 
-      const fetchTransactionsResult = await axios.get<FetchTransactionsRes>(
+      const fetchTransactionsResult = axios.get<FetchTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${editTransactionYear}-${editTransactionMonth}`,
         {
           cancelToken: signal.token,
@@ -220,7 +225,7 @@ export const editTransactions = (
         }
       );
 
-      const fetchLatestTransactionsResult = await axios.get<FetchLatestTransactionsRes>(
+      const fetchLatestTransactionsResult = axios.get<FetchLatestTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/latest`,
         {
           cancelToken: signal.token,
@@ -228,10 +233,15 @@ export const editTransactions = (
         }
       );
 
-      const editedTransactionsList = fetchTransactionsResult.data.transactions_list;
-      const editedLatestTransactionsList = fetchLatestTransactionsResult.data.transactions_list;
+      const editedTransactionsList = await fetchTransactionsResult;
+      const editedLatestTransactionsList = await fetchLatestTransactionsResult;
 
-      dispatch(editTransactionsActions(editedTransactionsList, editedLatestTransactionsList));
+      dispatch(
+        editTransactionsActions(
+          editedTransactionsList.data.transactions_list,
+          editedLatestTransactionsList.data.transactions_list
+        )
+      );
     } catch (error) {
       dispatch(
         failedEditTransactionsActions(error.response.status, error.response.data.error.message)
@@ -257,7 +267,7 @@ export const deleteTransactions = (
         }
       );
 
-      const fetchTransactionsResult = await axios.get<FetchTransactionsRes>(
+      const fetchTransactionsResult = axios.get<FetchTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/${editTransactionYear}-${editTransactionMonth}`,
         {
           cancelToken: signal.token,
@@ -265,7 +275,7 @@ export const deleteTransactions = (
         }
       );
 
-      const fetchLatestTransactionsResult = await axios.get<FetchLatestTransactionsRes>(
+      const fetchLatestTransactionsResult = axios.get<FetchLatestTransactionsRes>(
         `${process.env.REACT_APP_ACCOUNT_API_HOST}/transactions/latest`,
         {
           cancelToken: signal.token,
@@ -274,14 +284,14 @@ export const deleteTransactions = (
       );
 
       const deletedTransactionsList =
-        fetchTransactionsResult.data.transactions_list === undefined
+        (await fetchTransactionsResult).data.transactions_list === undefined
           ? []
-          : fetchTransactionsResult.data.transactions_list;
+          : (await fetchTransactionsResult).data.transactions_list;
 
       const deletedLatestTransactionsList =
-        fetchLatestTransactionsResult.data.transactions_list === undefined
+        fetchLatestTransactionsResult === undefined
           ? []
-          : fetchLatestTransactionsResult.data.transactions_list;
+          : (await fetchLatestTransactionsResult).data.transactions_list;
 
       dispatch(deleteTransactionsActions(deletedTransactionsList, deletedLatestTransactionsList));
     } catch (error) {

--- a/test/budgets-test/Budgets.test.ts
+++ b/test/budgets-test/Budgets.test.ts
@@ -43,6 +43,11 @@ describe('async actions Budgets', () => {
         type: actionTypes.START_FETCH_STANDARD_BUDGETS,
         payload: {
           standardBudgetsLoading: true,
+
+          standardBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -145,6 +150,11 @@ it('Edit standard_budgets if fetch succeeds', async () => {
       type: actionTypes.START_EDIT_STANDARD_BUDGETS,
       payload: {
         standardBudgetsLoading: true,
+
+        standardBudgetsError: {
+          statusCode: null,
+          errorMessage: '',
+        },
       },
     },
     {
@@ -180,6 +190,11 @@ it('Get yearly_budgets if fetch succeeds', async () => {
       type: actionTypes.START_FETCH_YEARLY_BUDGETS,
       payload: {
         yearlyBudgetsLoading: true,
+
+        yearlyBudgetsError: {
+          statusCode: null,
+          errorMessage: '',
+        },
       },
     },
     {
@@ -214,6 +229,11 @@ it('Get custom_budgets if fetch succeeds', async () => {
       type: actionTypes.START_FETCH_CUSTOM_BUDGETS,
       payload: {
         customBudgetsLoading: true,
+
+        customBudgetsError: {
+          statusCode: null,
+          errorMessage: '',
+        },
       },
     },
     {
@@ -324,6 +344,11 @@ it('Add custom_budgets if fetch succeeds', async () => {
       payload: {
         customBudgetsLoading: true,
         yearlyBudgetsLoading: true,
+
+        customBudgetsError: {
+          statusCode: null,
+          errorMessage: '',
+        },
       },
     },
     {
@@ -442,6 +467,11 @@ it('Edit custom_budgets if fetch succeeds', async () => {
       payload: {
         customBudgetsLoading: true,
         yearlyBudgetsLoading: true,
+
+        customBudgetsError: {
+          statusCode: null,
+          errorMessage: '',
+        },
       },
     },
     {
@@ -554,6 +584,11 @@ it('Delete custom_budgets if fetch succeeds', async () => {
       type: START_DELETE_CUSTOM_BUDGETS,
       payload: {
         yearlyBudgetsLoading: true,
+
+        yearlyBudgetsError: {
+          statusCode: null,
+          errorMessage: '',
+        },
       },
     },
     {

--- a/test/group-budgets-test/GroupBudgets.test.ts
+++ b/test/group-budgets-test/GroupBudgets.test.ts
@@ -44,6 +44,11 @@ describe('async actions groupBudgets', () => {
         type: actionTypes.START_FETCH_GROUP_STANDARD_BUDGETS,
         payload: {
           groupStandardBudgetsLoading: true,
+
+          groupStandardBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -147,6 +152,11 @@ describe('async actions groupBudgets', () => {
         type: actionTypes.START_EDIT_GROUP_STANDARD_BUDGETS,
         payload: {
           groupStandardBudgetsLoading: true,
+
+          groupStandardBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -185,6 +195,11 @@ describe('async actions groupBudgets', () => {
         type: actionTypes.START_FETCH_GROUP_YEARLY_BUDGETS,
         payload: {
           groupYearlyBudgetsLoading: true,
+
+          groupYearlyBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -222,6 +237,11 @@ describe('async actions groupBudgets', () => {
         type: actionTypes.START_FETCH_GROUP_CUSTOM_BUDGETS,
         payload: {
           groupCustomBudgetsLoading: true,
+
+          groupCustomBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -330,6 +350,11 @@ describe('async actions groupBudgets', () => {
         payload: {
           groupCustomBudgetsLoading: true,
           groupYearlyBudgetsLoading: true,
+
+          groupCustomBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -451,6 +476,11 @@ describe('async actions groupBudgets', () => {
         payload: {
           groupCustomBudgetsLoading: true,
           groupYearlyBudgetsLoading: true,
+
+          groupCustomBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -571,6 +601,11 @@ describe('async actions groupBudgets', () => {
         type: actionTypes.START_DELETE_GROUP_CUSTOM_BUDGETS,
         payload: {
           groupYearlyBudgetsLoading: true,
+
+          groupCustomBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {

--- a/test/group-transactions-test/GroupTransactions.test.ts
+++ b/test/group-transactions-test/GroupTransactions.test.ts
@@ -68,6 +68,11 @@ describe('async actions groupTransactions', () => {
         type: actionTypes.START_FETCH_GROUP_TRANSACTIONS,
         payload: {
           groupTransactionsListLoading: true,
+
+          groupTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -103,6 +108,11 @@ describe('async actions groupTransactions', () => {
         type: actionTypes.START_FETCH_GROUP_LATEST_TRANSACTIONS,
         payload: {
           groupLatestTransactionsListLoading: true,
+
+          groupLatestTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -179,6 +189,16 @@ describe('async actions groupTransactions', () => {
         payload: {
           groupTransactionsListLoading: true,
           groupLatestTransactionsListLoading: true,
+
+          groupTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+
+          groupLatestTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -260,6 +280,16 @@ describe('async actions groupTransactions', () => {
         payload: {
           groupTransactionsListLoading: true,
           groupLatestTransactionsListLoading: true,
+
+          groupTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+
+          groupLatestTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -309,6 +339,16 @@ describe('async actions groupTransactions', () => {
         payload: {
           groupTransactionsListLoading: true,
           groupLatestTransactionsListLoading: true,
+
+          groupTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+
+          groupLatestTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -394,6 +434,16 @@ describe('async actions groupTransactions', () => {
         payload: {
           groupAccountListLoading: true,
           groupYearlyAccountListLoading: true,
+
+          groupAccountListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+
+          groupYearlyAccountListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -449,6 +499,11 @@ describe('async actions groupTransactions', () => {
         type: actionTypes.START_EDIT_GROUP_ACCOUNT,
         payload: {
           groupAccountListLoading: true,
+
+          groupAccountListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -507,6 +562,16 @@ describe('async actions groupTransactions', () => {
         payload: {
           groupAccountListLoading: true,
           groupYearlyAccountListLoading: true,
+
+          groupAccountListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+
+          groupYearlyAccountListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -554,6 +619,11 @@ describe('async actions groupTransactions', () => {
         type: actionTypes.START_SEARCH_GROUP_TRANSACTIONS,
         payload: {
           groupSearchTransactionsListLoading: true,
+
+          groupSearchTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {

--- a/test/transactions-test/TransactionsOperations.test.ts
+++ b/test/transactions-test/TransactionsOperations.test.ts
@@ -53,6 +53,11 @@ describe('async actions transactions', () => {
         type: actionTypes.START_FETCH_TRANSACTIONS,
         payload: {
           transactionsListLoading: true,
+
+          transactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -81,6 +86,11 @@ describe('async actions transactions', () => {
         type: actionTypes.START_FETCH_LATEST_TRANSACTIONS,
         payload: {
           latestTransactionsListLoading: true,
+
+          latestTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -147,6 +157,16 @@ describe('async actions transactions', () => {
         payload: {
           transactionsListLoading: true,
           latestTransactionsListLoading: true,
+
+          transactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+
+          latestTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -218,6 +238,16 @@ describe('async actions transactions', () => {
         payload: {
           transactionsListLoading: true,
           latestTransactionsListLoading: true,
+
+          transactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+
+          latestTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -258,6 +288,16 @@ describe('async actions transactions', () => {
         payload: {
           transactionsListLoading: true,
           latestTransactionsListLoading: true,
+
+          transactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+
+          latestTransactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {
@@ -296,6 +336,11 @@ describe('async actions transactions', () => {
         type: actionTypes.START_SEARCH_TRANSACTIONS,
         payload: {
           searchTransactionsListLoading: true,
+
+          transactionsListError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
       {


### PR DESCRIPTION
- `transactions, groupTransactions, budgets, groupBudgets`のSTART actionに`statusCode, errorMessage`を
   追加しました。

- 上記の変更に伴い`CategoriesOperations.test, GroupCategoriesOperations.test, BudgetsOperations.test, 
   GroupBudgetsOperations.test`を修正しました。

- `operations`の`add, edit, delete`の処理の後に複数のfetch処理を行う際に同時にfetch処理を実行するように
   awaitの位置を修正しました。
   