### PR TITLE
Modify the operations of budgets and group budgets

### DIFF
--- a/src/containers/budgets/AddCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/AddCustomBudgetsContainer.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 import { useHistory } from 'react-router-dom';
 import axios from 'axios';
-import { getTotalStandardBudget, getCopiedCustomBudgets } from '../../reducks/budgets/selectors';
+import { getTotalStandardBudget, getInitialCustomBudgets } from '../../reducks/budgets/selectors';
 import {
   addCustomBudgets,
   fetchCustomBudgets,
@@ -23,9 +23,9 @@ const AddCustomBudgetsContainer = (props: AddCustomBudgetsContainerProps) => {
   const searchLocation = useLocation().search;
   const getQuery = new URLSearchParams(searchLocation);
   const queryMonth = getQuery.get('month');
-  const copiedCustomBudgetsList = useSelector(getCopiedCustomBudgets);
+  const initialCustomBudgets = useSelector(getInitialCustomBudgets);
   const totalStandardBudget = useSelector(getTotalStandardBudget);
-  const [customBudgets, setCustomBudgets] = useState<CustomBudgetsList>([]);
+  const [initialCustomBudgetsList, setInitialCustomBudgetsList] = useState<CustomBudgetsList>([]);
   const yearsInPersonal = `${props.budgetsYear}年${queryMonth}月`;
 
   useEffect(() => {
@@ -42,14 +42,14 @@ const AddCustomBudgetsContainer = (props: AddCustomBudgetsContainerProps) => {
   }, []);
 
   useEffect(() => {
-    setCustomBudgets(copiedCustomBudgetsList);
-  }, [copiedCustomBudgetsList]);
+    setInitialCustomBudgetsList(initialCustomBudgets);
+  }, [initialCustomBudgets]);
 
   const totalCustomBudget = () => {
     let total = 0;
 
-    for (let i = 0; i < customBudgets.length; i++) {
-      total += Number(customBudgets[i].budget);
+    for (let i = 0; i < initialCustomBudgetsList.length; i++) {
+      total += Number(initialCustomBudgetsList[i].budget);
     }
 
     return total === totalStandardBudget;
@@ -59,8 +59,8 @@ const AddCustomBudgetsContainer = (props: AddCustomBudgetsContainerProps) => {
     <AddCustomBudgets
       pathName={pathName}
       budgetsYear={props.budgetsYear}
-      customBudgets={customBudgets}
-      setCustomBudgets={setCustomBudgets}
+      customBudgets={initialCustomBudgetsList}
+      setCustomBudgets={setInitialCustomBudgetsList}
       unInputBudgets={totalCustomBudget()}
       totalStandardBudget={totalStandardBudget}
       yearsInPersonal={yearsInPersonal}
@@ -76,7 +76,7 @@ const AddCustomBudgetsContainer = (props: AddCustomBudgetsContainerProps) => {
             addCustomBudgets(
               String(props.budgetsYear),
               queryMonth,
-              customBudgets.map((budget) => {
+              initialCustomBudgetsList.map((budget) => {
                 const {
                   big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
                   last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/containers/budgets/AddGroupCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/AddGroupCustomBudgetsContainer.tsx
@@ -23,9 +23,8 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
   const dispatch = useDispatch();
   const history = useHistory();
   const { group_id } = useParams<{ group_id: string }>();
-  const searchLocation = useLocation().search;
-  const getQuery = new URLSearchParams(searchLocation);
-  const queryMonth = getQuery.get('month');
+  const searchQuery = new URLSearchParams(useLocation().search);
+  const queryMonth = searchQuery.get('month');
   const yearsInGroup = `${props.budgetsYear}年${queryMonth}月`;
   const initialGroupCustomBudgets = useSelector(getInitialGroupCustomBudgets);
   const groupTotalStandardBudget = useSelector(getGroupTotalStandardBudget);
@@ -39,20 +38,25 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
     if (!editing) {
       const signal = axios.CancelToken.source();
 
-      if (queryMonth != null) {
-        dispatch(
-          fetchGroupCustomBudgets(String(props.budgetsYear), queryMonth, Number(group_id), signal)
-        );
-      }
-
+      dispatch(
+        fetchGroupCustomBudgets(
+          String(props.budgetsYear),
+          String(queryMonth),
+          Number(group_id),
+          signal
+        )
+      );
       dispatch(fetchGroupStandardBudgets(Number(group_id), signal));
 
       const interval = setInterval(() => {
-        if (queryMonth != null) {
-          dispatch(
-            fetchGroupCustomBudgets(String(props.budgetsYear), queryMonth, Number(group_id), signal)
-          );
-        }
+        dispatch(
+          fetchGroupCustomBudgets(
+            String(props.budgetsYear),
+            String(queryMonth),
+            Number(group_id),
+            signal
+          )
+        );
 
         dispatch(fetchGroupStandardBudgets(Number(group_id), signal));
       }, 3000);
@@ -68,52 +72,54 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
     setInitialGroupCustomBudgetsList(initialGroupCustomBudgets);
   }, [initialGroupCustomBudgets]);
 
-  const totalGroupCustomBudget = () => {
-    let total = 0;
+  const disabledAddGroupCustomBudget = () => {
+    const totalGroupCustomBudget = initialGroupCustomBudgetsList.reduce(
+      (prevCustomBudget, currentCustomBudget) =>
+        prevCustomBudget + Number(currentCustomBudget.budget),
+      0
+    );
 
-    for (let i = 0; i < initialGroupCustomBudgetsList.length; i++) {
-      total += Number(initialGroupCustomBudgetsList[i].budget);
-    }
+    return totalGroupCustomBudget === groupTotalStandardBudget || queryMonth === null;
+  };
 
-    return total === groupTotalStandardBudget;
+  const handleBackPage = () => {
+    history.push({
+      pathname: `/group/${group_id}/budgets`,
+      search: `?yearly&year=${props.budgetsYear}`,
+    });
+  };
+
+  const handleAddGroupCustomBudget = () => {
+    dispatch(
+      addGroupCustomBudgets(
+        String(props.budgetsYear),
+        String(queryMonth),
+        Number(group_id),
+        initialGroupCustomBudgetsList.map((groupCustomBudget) => {
+          const {
+            big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+            last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+            ...rest
+          } = groupCustomBudget;
+          return {
+            big_category_id: rest.big_category_id,
+            budget: Number(rest.budget),
+          };
+        })
+      )
+    );
   };
 
   return (
     <AddGroupCustomBudgets
       setEditing={setEditing}
       yearsInGroup={yearsInGroup}
-      unAddCustomBudgets={totalGroupCustomBudget()}
+      unAddCustomBudgets={disabledAddGroupCustomBudget()}
       groupCustomBudgets={initialGroupCustomBudgetsList}
       setGroupCustomBudgets={setInitialGroupCustomBudgetsList}
       groupTotalStandardBudget={groupTotalStandardBudget}
-      backPageOperation={() =>
-        history.push({
-          pathname: `/group/${group_id}/budgets`,
-          search: `?yearly&year=${props.budgetsYear}`,
-        })
-      }
-      addGroupCustomBudgetOperation={() => {
-        if (queryMonth != null) {
-          dispatch(
-            addGroupCustomBudgets(
-              String(props.budgetsYear),
-              queryMonth,
-              Number(group_id),
-              initialGroupCustomBudgetsList.map((groupCustomBudget) => {
-                const {
-                  big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
-                  last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
-                  ...rest
-                } = groupCustomBudget;
-                return {
-                  big_category_id: rest.big_category_id,
-                  budget: Number(rest.budget),
-                };
-              })
-            )
-          );
-        }
-      }}
+      backPageOperation={handleBackPage}
+      addGroupCustomBudgetOperation={handleAddGroupCustomBudget}
     />
   );
 };

--- a/src/containers/budgets/AddGroupCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/AddGroupCustomBudgetsContainer.tsx
@@ -4,7 +4,7 @@ import { useLocation, useParams } from 'react-router';
 import axios from 'axios';
 import {
   getGroupTotalStandardBudget,
-  getCopiedCustomBudgets,
+  getInitialGroupCustomBudgets,
 } from '../../reducks/groupBudgets/selectors';
 import {
   addGroupCustomBudgets,
@@ -27,9 +27,12 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
   const getQuery = new URLSearchParams(searchLocation);
   const queryMonth = getQuery.get('month');
   const yearsInGroup = `${props.budgetsYear}年${queryMonth}月`;
-  const copiedCustomBudget = useSelector(getCopiedCustomBudgets);
+  const initialGroupCustomBudgets = useSelector(getInitialGroupCustomBudgets);
   const groupTotalStandardBudget = useSelector(getGroupTotalStandardBudget);
-  const [groupCustomBudgets, setGroupCustomBudgets] = useState<GroupCustomBudgetsList>([]);
+  const [
+    initialGroupCustomBudgetsList,
+    setInitialGroupCustomBudgetsList,
+  ] = useState<GroupCustomBudgetsList>([]);
   const [editing, setEditing] = useState<boolean>(false);
 
   useEffect(() => {
@@ -41,6 +44,7 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
           fetchGroupCustomBudgets(String(props.budgetsYear), queryMonth, Number(group_id), signal)
         );
       }
+
       dispatch(fetchGroupStandardBudgets(Number(group_id), signal));
 
       const interval = setInterval(() => {
@@ -61,26 +65,26 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
   }, [editing]);
 
   useEffect(() => {
-    setGroupCustomBudgets(copiedCustomBudget);
-  }, [copiedCustomBudget]);
+    setInitialGroupCustomBudgetsList(initialGroupCustomBudgets);
+  }, [initialGroupCustomBudgets]);
 
   const totalGroupCustomBudget = () => {
     let total = 0;
 
-    for (let i = 0; i < groupCustomBudgets.length; i++) {
-      total += Number(groupCustomBudgets[i].budget);
+    for (let i = 0; i < initialGroupCustomBudgetsList.length; i++) {
+      total += Number(initialGroupCustomBudgetsList[i].budget);
     }
 
-    return total;
+    return total === groupTotalStandardBudget;
   };
 
   return (
     <AddGroupCustomBudgets
       setEditing={setEditing}
       yearsInGroup={yearsInGroup}
-      unAddCustomBudgets={totalGroupCustomBudget() === groupTotalStandardBudget}
-      groupCustomBudgets={groupCustomBudgets}
-      setGroupCustomBudgets={setGroupCustomBudgets}
+      unAddCustomBudgets={totalGroupCustomBudget()}
+      groupCustomBudgets={initialGroupCustomBudgetsList}
+      setGroupCustomBudgets={setInitialGroupCustomBudgetsList}
       groupTotalStandardBudget={groupTotalStandardBudget}
       backPageOperation={() =>
         history.push({
@@ -95,7 +99,7 @@ const AddGroupCustomBudgetsContainer = (props: AddGroupCustomBudgetsContainerPro
               String(props.budgetsYear),
               queryMonth,
               Number(group_id),
-              groupCustomBudgets.map((groupCustomBudget) => {
+              initialGroupCustomBudgetsList.map((groupCustomBudget) => {
                 const {
                   big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
                   last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/containers/budgets/CustomBudgetsContainer.tsx
+++ b/src/containers/budgets/CustomBudgetsContainer.tsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { useLocation, useParams } from 'react-router';
+import { useLocation } from 'react-router';
 import axios from 'axios';
 import { CustomBudgetsList } from '../../reducks/budgets/types';
 import { editCustomBudgets, fetchCustomBudgets } from '../../reducks/budgets/operations';
 import { getCustomBudgets, getTotalCustomBudget } from '../../reducks/budgets/selectors';
 import CustomBudgets from '../../components/budget/CustomBudgets';
-import { fetchGroupCustomBudgets } from '../../reducks/groupBudgets/operations';
 
 interface CustomBudgetsContainerProps {
   budgetsYear: number;
@@ -16,11 +15,9 @@ interface CustomBudgetsContainerProps {
 const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
   const dispatch = useDispatch();
   const history = useHistory();
-  const { group_id } = useParams<{ group_id: string }>();
   const pathName = useLocation().pathname.split('/')[1];
-  const searchLocation = useLocation().search;
-  const getQuery = new URLSearchParams(searchLocation);
-  const queryMonth = getQuery.get('month');
+  const searchQuery = new URLSearchParams(useLocation().search);
+  const queryMonth = searchQuery.get('month');
   const customBudgets = useSelector(getCustomBudgets);
   const totalCustomBudget = useSelector(getTotalCustomBudget);
   const yearsInPersonal = `${props.budgetsYear}年${queryMonth}月`;
@@ -28,17 +25,7 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
 
   useEffect(() => {
     const signal = axios.CancelToken.source();
-    if (pathName !== 'group') {
-      if (queryMonth != null) {
-        dispatch(fetchCustomBudgets(String(props.budgetsYear), queryMonth, signal));
-      }
-    } else {
-      if (queryMonth != null) {
-        dispatch(
-          fetchGroupCustomBudgets(String(props.budgetsYear), queryMonth, Number(group_id), signal)
-        );
-      }
-    }
+    dispatch(fetchCustomBudgets(String(props.budgetsYear), String(queryMonth), signal));
 
     return () => signal.cancel();
   }, []);
@@ -47,52 +34,53 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
     setCustomBudgetsList(customBudgets);
   }, [customBudgets]);
 
-  const totalBudget = () => {
-    let total = 0;
+  const disabledEditCustomBudget = () => {
+    const totalBudget = customBudgetsList.reduce(
+      (prevBudget, currentBudget) => prevBudget + Number(currentBudget.budget),
+      0
+    );
 
-    for (let i = 0; i < customBudgetsList.length; i++) {
-      total += Number(customBudgetsList[i].budget);
-    }
+    return totalBudget === totalCustomBudget || queryMonth === null;
+  };
 
-    return total === totalCustomBudget;
+  const handleBackPage = () => {
+    history.push({
+      pathname: '/budgets',
+      search: `?yearly&year=${props.budgetsYear}`,
+    });
+  };
+
+  const handleEditCustomBudget = () => {
+    dispatch(
+      editCustomBudgets(
+        String(props.budgetsYear),
+        String(queryMonth),
+        customBudgetsList.map((budget) => {
+          const {
+            big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+            last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+            ...rest
+          } = budget;
+          return {
+            big_category_id: rest.big_category_id,
+            budget: Number(rest.budget),
+          };
+        })
+      )
+    );
   };
 
   return (
     <CustomBudgets
-      unInput={totalBudget()}
+      unInput={disabledEditCustomBudget()}
       pathName={pathName}
       budgetsYear={props.budgetsYear}
       customBudgets={customBudgetsList}
       setCustomBudgets={setCustomBudgetsList}
       yearsInPersonal={yearsInPersonal}
       totalCustomBudget={totalCustomBudget}
-      backPageOperation={() =>
-        history.push({
-          pathname: '/budgets',
-          search: `?yearly&year=${props.budgetsYear}`,
-        })
-      }
-      editCustomBudgetOperation={() => {
-        if (queryMonth != null) {
-          dispatch(
-            editCustomBudgets(
-              String(props.budgetsYear),
-              queryMonth,
-              customBudgetsList.map((budget) => {
-                const {
-                  big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
-                  last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
-                  ...rest
-                } = budget;
-                return {
-                  big_category_id: rest.big_category_id,
-                  budget: Number(rest.budget),
-                };
-              })
-            )
-          );
-        }
-      }}
+      backPageOperation={handleBackPage}
+      editCustomBudgetOperation={handleEditCustomBudget}
     />
   );
 };

--- a/src/containers/budgets/CustomBudgetsContainer.tsx
+++ b/src/containers/budgets/CustomBudgetsContainer.tsx
@@ -21,10 +21,10 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
   const searchLocation = useLocation().search;
   const getQuery = new URLSearchParams(searchLocation);
   const queryMonth = getQuery.get('month');
-  const customBudgetsList = useSelector(getCustomBudgets);
+  const customBudgets = useSelector(getCustomBudgets);
   const totalCustomBudget = useSelector(getTotalCustomBudget);
   const yearsInPersonal = `${props.budgetsYear}年${queryMonth}月`;
-  const [customBudgets, setCustomBudgets] = useState<CustomBudgetsList>([]);
+  const [customBudgetsList, setCustomBudgetsList] = useState<CustomBudgetsList>([]);
 
   useEffect(() => {
     const signal = axios.CancelToken.source();
@@ -44,14 +44,14 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
   }, []);
 
   useEffect(() => {
-    setCustomBudgets(customBudgetsList);
-  }, [customBudgetsList]);
+    setCustomBudgetsList(customBudgets);
+  }, [customBudgets]);
 
   const totalBudget = () => {
     let total = 0;
 
-    for (let i = 0; i < customBudgets.length; i++) {
-      total += Number(customBudgets[i].budget);
+    for (let i = 0; i < customBudgetsList.length; i++) {
+      total += Number(customBudgetsList[i].budget);
     }
 
     return total === totalCustomBudget;
@@ -62,8 +62,8 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
       unInput={totalBudget()}
       pathName={pathName}
       budgetsYear={props.budgetsYear}
-      customBudgets={customBudgets}
-      setCustomBudgets={setCustomBudgets}
+      customBudgets={customBudgetsList}
+      setCustomBudgets={setCustomBudgetsList}
       yearsInPersonal={yearsInPersonal}
       totalCustomBudget={totalCustomBudget}
       backPageOperation={() =>
@@ -78,7 +78,7 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
             editCustomBudgets(
               String(props.budgetsYear),
               queryMonth,
-              customBudgets.map((budget) => {
+              customBudgetsList.map((budget) => {
                 const {
                   big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
                   last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/containers/budgets/CustomBudgetsContainer.tsx
+++ b/src/containers/budgets/CustomBudgetsContainer.tsx
@@ -25,7 +25,6 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
   const totalCustomBudget = useSelector(getTotalCustomBudget);
   const yearsInPersonal = `${props.budgetsYear}年${queryMonth}月`;
   const [customBudgets, setCustomBudgets] = useState<CustomBudgetsList>([]);
-  const unInput = customBudgets === customBudgetsList;
 
   useEffect(() => {
     const signal = axios.CancelToken.source();
@@ -48,9 +47,19 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
     setCustomBudgets(customBudgetsList);
   }, [customBudgetsList]);
 
+  const totalBudget = () => {
+    let total = 0;
+
+    for (let i = 0; i < customBudgets.length; i++) {
+      total += Number(customBudgets[i].budget);
+    }
+
+    return total === totalCustomBudget;
+  };
+
   return (
     <CustomBudgets
-      unInput={unInput}
+      unInput={totalBudget()}
       pathName={pathName}
       budgetsYear={props.budgetsYear}
       customBudgets={customBudgets}
@@ -65,12 +74,10 @@ const CustomBudgetsContainer = (props: CustomBudgetsContainerProps) => {
       }
       editCustomBudgetOperation={() => {
         if (queryMonth != null) {
-          const signal = axios.CancelToken.source();
           dispatch(
             editCustomBudgets(
               String(props.budgetsYear),
               queryMonth,
-              signal,
               customBudgets.map((budget) => {
                 const {
                   big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/containers/budgets/GroupCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupCustomBudgetsContainer.tsx
@@ -30,7 +30,7 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
   const groupTotalCustomBudget = useSelector(getTotalGroupCustomBudget);
   const [groupCustomBudgets, setGroupCustomBudgets] = useState<GroupCustomBudgetsList>([]);
   const [editing, setEditing] = useState<boolean>(false);
-  const unEditCustomBudget = groupCustomBudgets === groupCustomBudgetsList;
+  // const unEditCustomBudget = groupCustomBudgets === groupCustomBudgetsList;
 
   useEffect(() => {
     if (!editing) {
@@ -59,13 +59,23 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
     setGroupCustomBudgets(groupCustomBudgetsList);
   }, [groupCustomBudgetsList]);
 
+  const totalBudget = () => {
+    let total = 0;
+
+    for (let i = 0; i < groupCustomBudgets.length; i++) {
+      total += Number(groupCustomBudgets[i].budget);
+    }
+
+    return total === groupTotalCustomBudget;
+  };
+
   return (
     <GroupCustomBudgets
       setEditing={setEditing}
       yearsInGroup={yearsInGroup}
       groupCustomBudgets={groupCustomBudgets}
       setGroupCustomBudgets={setGroupCustomBudgets}
-      unEditCustomBudget={unEditCustomBudget}
+      unEditCustomBudget={totalBudget()}
       groupTotalCustomBudget={groupTotalCustomBudget}
       backPageOperation={() =>
         history.push({
@@ -75,13 +85,11 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
       }
       editGroupCustomBudgetOperation={() => {
         if (queryMonth != null) {
-          const signal = axios.CancelToken.source();
           dispatch(
             editGroupCustomBudgets(
               String(props.budgetsYear),
               queryMonth,
               Number(group_id),
-              signal,
               groupCustomBudgets.map((groupBudget) => {
                 const {
                   big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/containers/budgets/GroupCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupCustomBudgetsContainer.tsx
@@ -30,7 +30,6 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
   const groupTotalCustomBudget = useSelector(getTotalGroupCustomBudget);
   const [groupCustomBudgets, setGroupCustomBudgets] = useState<GroupCustomBudgetsList>([]);
   const [editing, setEditing] = useState<boolean>(false);
-  // const unEditCustomBudget = groupCustomBudgets === groupCustomBudgetsList;
 
   useEffect(() => {
     if (!editing) {

--- a/src/containers/budgets/GroupCustomBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupCustomBudgetsContainer.tsx
@@ -26,9 +26,9 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
   const getQuery = new URLSearchParams(searchLocation);
   const queryMonth = getQuery.get('month');
   const yearsInGroup = `${props.budgetsYear}年${queryMonth}月`;
-  const groupCustomBudgetsList = useSelector(getGroupCustomBudgets);
+  const groupCustomBudgets = useSelector(getGroupCustomBudgets);
   const groupTotalCustomBudget = useSelector(getTotalGroupCustomBudget);
-  const [groupCustomBudgets, setGroupCustomBudgets] = useState<GroupCustomBudgetsList>([]);
+  const [groupCustomBudgetsList, setGroupCustomBudgetsList] = useState<GroupCustomBudgetsList>([]);
   const [editing, setEditing] = useState<boolean>(false);
 
   useEffect(() => {
@@ -55,14 +55,14 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
   }, [editing]);
 
   useEffect(() => {
-    setGroupCustomBudgets(groupCustomBudgetsList);
-  }, [groupCustomBudgetsList]);
+    setGroupCustomBudgetsList(groupCustomBudgets);
+  }, [groupCustomBudgets]);
 
   const totalBudget = () => {
     let total = 0;
 
-    for (let i = 0; i < groupCustomBudgets.length; i++) {
-      total += Number(groupCustomBudgets[i].budget);
+    for (let i = 0; i < groupCustomBudgetsList.length; i++) {
+      total += Number(groupCustomBudgetsList[i].budget);
     }
 
     return total === groupTotalCustomBudget;
@@ -72,8 +72,8 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
     <GroupCustomBudgets
       setEditing={setEditing}
       yearsInGroup={yearsInGroup}
-      groupCustomBudgets={groupCustomBudgets}
-      setGroupCustomBudgets={setGroupCustomBudgets}
+      groupCustomBudgets={groupCustomBudgetsList}
+      setGroupCustomBudgets={setGroupCustomBudgetsList}
       unEditCustomBudget={totalBudget()}
       groupTotalCustomBudget={groupTotalCustomBudget}
       backPageOperation={() =>
@@ -89,7 +89,7 @@ const GroupCustomBudgetsContainer = (props: GroupCustomBudgetsContainerProps) =>
               String(props.budgetsYear),
               queryMonth,
               Number(group_id),
-              groupCustomBudgets.map((groupBudget) => {
+              groupCustomBudgetsList.map((groupBudget) => {
                 const {
                   big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
                   last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/containers/budgets/GroupStandardBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupStandardBudgetsContainer.tsx
@@ -17,10 +17,13 @@ import GroupStandardBudgets from '../../components/budget/GroupStandardBudgets';
 const GroupStandardBudgetsContainer = () => {
   const dispatch = useDispatch();
   const { group_id } = useParams<{ group_id: string }>();
-  const groupStandardBudgetsList = useSelector(getGroupStandardBudgets);
+  const groupStandardBudgets = useSelector(getGroupStandardBudgets);
   const groupTotalStandardBudget = useSelector(getGroupTotalStandardBudget);
   const [editing, setEditing] = useState<boolean>(false);
-  const [groupStandardBudgets, setGroupStandardBudgets] = useState<GroupStandardBudgetsList>([]);
+  const [
+    groupStandardBudgetsList,
+    setGroupStandardBudgetsList,
+  ] = useState<GroupStandardBudgetsList>([]);
 
   const fetchGroupStandardBudgetsData = (signal: CancelTokenSource) => {
     dispatch(fetchGroups(signal));
@@ -44,14 +47,14 @@ const GroupStandardBudgetsContainer = () => {
   }, [editing]);
 
   useEffect(() => {
-    setGroupStandardBudgets(groupStandardBudgetsList);
-  }, [groupStandardBudgetsList]);
+    setGroupStandardBudgetsList(groupStandardBudgets);
+  }, [groupStandardBudgets]);
 
   const totalBudget = () => {
     let total = 0;
 
-    for (let i = 0; i < groupStandardBudgets.length; i++) {
-      total += Number(groupStandardBudgets[i].budget);
+    for (let i = 0; i < groupStandardBudgetsList.length; i++) {
+      total += Number(groupStandardBudgetsList[i].budget);
     }
 
     return total === groupTotalStandardBudget;
@@ -61,14 +64,14 @@ const GroupStandardBudgetsContainer = () => {
     <GroupStandardBudgets
       setEditing={setEditing}
       unEditBudgets={totalBudget()}
-      groupStandardBudgets={groupStandardBudgets}
-      setGroupStandardBudgets={setGroupStandardBudgets}
+      groupStandardBudgets={groupStandardBudgetsList}
+      setGroupStandardBudgets={setGroupStandardBudgetsList}
       groupTotalStandardBudget={groupTotalStandardBudget}
       editGroupStandardBudgetOperation={() => {
         dispatch(
           editGroupStandardBudgets(
             Number(group_id),
-            groupStandardBudgets.map((groupBudget) => {
+            groupStandardBudgetsList.map((groupBudget) => {
               const {
                 big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
                 last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/containers/budgets/GroupStandardBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupStandardBudgetsContainer.tsx
@@ -21,7 +21,6 @@ const GroupStandardBudgetsContainer = () => {
   const groupTotalStandardBudget = useSelector(getGroupTotalStandardBudget);
   const [editing, setEditing] = useState<boolean>(false);
   const [groupStandardBudgets, setGroupStandardBudgets] = useState<GroupStandardBudgetsList>([]);
-  const unEditBudgets = groupStandardBudgets === groupStandardBudgetsList;
 
   const fetchGroupStandardBudgetsData = (signal: CancelTokenSource) => {
     dispatch(fetchGroups(signal));
@@ -48,19 +47,27 @@ const GroupStandardBudgetsContainer = () => {
     setGroupStandardBudgets(groupStandardBudgetsList);
   }, [groupStandardBudgetsList]);
 
+  const totalBudget = () => {
+    let total = 0;
+
+    for (let i = 0; i < groupStandardBudgets.length; i++) {
+      total += Number(groupStandardBudgets[i].budget);
+    }
+
+    return total === groupTotalStandardBudget;
+  };
+
   return (
     <GroupStandardBudgets
       setEditing={setEditing}
-      unEditBudgets={unEditBudgets}
+      unEditBudgets={totalBudget()}
       groupStandardBudgets={groupStandardBudgets}
       setGroupStandardBudgets={setGroupStandardBudgets}
       groupTotalStandardBudget={groupTotalStandardBudget}
       editGroupStandardBudgetOperation={() => {
-        const signal = axios.CancelToken.source();
         dispatch(
           editGroupStandardBudgets(
             Number(group_id),
-            signal,
             groupStandardBudgets.map((groupBudget) => {
               const {
                 big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/containers/budgets/GroupStandardBudgetsContainer.tsx
+++ b/src/containers/budgets/GroupStandardBudgetsContainer.tsx
@@ -50,41 +50,42 @@ const GroupStandardBudgetsContainer = () => {
     setGroupStandardBudgetsList(groupStandardBudgets);
   }, [groupStandardBudgets]);
 
-  const totalBudget = () => {
-    let total = 0;
+  const disabledEditGroupStandardBudget = () => {
+    const totalStandardBudget = groupStandardBudgetsList.reduce(
+      (prevBudget, currentBudget) => prevBudget + Number(currentBudget.budget),
+      0
+    );
 
-    for (let i = 0; i < groupStandardBudgetsList.length; i++) {
-      total += Number(groupStandardBudgetsList[i].budget);
-    }
+    return totalStandardBudget === groupTotalStandardBudget;
+  };
 
-    return total === groupTotalStandardBudget;
+  const handleEditGroupStandardBudget = () => {
+    dispatch(
+      editGroupStandardBudgets(
+        Number(group_id),
+        groupStandardBudgetsList.map((groupBudget) => {
+          const {
+            big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+            last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+            ...rest
+          } = groupBudget;
+          return {
+            big_category_id: rest.big_category_id,
+            budget: Number(rest.budget),
+          };
+        })
+      )
+    );
   };
 
   return (
     <GroupStandardBudgets
       setEditing={setEditing}
-      unEditBudgets={totalBudget()}
+      unEditBudgets={disabledEditGroupStandardBudget()}
       groupStandardBudgets={groupStandardBudgetsList}
       setGroupStandardBudgets={setGroupStandardBudgetsList}
       groupTotalStandardBudget={groupTotalStandardBudget}
-      editGroupStandardBudgetOperation={() => {
-        dispatch(
-          editGroupStandardBudgets(
-            Number(group_id),
-            groupStandardBudgetsList.map((groupBudget) => {
-              const {
-                big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
-                last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
-                ...rest
-              } = groupBudget;
-              return {
-                big_category_id: rest.big_category_id,
-                budget: Number(rest.budget),
-              };
-            })
-          )
-        );
-      }}
+      editGroupStandardBudgetOperation={handleEditGroupStandardBudget}
     />
   );
 };

--- a/src/containers/budgets/GroupYearlyBudgetsRowContainer.tsx
+++ b/src/containers/budgets/GroupYearlyBudgetsRowContainer.tsx
@@ -19,16 +19,16 @@ const GroupYearlyBudgetsRowContainer = (props: GroupYearlyBudgetsRowContainerPro
   const dispatch = useDispatch();
   const history = useHistory();
   const { group_id } = useParams<{ group_id: string }>();
-  const groupYearlyBudgetsList = useSelector(getGroupYearlyBudgets);
-  const [groupYearlyBudgets, setGroupYearlyBudgets] = useState<GroupYearlyBudgetsList>({
+  const groupYearlyBudgets = useSelector(getGroupYearlyBudgets);
+  const [groupYearlyBudgetsList, setGroupYearlyBudgetsList] = useState<GroupYearlyBudgetsList>({
     year: '',
     yearly_total_budget: 0,
     monthly_budgets: [],
   });
 
   useEffect(() => {
-    setGroupYearlyBudgets(groupYearlyBudgetsList);
-  }, [groupYearlyBudgetsList]);
+    setGroupYearlyBudgetsList(groupYearlyBudgets);
+  }, [groupYearlyBudgets]);
 
   useEffect(() => {
     const signal = axios.CancelToken.source();
@@ -47,7 +47,7 @@ const GroupYearlyBudgetsRowContainer = (props: GroupYearlyBudgetsRowContainerPro
   return (
     <GroupYearlyBudgetsRow
       years={props.budgetsYear}
-      groupYearlyBudgets={groupYearlyBudgets}
+      groupYearlyBudgets={groupYearlyBudgetsList}
       deleteCustomBudgets={(selectYear, selectMonth) => {
         dispatch(deleteGroupCustomBudgets(selectYear, selectMonth, Number(group_id)));
       }}

--- a/src/containers/budgets/GroupYearlyBudgetsRowContainer.tsx
+++ b/src/containers/budgets/GroupYearlyBudgetsRowContainer.tsx
@@ -44,26 +44,34 @@ const GroupYearlyBudgetsRowContainer = (props: GroupYearlyBudgetsRowContainerPro
     };
   }, [props.budgetsYear]);
 
+  const deleteGroupCustomBudget = (selectYear: string, selectMonth: string) => {
+    dispatch(deleteGroupCustomBudgets(selectYear, selectMonth, Number(group_id)));
+  };
+
+  const routingEditBudgetsPage = (
+    routingAddress: string,
+    selectYear: string,
+    selectMonth: string
+  ) => {
+    if (routingAddress === 'custom') {
+      history.push({
+        pathname: `/group/${group_id}/budgets`,
+        search: `?edit_custom&year=${props.budgetsYear}&month=${selectMonth}`,
+      });
+    } else {
+      history.push({
+        pathname: `/group/${group_id}/budgets`,
+        search: `?add_custom&year=${props.budgetsYear}&month=${selectMonth}`,
+      });
+    }
+  };
+
   return (
     <GroupYearlyBudgetsRow
       years={props.budgetsYear}
       groupYearlyBudgets={groupYearlyBudgetsList}
-      deleteCustomBudgets={(selectYear, selectMonth) => {
-        dispatch(deleteGroupCustomBudgets(selectYear, selectMonth, Number(group_id)));
-      }}
-      routingEditBudgets={(routingAddress, selectYear, selectMonth) => {
-        if (routingAddress === 'custom') {
-          history.push({
-            pathname: `/group/${group_id}/budgets`,
-            search: `?edit_custom&year=${props.budgetsYear}&month=${selectMonth}`,
-          });
-        } else {
-          history.push({
-            pathname: `/group/${group_id}/budgets`,
-            search: `?add_custom&year=${props.budgetsYear}&month=${selectMonth}`,
-          });
-        }
-      }}
+      deleteCustomBudgets={deleteGroupCustomBudget}
+      routingEditBudgets={routingEditBudgetsPage}
     />
   );
 };

--- a/src/containers/budgets/GroupYearlyBudgetsRowContainer.tsx
+++ b/src/containers/budgets/GroupYearlyBudgetsRowContainer.tsx
@@ -49,8 +49,7 @@ const GroupYearlyBudgetsRowContainer = (props: GroupYearlyBudgetsRowContainerPro
       years={props.budgetsYear}
       groupYearlyBudgets={groupYearlyBudgets}
       deleteCustomBudgets={(selectYear, selectMonth) => {
-        const signal = axios.CancelToken.source();
-        dispatch(deleteGroupCustomBudgets(selectYear, selectMonth, Number(group_id), signal));
+        dispatch(deleteGroupCustomBudgets(selectYear, selectMonth, Number(group_id)));
       }}
       routingEditBudgets={(routingAddress, selectYear, selectMonth) => {
         if (routingAddress === 'custom') {

--- a/src/containers/budgets/StandardBudgetsContainer.tsx
+++ b/src/containers/budgets/StandardBudgetsContainer.tsx
@@ -12,7 +12,7 @@ const StandardBudgetsContainer = () => {
   const pathName = useLocation().pathname.split('/')[1];
   const standardBudgets = useSelector(getStandardBudgets);
   const totalStandardBudget = useSelector(getTotalStandardBudget);
-  const [budgets, setBudgets] = useState<StandardBudgetsList>([]);
+  const [standardBudgetsList, setStandardBudgetsList] = useState<StandardBudgetsList>([]);
 
   useEffect(() => {
     if (!standardBudgets.length && pathName !== 'group') {
@@ -24,14 +24,14 @@ const StandardBudgetsContainer = () => {
   }, []);
 
   useEffect(() => {
-    setBudgets(standardBudgets);
+    setStandardBudgetsList(standardBudgets);
   }, [standardBudgets]);
 
   const totalBudget = () => {
     let total = 0;
 
-    for (let i = 0; i < budgets.length; i++) {
-      total += Number(budgets[i].budget);
+    for (let i = 0; i < standardBudgetsList.length; i++) {
+      total += Number(standardBudgetsList[i].budget);
     }
 
     return total === totalStandardBudget;
@@ -39,15 +39,15 @@ const StandardBudgetsContainer = () => {
 
   return (
     <StandardBudgets
-      budgets={budgets}
-      setBudgets={setBudgets}
+      budgets={standardBudgetsList}
+      setBudgets={setStandardBudgetsList}
       pathName={pathName}
       unEditBudgets={totalBudget()}
       totalStandardBudget={totalStandardBudget}
       editStandardBudgetOperation={() => {
         dispatch(
           editStandardBudgets(
-            budgets.map((budget) => {
+            standardBudgetsList.map((budget) => {
               const {
                 big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
                 last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/containers/budgets/StandardBudgetsContainer.tsx
+++ b/src/containers/budgets/StandardBudgetsContainer.tsx
@@ -27,14 +27,31 @@ const StandardBudgetsContainer = () => {
     setStandardBudgetsList(standardBudgets);
   }, [standardBudgets]);
 
-  const totalBudget = () => {
-    let total = 0;
+  const disabledEditStandardBudget = () => {
+    const totalBudget = standardBudgetsList.reduce(
+      (prevBudget, currentBudget) => prevBudget + Number(currentBudget.budget),
+      0
+    );
 
-    for (let i = 0; i < standardBudgetsList.length; i++) {
-      total += Number(standardBudgetsList[i].budget);
-    }
+    return totalBudget === totalStandardBudget;
+  };
 
-    return total === totalStandardBudget;
+  const handleEditStandardBudget = () => {
+    dispatch(
+      editStandardBudgets(
+        standardBudgetsList.map((budget) => {
+          const {
+            big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
+            last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
+            ...rest
+          } = budget;
+          return {
+            big_category_id: rest.big_category_id,
+            budget: Number(rest.budget),
+          };
+        })
+      )
+    );
   };
 
   return (
@@ -42,25 +59,9 @@ const StandardBudgetsContainer = () => {
       budgets={standardBudgetsList}
       setBudgets={setStandardBudgetsList}
       pathName={pathName}
-      unEditBudgets={totalBudget()}
+      unEditBudgets={disabledEditStandardBudget()}
       totalStandardBudget={totalStandardBudget}
-      editStandardBudgetOperation={() => {
-        dispatch(
-          editStandardBudgets(
-            standardBudgetsList.map((budget) => {
-              const {
-                big_category_name: _big_category_name, // eslint-disable-line @typescript-eslint/no-unused-vars
-                last_month_expenses: _last_month_expenses, // eslint-disable-line @typescript-eslint/no-unused-vars
-                ...rest
-              } = budget;
-              return {
-                big_category_id: rest.big_category_id,
-                budget: Number(rest.budget),
-              };
-            })
-          )
-        );
-      }}
+      editStandardBudgetOperation={handleEditStandardBudget}
     />
   );
 };

--- a/src/containers/budgets/StandardBudgetsContainer.tsx
+++ b/src/containers/budgets/StandardBudgetsContainer.tsx
@@ -13,7 +13,6 @@ const StandardBudgetsContainer = () => {
   const standardBudgets = useSelector(getStandardBudgets);
   const totalStandardBudget = useSelector(getTotalStandardBudget);
   const [budgets, setBudgets] = useState<StandardBudgetsList>([]);
-  const unEditBudgets = budgets === standardBudgets;
 
   useEffect(() => {
     if (!standardBudgets.length && pathName !== 'group') {
@@ -28,15 +27,24 @@ const StandardBudgetsContainer = () => {
     setBudgets(standardBudgets);
   }, [standardBudgets]);
 
+  const totalBudget = () => {
+    let total = 0;
+
+    for (let i = 0; i < budgets.length; i++) {
+      total += Number(budgets[i].budget);
+    }
+
+    return total === totalStandardBudget;
+  };
+
   return (
     <StandardBudgets
       budgets={budgets}
       setBudgets={setBudgets}
       pathName={pathName}
-      unEditBudgets={unEditBudgets}
+      unEditBudgets={totalBudget()}
       totalStandardBudget={totalStandardBudget}
       editStandardBudgetOperation={() => {
-        const signal = axios.CancelToken.source();
         dispatch(
           editStandardBudgets(
             budgets.map((budget) => {
@@ -49,8 +57,7 @@ const StandardBudgetsContainer = () => {
                 big_category_id: rest.big_category_id,
                 budget: Number(rest.budget),
               };
-            }),
-            signal
+            })
           )
         );
       }}

--- a/src/containers/budgets/YearlyBudgetsRowContainer.tsx
+++ b/src/containers/budgets/YearlyBudgetsRowContainer.tsx
@@ -33,8 +33,7 @@ const YearlyBudgetsRowContainer = (props: YearlyBudgetsRowContainerProps) => {
   }, [props.budgetsYear]);
 
   const deleteCustom = (selectYear: string, selectMonth: string) => {
-    const signal = axios.CancelToken.source();
-    dispatch(deleteCustomBudgets(selectYear, selectMonth, signal));
+    dispatch(deleteCustomBudgets(selectYear, selectMonth));
   };
 
   return (

--- a/src/containers/budgets/YearlyBudgetsRowContainer.tsx
+++ b/src/containers/budgets/YearlyBudgetsRowContainer.tsx
@@ -32,28 +32,34 @@ const YearlyBudgetsRowContainer = (props: YearlyBudgetsRowContainerProps) => {
     return () => signal.cancel();
   }, [props.budgetsYear]);
 
-  const deleteCustom = (selectYear: string, selectMonth: string) => {
+  const deleteCustomBudget = (selectYear: string, selectMonth: string) => {
     dispatch(deleteCustomBudgets(selectYear, selectMonth));
+  };
+
+  const routingEditGroupCustomBudgetPage = (
+    routingAddress: string,
+    selectYear: string,
+    selectMonth: string
+  ) => {
+    if (routingAddress === 'custom') {
+      history.push({
+        pathname: '/budgets',
+        search: `?edit_custom&year=${props.budgetsYear}&month=${selectMonth}`,
+      });
+    } else {
+      history.push({
+        pathname: '/budgets',
+        search: `?add_custom&year=${props.budgetsYear}&month=${selectMonth}`,
+      });
+    }
   };
 
   return (
     <YearlyBudgetsRow
       budgetsYear={props.budgetsYear}
       yearBudget={yearBudgetsList}
-      deleteCustomBudgets={deleteCustom}
-      routingEditCustomBudgets={(routingAddress, selectYear, selectMonth) => {
-        if (routingAddress === 'custom') {
-          history.push({
-            pathname: '/budgets',
-            search: `?edit_custom&year=${props.budgetsYear}&month=${selectMonth}`,
-          });
-        } else {
-          history.push({
-            pathname: '/budgets',
-            search: `?add_custom&year=${props.budgetsYear}&month=${selectMonth}`,
-          });
-        }
-      }}
+      deleteCustomBudgets={deleteCustomBudget}
+      routingEditCustomBudgets={routingEditGroupCustomBudgetPage}
     />
   );
 };

--- a/src/containers/budgets/YearlyBudgetsRowContainer.tsx
+++ b/src/containers/budgets/YearlyBudgetsRowContainer.tsx
@@ -15,14 +15,14 @@ const YearlyBudgetsRowContainer = (props: YearlyBudgetsRowContainerProps) => {
   const dispatch = useDispatch();
   const history = useHistory();
   const yearlyBudgets = useSelector(getYearlyBudgets);
-  const [yearBudget, setYearBudget] = useState<YearlyBudgetsList>({
+  const [yearBudgetsList, setYearBudgetsList] = useState<YearlyBudgetsList>({
     year: '',
     yearly_total_budget: 0,
     monthly_budgets: [],
   });
 
   useEffect(() => {
-    setYearBudget(yearlyBudgets);
+    setYearBudgetsList(yearlyBudgets);
   }, [yearlyBudgets]);
 
   useEffect(() => {
@@ -39,7 +39,7 @@ const YearlyBudgetsRowContainer = (props: YearlyBudgetsRowContainerProps) => {
   return (
     <YearlyBudgetsRow
       budgetsYear={props.budgetsYear}
-      yearBudget={yearBudget}
+      yearBudget={yearBudgetsList}
       deleteCustomBudgets={deleteCustom}
       routingEditCustomBudgets={(routingAddress, selectYear, selectMonth) => {
         if (routingAddress === 'custom') {

--- a/src/containers/templates/budgets/BudgetsContainer.tsx
+++ b/src/containers/templates/budgets/BudgetsContainer.tsx
@@ -30,24 +30,28 @@ const BudgetsContainer = () => {
     };
   }, []);
 
+  const routingStandardBudgetPage = () => {
+    pathName !== 'group'
+      ? dispatch(push('/budgets?standard'))
+      : dispatch(push(`/group/${group_id}/budgets?standard`));
+  };
+
+  const routingYearlyBudgetPage = () => {
+    pathName !== 'group'
+      ? history.push({ pathname: '/budgets', search: `?yearly&year=${budgetsYear}` })
+      : history.push({
+          pathname: `/group/${group_id}/budgets`,
+          search: `?yearly&year=${budgetsYear}`,
+        });
+  };
+
   return (
     <Budgets
       query={query}
       budgetsYear={budgetsYear}
       setBudgetsYear={setBudgetsYear}
-      routingStandard={() =>
-        pathName !== 'group'
-          ? dispatch(push('/budgets?standard'))
-          : dispatch(push(`/group/${group_id}/budgets?standard`))
-      }
-      routingYearly={() => {
-        pathName !== 'group'
-          ? history.push({ pathname: '/budgets', search: `?yearly&year=${budgetsYear}` })
-          : history.push({
-              pathname: `/group/${group_id}/budgets`,
-              search: `?yearly&year=${budgetsYear}`,
-            });
-      }}
+      routingStandard={routingStandardBudgetPage}
+      routingYearly={routingYearlyBudgetPage}
     />
   );
 };

--- a/src/reducks/budgets/actions.ts
+++ b/src/reducks/budgets/actions.ts
@@ -20,7 +20,6 @@ export type budgetsActions = ReturnType<
   | typeof startDeleteCustomBudgetsActions
   | typeof deleteCustomBudgetsActions
   | typeof failedDeleteCustomBudgetsActions
-  | typeof copyStandardBudgetsActions
   | typeof startFetchYearlyBudgetsActions
   | typeof fetchYearlyBudgetsActions
   | typeof cancelFetchYearlyBudgetsActions
@@ -297,16 +296,6 @@ export const failedDeleteCustomBudgetsActions = (statusCode: number, errorMessag
         statusCode: statusCode,
         errorMessage: errorMessage,
       },
-    },
-  };
-};
-
-export const COPY_STANDARD_BUDGETS = 'COPY_STANDARD_BUDGETS';
-export const copyStandardBudgetsActions = (custom_budgets_list: CustomBudgetsList) => {
-  return {
-    type: COPY_STANDARD_BUDGETS,
-    payload: {
-      custom_budgets_list: custom_budgets_list,
     },
   };
 };

--- a/src/reducks/budgets/reducers.ts
+++ b/src/reducks/budgets/reducers.ts
@@ -104,11 +104,6 @@ export const budgetsReducer = (state = initialState.budgets, action: budgetsActi
         ...state,
         ...action.payload,
       };
-    case Actions.COPY_STANDARD_BUDGETS:
-      return {
-        ...state,
-        ...action.payload,
-      };
     case Actions.START_FETCH_YEARLY_BUDGETS:
       return {
         ...state,

--- a/src/reducks/budgets/selectors.ts
+++ b/src/reducks/budgets/selectors.ts
@@ -3,13 +3,13 @@ import { State } from '../store/types';
 import { CurrentMonthBudgetStatusList } from './types';
 import { displayWeeks } from '../../lib/date';
 import {
-  year,
-  month,
-  todayDate,
-  todayOfWeek,
-  thisMonthEndDate,
   currentWeekNumber,
   incomeTransactionType,
+  month,
+  thisMonthEndDate,
+  todayDate,
+  todayOfWeek,
+  year,
 } from '../../lib/constant';
 
 const budgetsSelector = (state: State) => state.budgets;
@@ -30,6 +30,22 @@ export const getYearlyTotalBudgets = (state: State) =>
 export const getCustomBudgets = createSelector(
   [budgetsSelector],
   (state) => state.custom_budgets_list
+);
+
+const customBudgetsList = (state: State) => state.budgets.custom_budgets_list;
+const standardBudgetsList = (state: State) => state.budgets.standard_budgets_list;
+
+export const getCopiedCustomBudgets = createSelector(
+  [customBudgetsList, standardBudgetsList],
+  (customBudgetsList, standardBudgetsList) => {
+    return standardBudgetsList.map((standardBudget) => {
+      customBudgetsList.map((customBudget) => {
+        return (customBudget.budget = standardBudget.budget);
+      });
+
+      return standardBudget;
+    });
+  }
 );
 
 const yearlyBudgets = (state: State) => state.budgets.yearly_budgets_list;
@@ -167,8 +183,6 @@ export const getAmountPerDay = createSelector(
   }
 );
 
-const standardBudgetsList = (state: State) => state.budgets.standard_budgets_list;
-
 export const getTotalStandardBudget = createSelector(
   [standardBudgetsList],
   (standardBudgetsList) => {
@@ -183,8 +197,6 @@ export const getTotalStandardBudget = createSelector(
     return totalBudget.totalStandardBudget;
   }
 );
-
-const customBudgetsList = (state: State) => state.budgets.custom_budgets_list;
 
 export const getTotalCustomBudget = createSelector([customBudgetsList], (customBudgetsList) => {
   const totalBudget = {

--- a/src/reducks/budgets/selectors.ts
+++ b/src/reducks/budgets/selectors.ts
@@ -35,7 +35,7 @@ export const getCustomBudgets = createSelector(
 const customBudgetsList = (state: State) => state.budgets.custom_budgets_list;
 const standardBudgetsList = (state: State) => state.budgets.standard_budgets_list;
 
-export const getCopiedCustomBudgets = createSelector(
+export const getInitialCustomBudgets = createSelector(
   [customBudgetsList, standardBudgetsList],
   (customBudgetsList, standardBudgetsList) => {
     return standardBudgetsList.map((standardBudget) => {

--- a/src/reducks/groupBudgets/actions.ts
+++ b/src/reducks/groupBudgets/actions.ts
@@ -8,7 +8,6 @@ export type groupBudgetsActions = ReturnType<
   | typeof startEditGroupStandardBudgetsActions
   | typeof editGroupStandardBudgetsActions
   | typeof failedEditGroupStandardBudgetsActions
-  | typeof copyGroupStandardBudgetsActions
   | typeof startFetchGroupCustomBudgetsActions
   | typeof fetchGroupCustomBudgetsActions
   | typeof cancelFetchGroupCustomBudgetsActions
@@ -265,16 +264,6 @@ export const failedEditGroupCustomBudgetsActions = (statusCode: number, errorMes
         statusCode: statusCode,
         errorMessage: errorMessage,
       },
-    },
-  };
-};
-
-export const COPY_GROUP_STANDARD_BUDGETS = 'COPY_GROUP_STANDARD_BUDGETS';
-export const copyGroupStandardBudgetsActions = (groupCustomBudgetsList: GroupCustomBudgetsList) => {
-  return {
-    type: COPY_GROUP_STANDARD_BUDGETS,
-    payload: {
-      groupCustomBudgetsList: groupCustomBudgetsList,
     },
   };
 };

--- a/src/reducks/groupBudgets/reducers.ts
+++ b/src/reducks/groupBudgets/reducers.ts
@@ -82,11 +82,6 @@ export const groupBudgetsReducer = (
         ...state,
         ...action.payload,
       };
-    case Actions.COPY_GROUP_STANDARD_BUDGETS:
-      return {
-        ...state,
-        ...action.payload,
-      };
     case Actions.START_ADD_GROUP_CUSTOM_BUDGETS:
       return {
         ...state,

--- a/src/reducks/groupBudgets/selectors.ts
+++ b/src/reducks/groupBudgets/selectors.ts
@@ -32,7 +32,7 @@ export const getGroupYearlyBudgets = createSelector(
 const groupStandardBudgetsList = (state: State) => state.groupBudgets.groupStandardBudgetsList;
 const groupCustomBudgetsList = (state: State) => state.groupBudgets.groupCustomBudgetsList;
 
-export const getCopiedCustomBudgets = createSelector(
+export const getInitialGroupCustomBudgets = createSelector(
   [groupStandardBudgetsList, groupCustomBudgetsList],
   (groupStandardBudgetsList, groupCustomBudgetsList) => {
     return groupStandardBudgetsList.map((groupStandardBudget) => {

--- a/src/reducks/groupBudgets/selectors.ts
+++ b/src/reducks/groupBudgets/selectors.ts
@@ -2,13 +2,13 @@ import { createSelector } from 'reselect';
 import { State } from '../store/types';
 import { CurrentMonthBudgetGroupStatusList } from './types';
 import {
-  todayDate,
-  thisMonthEndDate,
-  todayOfWeek,
+  currentWeekNumber,
   incomeTransactionType,
   month,
+  thisMonthEndDate,
+  todayDate,
+  todayOfWeek,
   year,
-  currentWeekNumber,
 } from '../../lib/constant';
 import { displayWeeks } from '../../lib/date';
 
@@ -27,6 +27,22 @@ export const getGroupCustomBudgets = createSelector(
 export const getGroupYearlyBudgets = createSelector(
   [groupBudgetsSelector],
   (state) => state.groupYearlyBudgetsList
+);
+
+const groupStandardBudgetsList = (state: State) => state.groupBudgets.groupStandardBudgetsList;
+const groupCustomBudgetsList = (state: State) => state.groupBudgets.groupCustomBudgetsList;
+
+export const getCopiedCustomBudgets = createSelector(
+  [groupStandardBudgetsList, groupCustomBudgetsList],
+  (groupStandardBudgetsList, groupCustomBudgetsList) => {
+    return groupStandardBudgetsList.map((groupStandardBudget) => {
+      groupCustomBudgetsList.map((groupCustomBudget) => {
+        return (groupCustomBudget.budget = groupStandardBudget.budget);
+      });
+
+      return groupStandardBudget;
+    });
+  }
 );
 
 export const getGroupYearlyTotalBudgets = (state: State) =>
@@ -169,8 +185,6 @@ export const getGroupAmountPerDay = createSelector(
   }
 );
 
-const groupStandardBudgetsList = (state: State) => state.groupBudgets.groupStandardBudgetsList;
-
 export const getGroupTotalStandardBudget = createSelector(
   [groupStandardBudgetsList],
   (groupStandardBudgetsList) => {
@@ -185,8 +199,6 @@ export const getGroupTotalStandardBudget = createSelector(
     return currentTotalBudget.standardTotalBudget;
   }
 );
-
-const groupCustomBudgetsList = (state: State) => state.groupBudgets.groupCustomBudgetsList;
 
 export const getTotalGroupCustomBudget = createSelector(
   [groupCustomBudgetsList],

--- a/test/budgets-test/Budgets.test.ts
+++ b/test/budgets-test/Budgets.test.ts
@@ -1,5 +1,6 @@
 import * as actionTypes from '../../src/reducks/budgets/actions';
 import axios from 'axios';
+import { accountServiceInstance } from '../../src/reducks/axiosConfig';
 import axiosMockAdapter from 'axios-mock-adapter';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -21,20 +22,27 @@ import editCustomBudget from './editCustomBudgetsResponse.json';
 import deleteCustomBudget from './deleteCustomBudgetsResponse.json';
 import addCustomBudgetsPayload from './addCustomBudgetsPayload.json';
 import editCustomBudgetsPayload from './editCustomBudgetsPayload.json';
-import { START_DELETE_CUSTOM_BUDGETS } from '../../src/reducks/budgets/actions';
-const axiosMock = new axiosMockAdapter(axios);
+
+const axiosMock = new axiosMockAdapter(accountServiceInstance);
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
+const store = mockStore({
+  budgets: {
+    standard_budgets_list: [],
+    custom_budgets_list: [],
+    yearly_budgets_list: {},
+  },
+});
+
 process.on('unhandledRejection', console.dir);
 
 describe('async actions Budgets', () => {
   beforeEach(() => {
     store.clearActions();
   });
-  const store = mockStore({ budgets: { standard_budgets_list: [] } });
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/standard-budgets`;
 
   it('Get standard_budgets if fetch succeeds', async () => {
+    const url = `/standard-budgets`;
     const signal = axios.CancelToken.source();
     const mockStandardBudgets = standardBudgets;
 
@@ -64,546 +72,499 @@ describe('async actions Budgets', () => {
     await fetchStandardBudgets(signal)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
-});
 
-it('Edit standard_budgets if fetch succeeds', async () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
+  it('Edit standard_budgets if fetch succeeds', async () => {
+    const editUrl = `/standard-budgets`;
+    const fetchUrl = `/standard-budgets`;
+    const nextStandardBudget = {
+      standard_budgets: [
+        {
+          big_category_id: 2,
+          budget: 25000,
+        },
+        {
+          big_category_id: 3,
+          budget: 5000,
+        },
+        {
+          big_category_id: 4,
+          budget: 4500,
+        },
+        {
+          big_category_id: 5,
+          budget: 1000,
+        },
+        {
+          big_category_id: 6,
+          budget: 1000,
+        },
+        {
+          big_category_id: 7,
+          budget: 0,
+        },
+        {
+          big_category_id: 8,
+          budget: 4900,
+        },
+        {
+          big_category_id: 9,
+          budget: 4400,
+        },
+        {
+          big_category_id: 10,
+          budget: 10000,
+        },
+        {
+          big_category_id: 11,
+          budget: 15000,
+        },
+        {
+          big_category_id: 12,
+          budget: 3000,
+        },
+        {
+          big_category_id: 13,
+          budget: 0,
+        },
+        {
+          big_category_id: 14,
+          budget: 9800,
+        },
+        {
+          big_category_id: 15,
+          budget: 0,
+        },
+        {
+          big_category_id: 16,
+          budget: 0,
+        },
+        {
+          big_category_id: 17,
+          budget: 0,
+        },
+      ],
+    };
+    const mockStandardBudgets = editBudgets;
 
-  const store = mockStore({ standardBudgets });
-  const signal = axios.CancelToken.source();
-  const editUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/standard-budgets`;
-  const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/standard-budgets`;
-  const nextStandardBudget = {
-    standard_budgets: [
+    const expectedActions = [
       {
-        big_category_id: 2,
-        budget: 25000,
-      },
-      {
-        big_category_id: 3,
-        budget: 5000,
-      },
-      {
-        big_category_id: 4,
-        budget: 4500,
-      },
-      {
-        big_category_id: 5,
-        budget: 1000,
-      },
-      {
-        big_category_id: 6,
-        budget: 1000,
-      },
-      {
-        big_category_id: 7,
-        budget: 0,
-      },
-      {
-        big_category_id: 8,
-        budget: 4900,
-      },
-      {
-        big_category_id: 9,
-        budget: 4400,
-      },
-      {
-        big_category_id: 10,
-        budget: 10000,
-      },
-      {
-        big_category_id: 11,
-        budget: 15000,
-      },
-      {
-        big_category_id: 12,
-        budget: 3000,
-      },
-      {
-        big_category_id: 13,
-        budget: 0,
-      },
-      {
-        big_category_id: 14,
-        budget: 9800,
-      },
-      {
-        big_category_id: 15,
-        budget: 0,
-      },
-      {
-        big_category_id: 16,
-        budget: 0,
-      },
-      {
-        big_category_id: 17,
-        budget: 0,
-      },
-    ],
-  };
-  const mockStandardBudgets = editBudgets;
+        type: actionTypes.START_EDIT_STANDARD_BUDGETS,
+        payload: {
+          standardBudgetsLoading: true,
 
-  const expectedActions = [
-    {
-      type: actionTypes.START_EDIT_STANDARD_BUDGETS,
-      payload: {
-        standardBudgetsLoading: true,
-
-        standardBudgetsError: {
-          statusCode: null,
-          errorMessage: '',
+          standardBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
-    },
-    {
-      type: actionTypes.EDIT_STANDARD_BUDGETS,
-      payload: {
-        standardBudgetsLoading: false,
-        standard_budgets_list: mockStandardBudgets.standard_budgets,
-      },
-    },
-  ];
-
-  axiosMock.onPut(editUrl).reply(200, mockStandardBudgets);
-  axiosMock.onGet(fetchUrl).reply(200, editBudgets);
-
-  await editStandardBudgets(nextStandardBudget.standard_budgets, signal)(store.dispatch);
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('Get yearly_budgets if fetch succeeds', async () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-
-  const date = new Date();
-  const year = date.getFullYear();
-  const signal = axios.CancelToken.source();
-  const store = mockStore({ budgets: { yearly_budgets_list: [] } });
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/${year}`;
-  const mockYearlyBudgets = yearlyBudgets;
-
-  const expectedActions = [
-    {
-      type: actionTypes.START_FETCH_YEARLY_BUDGETS,
-      payload: {
-        yearlyBudgetsLoading: true,
-
-        yearlyBudgetsError: {
-          statusCode: null,
-          errorMessage: '',
+      {
+        type: actionTypes.EDIT_STANDARD_BUDGETS,
+        payload: {
+          standardBudgetsLoading: false,
+          standard_budgets_list: mockStandardBudgets.standard_budgets,
         },
       },
-    },
-    {
-      type: actionTypes.FETCH_YEARLY_BUDGETS,
-      payload: {
-        yearlyBudgetsLoading: false,
-        yearly_budgets_list: mockYearlyBudgets,
-      },
-    },
-  ];
+    ];
 
-  axiosMock.onGet(url).reply(200, mockYearlyBudgets);
+    axiosMock.onPut(editUrl).reply(200, mockStandardBudgets);
+    axiosMock.onGet(fetchUrl).reply(200, editBudgets);
 
-  await fetchYearlyBudgets(year, signal)(store.dispatch);
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('Get custom_budgets if fetch succeeds', async () => {
-  beforeEach(() => {
-    store.clearActions();
+    await editStandardBudgets(nextStandardBudget.standard_budgets)(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
   });
 
-  const selectYear = '2020';
-  const selectMonth = '07';
-  const signal = axios.CancelToken.source();
-  const store = mockStore({ budgets: { custom_budgets_list: [] } });
-  const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`;
-  const mockCustomBudgets = customBudgets;
+  it('Get yearly_budgets if fetch succeeds', async () => {
+    const year = 2020;
+    const signal = axios.CancelToken.source();
+    const url = `/budgets/${year}`;
+    const mockYearlyBudgets = yearlyBudgets;
 
-  const expectedActions = [
-    {
-      type: actionTypes.START_FETCH_CUSTOM_BUDGETS,
-      payload: {
-        customBudgetsLoading: true,
+    const expectedActions = [
+      {
+        type: actionTypes.START_FETCH_YEARLY_BUDGETS,
+        payload: {
+          yearlyBudgetsLoading: true,
 
-        customBudgetsError: {
-          statusCode: null,
-          errorMessage: '',
+          yearlyBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
-    },
-    {
-      type: actionTypes.FETCH_CUSTOM_BUDGETS,
-      payload: {
-        customBudgetsLoading: false,
-        custom_budgets_list: mockCustomBudgets.custom_budgets,
-      },
-    },
-  ];
-
-  axiosMock.onGet(url).reply(200, mockCustomBudgets);
-
-  await fetchCustomBudgets(selectYear, selectMonth, signal)(store.dispatch);
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('Add custom_budgets if fetch succeeds', async () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-
-  const selectYear = '2020';
-  const selectMonth = '06';
-  const signal = axios.CancelToken.source();
-  const store = mockStore({
-    budgets: {
-      yearly_budgets_list: yearlyBudgets,
-      standard_budgets_list: editBudgets.standard_budgets,
-    },
-  });
-  const addUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`;
-  const fetchCustomUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`;
-  const fetchYearlyUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/${selectYear}`;
-
-  const nextCustomBudgets = {
-    custom_budgets: [
       {
-        big_category_id: 2,
-        budget: 25000,
-      },
-      {
-        big_category_id: 3,
-        budget: 5000,
-      },
-      {
-        big_category_id: 4,
-        budget: 4500,
-      },
-      {
-        big_category_id: 5,
-        budget: 1000,
-      },
-      {
-        big_category_id: 6,
-        budget: 1000,
-      },
-      {
-        big_category_id: 7,
-        budget: 2000,
-      },
-      {
-        big_category_id: 8,
-        budget: 4900,
-      },
-      {
-        big_category_id: 9,
-        budget: 4400,
-      },
-      {
-        big_category_id: 10,
-        budget: 10000,
-      },
-      {
-        big_category_id: 11,
-        budget: 15000,
-      },
-      {
-        big_category_id: 12,
-        budget: 3000,
-      },
-      {
-        big_category_id: 13,
-        budget: 0,
-      },
-      {
-        big_category_id: 14,
-        budget: 9800,
-      },
-      {
-        big_category_id: 15,
-        budget: 0,
-      },
-      {
-        big_category_id: 16,
-        budget: 0,
-      },
-      {
-        big_category_id: 17,
-        budget: 0,
-      },
-    ],
-  };
-
-  const expectedActions = [
-    {
-      type: actionTypes.START_ADD_CUSTOM_BUDGETS,
-      payload: {
-        customBudgetsLoading: true,
-        yearlyBudgetsLoading: true,
-
-        customBudgetsError: {
-          statusCode: null,
-          errorMessage: '',
+        type: actionTypes.FETCH_YEARLY_BUDGETS,
+        payload: {
+          yearlyBudgetsLoading: false,
+          yearly_budgets_list: mockYearlyBudgets,
         },
       },
-    },
-    {
-      type: actionTypes.ADD_CUSTOM_BUDGETS,
-      payload: {
-        customBudgetsLoading: false,
-        custom_budgets_list: addCustomBudget.custom_budgets,
-        yearlyBudgetsLoading: false,
-        yearly_budgets_list: addCustomBudgetsPayload,
-      },
-    },
-  ];
+    ];
 
-  axiosMock.onPost(addUrl).reply(201, addCustomBudget);
-  axiosMock.onGet(fetchCustomUrl).reply(200, addCustomBudget);
-  axiosMock.onGet(fetchYearlyUrl).reply(200, addCustomBudgetsPayload);
+    axiosMock.onGet(url).reply(200, mockYearlyBudgets);
 
-  await addCustomBudgets(
-    selectYear,
-    selectMonth,
-    signal,
-    nextCustomBudgets.custom_budgets
-  )(store.dispatch);
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('Edit custom_budgets if fetch succeeds', async () => {
-  beforeEach(() => {
-    store.clearActions();
+    await fetchYearlyBudgets(year, signal)(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
   });
 
-  const selectYear = '2020';
-  const selectMonth = '06';
-  const signal = axios.CancelToken.source();
-  const store = mockStore({
-    budgets: {
-      yearly_budgets_list: addCustomBudgetsPayload,
-    },
-  });
-  const editUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`;
-  const fetchCustomUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`;
-  const fetchYearlyUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/${selectYear}`;
+  it('Get custom_budgets if fetch succeeds', async () => {
+    const selectYear = '2020';
+    const selectMonth = '07';
+    const signal = axios.CancelToken.source();
+    const url = `/custom-budgets/${selectYear}-${selectMonth}`;
+    const mockCustomBudgets = customBudgets;
 
-  const nextCustomBudgets = {
-    custom_budgets: [
+    const expectedActions = [
       {
-        big_category_id: 2,
-        budget: 38000,
-      },
-      {
-        big_category_id: 3,
-        budget: 4000,
-      },
-      {
-        big_category_id: 4,
-        budget: 7500,
-      },
-      {
-        big_category_id: 5,
-        budget: 1000,
-      },
-      {
-        big_category_id: 6,
-        budget: 1000,
-      },
-      {
-        big_category_id: 7,
-        budget: 0,
-      },
-      {
-        big_category_id: 8,
-        budget: 4900,
-      },
-      {
-        big_category_id: 9,
-        budget: 4400,
-      },
-      {
-        big_category_id: 10,
-        budget: 10000,
-      },
-      {
-        big_category_id: 11,
-        budget: 15000,
-      },
-      {
-        big_category_id: 12,
-        budget: 3000,
-      },
-      {
-        big_category_id: 13,
-        budget: 0,
-      },
-      {
-        big_category_id: 14,
-        budget: 3800,
-      },
-      {
-        big_category_id: 15,
-        budget: 0,
-      },
-      {
-        big_category_id: 16,
-        budget: 0,
-      },
-      {
-        big_category_id: 17,
-        budget: 0,
-      },
-    ],
-  };
+        type: actionTypes.START_FETCH_CUSTOM_BUDGETS,
+        payload: {
+          customBudgetsLoading: true,
 
-  const expectedActions = [
-    {
-      type: actionTypes.START_EDIT_CUSTOM_BUDGETS,
-      payload: {
-        customBudgetsLoading: true,
-        yearlyBudgetsLoading: true,
-
-        customBudgetsError: {
-          statusCode: null,
-          errorMessage: '',
+          customBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
         },
       },
-    },
-    {
-      type: actionTypes.EDIT_CUSTOM_BUDGETS,
-      payload: {
-        customBudgetsLoading: false,
-        custom_budgets_list: editCustomBudget.custom_budgets,
-        yearlyBudgetsLoading: false,
-        yearly_budgets_list: editCustomBudgetsPayload,
-      },
-    },
-  ];
-
-  axiosMock.onPut(editUrl).reply(200, editCustomBudget);
-  axiosMock.onGet(fetchCustomUrl).reply(200, editCustomBudget);
-  axiosMock.onGet(fetchYearlyUrl).reply(200, editCustomBudgetsPayload);
-
-  await editCustomBudgets(
-    selectYear,
-    selectMonth,
-    signal,
-    nextCustomBudgets.custom_budgets
-  )(store.dispatch);
-  expect(store.getActions()).toEqual(expectedActions);
-});
-
-it('Delete custom_budgets if fetch succeeds', async () => {
-  beforeEach(() => {
-    store.clearActions();
-  });
-
-  const selectYear = '2020';
-  const selectMonth = '07';
-  const signal = axios.CancelToken.source();
-  const store = mockStore({ budgets: { yearly_budgets_list: editCustomBudgetsPayload } });
-  const deleteUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/custom-budgets/${selectYear}-${selectMonth}`;
-  const fetchYearlyUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/budgets/${selectYear}`;
-
-  const mockResponse = deleteCustomBudget.message;
-
-  const deletedCustomBudgets = {
-    year: '2020-01-01T00:00:00Z',
-    yearly_total_budget: 1028600,
-    monthly_budgets: [
       {
-        month: '2020年01月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-      {
-        month: '2020年02月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-      {
-        month: '2020年03月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-      {
-        month: '2020年04月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-      {
-        month: '2020年05月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-      {
-        month: '2020年06月',
-        budget_type: 'CustomBudget',
-        monthly_total_budget: 92600,
-      },
-      {
-        month: '2020年07月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-      {
-        month: '2020年08月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-      {
-        month: '2020年09月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-      {
-        month: '2020年10月',
-        budget_type: 'CustomBudget',
-        monthly_total_budget: 100000,
-      },
-      {
-        month: '2020年11月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-      {
-        month: '2020年12月',
-        budget_type: 'StandardBudget',
-        monthly_total_budget: 83600,
-      },
-    ],
-  };
-
-  const expectedActions = [
-    {
-      type: START_DELETE_CUSTOM_BUDGETS,
-      payload: {
-        yearlyBudgetsLoading: true,
-
-        yearlyBudgetsError: {
-          statusCode: null,
-          errorMessage: '',
+        type: actionTypes.FETCH_CUSTOM_BUDGETS,
+        payload: {
+          customBudgetsLoading: false,
+          custom_budgets_list: mockCustomBudgets.custom_budgets,
         },
       },
-    },
-    {
-      type: actionTypes.DELETE_CUSTOM_BUDGETS,
-      payload: {
-        yearlyBudgetsLoading: false,
-        yearly_budgets_list: deletedCustomBudgets,
+    ];
+
+    axiosMock.onGet(url).reply(200, mockCustomBudgets);
+
+    await fetchCustomBudgets(selectYear, selectMonth, signal)(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('Add custom_budgets if fetch succeeds', async () => {
+    const selectYear = '2020';
+    const selectMonth = '06';
+    const addUrl = `/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchCustomUrl = `/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchYearlyUrl = `/budgets/${selectYear}`;
+
+    const nextCustomBudgets = {
+      custom_budgets: [
+        {
+          big_category_id: 2,
+          budget: 25000,
+        },
+        {
+          big_category_id: 3,
+          budget: 5000,
+        },
+        {
+          big_category_id: 4,
+          budget: 4500,
+        },
+        {
+          big_category_id: 5,
+          budget: 1000,
+        },
+        {
+          big_category_id: 6,
+          budget: 1000,
+        },
+        {
+          big_category_id: 7,
+          budget: 2000,
+        },
+        {
+          big_category_id: 8,
+          budget: 4900,
+        },
+        {
+          big_category_id: 9,
+          budget: 4400,
+        },
+        {
+          big_category_id: 10,
+          budget: 10000,
+        },
+        {
+          big_category_id: 11,
+          budget: 15000,
+        },
+        {
+          big_category_id: 12,
+          budget: 3000,
+        },
+        {
+          big_category_id: 13,
+          budget: 0,
+        },
+        {
+          big_category_id: 14,
+          budget: 9800,
+        },
+        {
+          big_category_id: 15,
+          budget: 0,
+        },
+        {
+          big_category_id: 16,
+          budget: 0,
+        },
+        {
+          big_category_id: 17,
+          budget: 0,
+        },
+      ],
+    };
+
+    const expectedActions = [
+      {
+        type: actionTypes.START_ADD_CUSTOM_BUDGETS,
+        payload: {
+          customBudgetsLoading: true,
+          yearlyBudgetsLoading: true,
+
+          customBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+        },
       },
-    },
-  ];
+      {
+        type: actionTypes.ADD_CUSTOM_BUDGETS,
+        payload: {
+          customBudgetsLoading: false,
+          custom_budgets_list: addCustomBudget.custom_budgets,
+          yearlyBudgetsLoading: false,
+          yearly_budgets_list: addCustomBudgetsPayload,
+        },
+      },
+    ];
 
-  axiosMock.onDelete(deleteUrl).reply(200, mockResponse);
-  axiosMock.onGet(fetchYearlyUrl).reply(200, deletedCustomBudgets);
+    axiosMock.onPost(addUrl).reply(201, addCustomBudget);
+    axiosMock.onGet(fetchCustomUrl).reply(200, addCustomBudget);
+    axiosMock.onGet(fetchYearlyUrl).reply(200, addCustomBudgetsPayload);
 
-  // @ts-ignore
-  await deleteCustomBudgets(selectYear, selectMonth, signal)(store.dispatch);
-  expect(store.getActions()).toEqual(expectedActions);
+    await addCustomBudgets(
+      selectYear,
+      selectMonth,
+      nextCustomBudgets.custom_budgets
+    )(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('Edit custom_budgets if fetch succeeds', async () => {
+    const selectYear = '2020';
+    const selectMonth = '06';
+    const editUrl = `/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchCustomUrl = `/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchYearlyUrl = `/budgets/${selectYear}`;
+
+    const nextCustomBudgets = {
+      custom_budgets: [
+        {
+          big_category_id: 2,
+          budget: 38000,
+        },
+        {
+          big_category_id: 3,
+          budget: 4000,
+        },
+        {
+          big_category_id: 4,
+          budget: 7500,
+        },
+        {
+          big_category_id: 5,
+          budget: 1000,
+        },
+        {
+          big_category_id: 6,
+          budget: 1000,
+        },
+        {
+          big_category_id: 7,
+          budget: 0,
+        },
+        {
+          big_category_id: 8,
+          budget: 4900,
+        },
+        {
+          big_category_id: 9,
+          budget: 4400,
+        },
+        {
+          big_category_id: 10,
+          budget: 10000,
+        },
+        {
+          big_category_id: 11,
+          budget: 15000,
+        },
+        {
+          big_category_id: 12,
+          budget: 3000,
+        },
+        {
+          big_category_id: 13,
+          budget: 0,
+        },
+        {
+          big_category_id: 14,
+          budget: 3800,
+        },
+        {
+          big_category_id: 15,
+          budget: 0,
+        },
+        {
+          big_category_id: 16,
+          budget: 0,
+        },
+        {
+          big_category_id: 17,
+          budget: 0,
+        },
+      ],
+    };
+
+    const expectedActions = [
+      {
+        type: actionTypes.START_EDIT_CUSTOM_BUDGETS,
+        payload: {
+          customBudgetsLoading: true,
+          yearlyBudgetsLoading: true,
+
+          customBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+        },
+      },
+      {
+        type: actionTypes.EDIT_CUSTOM_BUDGETS,
+        payload: {
+          customBudgetsLoading: false,
+          custom_budgets_list: editCustomBudget.custom_budgets,
+          yearlyBudgetsLoading: false,
+          yearly_budgets_list: editCustomBudgetsPayload,
+        },
+      },
+    ];
+
+    axiosMock.onPut(editUrl).reply(200, editCustomBudget);
+    axiosMock.onGet(fetchCustomUrl).reply(200, editCustomBudget);
+    axiosMock.onGet(fetchYearlyUrl).reply(200, editCustomBudgetsPayload);
+
+    await editCustomBudgets(
+      selectYear,
+      selectMonth,
+      nextCustomBudgets.custom_budgets
+    )(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it('Delete custom_budgets if fetch succeeds', async () => {
+    const selectYear = '2020';
+    const selectMonth = '07';
+    const deleteUrl = `/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchYearlyUrl = `/budgets/${selectYear}`;
+
+    const mockResponse = deleteCustomBudget.message;
+
+    const deletedCustomBudgets = {
+      year: '2020-01-01T00:00:00Z',
+      yearly_total_budget: 1028600,
+      monthly_budgets: [
+        {
+          month: '2020年01月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+        {
+          month: '2020年02月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+        {
+          month: '2020年03月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+        {
+          month: '2020年04月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+        {
+          month: '2020年05月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+        {
+          month: '2020年06月',
+          budget_type: 'CustomBudget',
+          monthly_total_budget: 92600,
+        },
+        {
+          month: '2020年07月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+        {
+          month: '2020年08月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+        {
+          month: '2020年09月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+        {
+          month: '2020年10月',
+          budget_type: 'CustomBudget',
+          monthly_total_budget: 100000,
+        },
+        {
+          month: '2020年11月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+        {
+          month: '2020年12月',
+          budget_type: 'StandardBudget',
+          monthly_total_budget: 83600,
+        },
+      ],
+    };
+
+    const expectedActions = [
+      {
+        type: actionTypes.START_DELETE_CUSTOM_BUDGETS,
+        payload: {
+          yearlyBudgetsLoading: true,
+
+          yearlyBudgetsError: {
+            statusCode: null,
+            errorMessage: '',
+          },
+        },
+      },
+      {
+        type: actionTypes.DELETE_CUSTOM_BUDGETS,
+        payload: {
+          yearlyBudgetsLoading: false,
+          yearly_budgets_list: deletedCustomBudgets,
+        },
+      },
+    ];
+
+    axiosMock.onDelete(deleteUrl).reply(200, mockResponse);
+    axiosMock.onGet(fetchYearlyUrl).reply(200, deletedCustomBudgets);
+
+    await deleteCustomBudgets(selectYear, selectMonth)(store.dispatch);
+    expect(store.getActions()).toEqual(expectedActions);
+  });
 });

--- a/test/group-budgets-test/GroupBudgets.test.ts
+++ b/test/group-budgets-test/GroupBudgets.test.ts
@@ -1,5 +1,6 @@
 import * as actionTypes from '../../src/reducks/groupBudgets/actions';
 import axios from 'axios';
+import { accountServiceInstance } from '../../src/reducks/axiosConfig';
 import axiosMockAdapter from 'axios-mock-adapter';
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
@@ -22,21 +23,27 @@ import editGroupCustomBudgetPayload from './editGroupCustomBudgetsPayload.json';
 import groupEditedCustomBudgets from './editGroupCustomBudgetsResponse.json';
 import groupDeletedCustomBudgets from './deleteGroupCustomBudgetsResponse.json';
 
-const axiosMock = new axiosMockAdapter(axios);
+const axiosMock = new axiosMockAdapter(accountServiceInstance);
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
+const store = mockStore({
+  groupBudgets: {
+    groupStandardBudgetsList: [],
+    groupCustomBudgetsList: [],
+    groupYearlyBudgetsList: {},
+  },
+});
 process.on('unhandledRejection', console.dir);
 
 describe('async actions groupBudgets', () => {
-  it('Get groupStandardBudgetsList if fetch succeeds', async () => {
-    beforeEach(() => {
-      store.clearActions();
-    });
+  beforeEach(() => {
+    store.clearActions();
+  });
 
-    const store = mockStore({ groupBudgets: { groupStandardBudgetsList: [] } });
+  it('Get groupStandardBudgetsList if fetch succeeds', async () => {
     const groupId = 1;
     const signal = axios.CancelToken.source();
-    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`;
+    const url = `/groups/${groupId}/standard-budgets`;
     const fetchedGroupStandardBudgetsList = groupStandardBudgets;
 
     const expectedActions = [
@@ -67,15 +74,9 @@ describe('async actions groupBudgets', () => {
   });
 
   it('Edit groupStandard_budgets if fetch succeeds', async () => {
-    beforeEach(() => {
-      store.clearActions();
-    });
-    const store = mockStore({ groupStandardBudgets });
-
     const groupId = 1;
-    const signal = axios.CancelToken.source();
-    const editUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`;
-    const fetchUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/standard-budgets`;
+    const editUrl = `/groups/${groupId}/standard-budgets`;
+    const fetchUrl = `/groups/${groupId}/standard-budgets`;
 
     const mockRequest = {
       standard_budgets: [
@@ -171,22 +172,16 @@ describe('async actions groupBudgets', () => {
     axiosMock.onPut(editUrl, mockRequest).reply(200, editedGroupStandardBudgetsList);
     axiosMock.onGet(fetchUrl).reply(200, editedGroupStandardBudgetsList);
 
-    await editGroupStandardBudgets(groupId, signal, mockRequest.standard_budgets)(store.dispatch);
+    await editGroupStandardBudgets(groupId, mockRequest.standard_budgets)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 
   it('Get groupYearlyBudgets if fetch succeeds', async () => {
-    beforeEach(() => {
-      store.clearActions();
-    });
-    const store = mockStore({ groupBudgets: { groupYearlyBudgetsList: [] } });
-
     const date = new Date();
     const year = date.getFullYear();
-
     const groupId = 1;
     const signal = axios.CancelToken.source();
-    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${year}`;
+    const url = `/groups/${groupId}/budgets/${year}`;
 
     const fetchedGroupYearlyBudgetsList = groupYearlyBudgets;
 
@@ -218,17 +213,11 @@ describe('async actions groupBudgets', () => {
   });
 
   it('Get groupCustomBudgets if fetch succeeds', async () => {
-    beforeEach(() => {
-      store.clearActions();
-    });
-
     const selectYear = '2020';
     const selectMonth = '01';
-    const store = mockStore({ groupBudgets: { groupCustomBudgetsList: [] } });
-
     const groupId = 1;
     const signal = axios.CancelToken.source();
-    const url = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const url = `/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
 
     const fetchedGroupCustomBudgesList = groupCustomBudgets;
 
@@ -260,18 +249,12 @@ describe('async actions groupBudgets', () => {
   });
 
   it('Add groupCustomBudgets if fetch succeeds', async () => {
-    beforeEach(() => {
-      store.clearActions();
-    });
-
     const groupId = 1;
     const selectYear = '2020';
     const selectMonth = '02';
-    const signal = axios.CancelToken.source();
-    const store = mockStore({ groupBudgets: { groupYearlyBudgetsList: groupYearlyBudgets } });
-    const addUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
-    const fetchCustomUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
-    const fetchYearlyUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${selectYear}`;
+    const addUrl = `/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchCustomUrl = `/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchYearlyUrl = `/groups/${groupId}/budgets/${selectYear}`;
 
     const addedGroupCustomBudgetsList = groupAddedCustomBudgets;
 
@@ -376,28 +359,18 @@ describe('async actions groupBudgets', () => {
       selectYear,
       selectMonth,
       groupId,
-      signal,
       mockRequest.custom_budgets
     )(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 
   it('Edit groupCustomBudgets  if fetch succeeds', async () => {
-    beforeEach(() => {
-      store.clearActions();
-    });
-
     const selectYear = '2020';
     const selectMonth = '02';
-    const signal = axios.CancelToken.source();
-    const store = mockStore({
-      groupBudgets: { groupYearlyBudgetsList: addGroupCustomBudgetPayload },
-    });
-
     const groupId = 1;
-    const editUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
-    const fetchCustomUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
-    const fetchYearlyUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${selectYear}`;
+    const editUrl = `/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchCustomUrl = `/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchYearlyUrl = `/groups/${groupId}/budgets/${selectYear}`;
 
     const mockRequest = {
       custom_budgets: [
@@ -502,30 +475,17 @@ describe('async actions groupBudgets', () => {
       selectYear,
       selectMonth,
       groupId,
-      signal,
       mockRequest.custom_budgets
     )(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 
   it('Delete groupCustomBudgets if fetch succeeds', async () => {
-    beforeEach(() => {
-      store.clearActions();
-    });
-
-    const store = mockStore({
-      groupBudgets: {
-        groupYearlyBudgetsList: groupYearlyBudgets,
-        groupStandardBudgetsList: groupEditedStandardBudgets.standard_budgets,
-      },
-    });
-
     const selectYear = '2020';
     const selectMonth = '02';
     const groupId = 1;
-    const signal = axios.CancelToken.source();
-    const deleteUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
-    const fetchYearlyUrl = `${process.env.REACT_APP_ACCOUNT_API_HOST}/groups/${groupId}/budgets/${selectYear}`;
+    const deleteUrl = `/groups/${groupId}/custom-budgets/${selectYear}-${selectMonth}`;
+    const fetchYearlyUrl = `/groups/${groupId}/budgets/${selectYear}`;
 
     const deletedGroupCustomBudgetsMessage = groupDeletedCustomBudgets.message;
 
@@ -620,7 +580,7 @@ describe('async actions groupBudgets', () => {
     axiosMock.onDelete(deleteUrl).reply(200, deletedGroupCustomBudgetsMessage);
     axiosMock.onGet(fetchYearlyUrl).reply(200, deletedYearlyBudgetsList);
 
-    await deleteGroupCustomBudgets(selectYear, selectMonth, groupId, signal)(store.dispatch);
+    await deleteGroupCustomBudgets(selectYear, selectMonth, groupId)(store.dispatch);
     expect(store.getActions()).toEqual(expectedActions);
   });
 });


### PR DESCRIPTION
- standardBudgetsをcustomBudgetsに代入する処理を行なっていた`copyStandardBudgets, groupCopyStandardBudgets`
  を削除し代入の処理を`selectors`で行う形に修正しました。

- 予算の更新, 追加のボタンのdisabledの条件をstateで管理しているbudgetの合計値とselectorで取得した合計値を比較する
  形に修正しました。

  