### PR TITLE
Modify the size of the tabs in the budget screen

### DIFF
--- a/src/components/budget/budget.scss
+++ b/src/components/budget/budget.scss
@@ -31,6 +31,7 @@
 
   &__switch-type {
     width: 30%;
+    height: 34px;
     margin: 0 auto;
 
   }


### PR DESCRIPTION
- 予算画面で標準予算と月別予算を切り替えた際にタブの大きさが変化するようになっていたので
  修正しました。