### PR TITLE
Don't use executeAfterAsyncProcess function in task and delete execut…

### DIFF
--- a/src/components/task/modules/area/taskToolBarArea/EditTaskUserModal/EditTaskUserModal.tsx
+++ b/src/components/task/modules/area/taskToolBarArea/EditTaskUserModal/EditTaskUserModal.tsx
@@ -26,64 +26,6 @@ interface EditTaskUserModalProps {
 }
 
 const EditTaskUserModal = (props: EditTaskUserModalProps) => {
-  const switchTaskUserForm = () => {
-    if (props.openEditUserForm && !props.openAddUserForm) {
-      return (
-        <>
-          <div className={styles.position}>
-            <h3>タスクユーザーリスト</h3>
-            <button onClick={props.handleCloseModal}>
-              <CloseIcon />
-            </button>
-          </div>
-          <div className={styles.content}>
-            {!props.groupTasksListForEachUser.length ? (
-              <p className={styles.message}>現在、タスクに参加しているメンバーはいません。</p>
-            ) : (
-              <ul className={styles.userList}>
-                {props.participatingTaskUsers.map((user) => {
-                  return (
-                    <li className={styles.userListItem} key={user.user_id}>
-                      {user.user_name}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            <button className={styles.selectBtn} onClick={props.handleOpenAddTaskUserForm}>
-              <span>タスクユーザーを追加</span>
-              <ChevronRightIcon />
-            </button>
-            <button className={styles.selectBtn} onClick={props.handleOpenDeleteTaskUserForm}>
-              <span>タスクユーザーを削除</span>
-              <ChevronRightIcon />
-            </button>
-          </div>
-        </>
-      );
-    } else if (!props.openEditUserForm && props.openAddUserForm) {
-      return (
-        <AddTaskUserFormContainer
-          approvedGroup={props.approvedGroup}
-          handleCloseAddTaskUserForm={props.handleCloseAddTaskUserForm}
-          handleCloseModal={props.handleCloseModal}
-          groupTasksListForEachUser={props.groupTasksListForEachUser}
-          btnClassName={styles.childAddBtn}
-        />
-      );
-    } else if (!props.openEditUserForm && props.openDeleteUserForm) {
-      return (
-        <DeleteTaskUserFormContainer
-          approvedGroup={props.approvedGroup}
-          handleCloseDeleteTaskUserForm={props.handleCloseDeleteTaskUserForm}
-          handleCloseModal={props.handleCloseModal}
-          groupTasksListForEachUser={props.groupTasksListForEachUser}
-          btnClassName={styles.childDeleteBtn}
-        />
-      );
-    }
-  };
-
   return (
     <>
       <button className={styles.btn} disabled={false} onClick={props.handleOpenModal}>
@@ -95,7 +37,59 @@ const EditTaskUserModal = (props: EditTaskUserModalProps) => {
         aria-labelledby="simple-modal-title"
         aria-describedby="simple-modal-description"
       >
-        <div className={styles.modalWrapper}>{switchTaskUserForm()}</div>
+        <div className={styles.modalWrapper}>
+          {props.openEditUserForm && (
+            <>
+              <div className={styles.position}>
+                <h3>タスクユーザーリスト</h3>
+                <button onClick={props.handleCloseModal}>
+                  <CloseIcon />
+                </button>
+              </div>
+              <div className={styles.content}>
+                {!props.groupTasksListForEachUser.length ? (
+                  <p className={styles.message}>現在、タスクに参加しているメンバーはいません。</p>
+                ) : (
+                  <ul className={styles.userList}>
+                    {props.participatingTaskUsers.map((user) => {
+                      return (
+                        <li className={styles.userListItem} key={user.user_id}>
+                          {user.user_name}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+                <button className={styles.selectBtn} onClick={props.handleOpenAddTaskUserForm}>
+                  <span>タスクユーザーを追加</span>
+                  <ChevronRightIcon />
+                </button>
+                <button className={styles.selectBtn} onClick={props.handleOpenDeleteTaskUserForm}>
+                  <span>タスクユーザーを削除</span>
+                  <ChevronRightIcon />
+                </button>
+              </div>
+            </>
+          )}
+          {!props.openEditUserForm && props.openAddUserForm && (
+            <AddTaskUserFormContainer
+              approvedGroup={props.approvedGroup}
+              handleCloseAddTaskUserForm={props.handleCloseAddTaskUserForm}
+              handleCloseModal={props.handleCloseModal}
+              groupTasksListForEachUser={props.groupTasksListForEachUser}
+              btnClassName={styles.childAddBtn}
+            />
+          )}
+          {!props.openEditUserForm && props.openDeleteUserForm && (
+            <DeleteTaskUserFormContainer
+              approvedGroup={props.approvedGroup}
+              handleCloseDeleteTaskUserForm={props.handleCloseDeleteTaskUserForm}
+              handleCloseModal={props.handleCloseModal}
+              groupTasksListForEachUser={props.groupTasksListForEachUser}
+              btnClassName={styles.childDeleteBtn}
+            />
+          )}
+        </div>
       </Modal>
     </>
   );

--- a/src/containers/task/modules/form/AddTaskNameFormContainer.tsx
+++ b/src/containers/task/modules/form/AddTaskNameFormContainer.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'react-router';
 import AddTaskNameForm from '../../../../components/task/modules/area/taskListArea/addTaskNameForm/AddTaskNameForm';
 import { addTaskItem } from '../../../../reducks/groupTasks/operations';
 import { AddTaskItemReq } from '../../../../reducks/groupTasks/types';
-import { executeAfterAsyncProcess } from '../../../../lib/function';
 
 const initialState = {
   initialTodoContent: '',
@@ -39,14 +38,18 @@ const AddTaskNameFormContainer = () => {
 
   const disabledButton = taskName === initialState.initialTodoContent;
 
-  const handleAddTaskItem = () => {
+  const handleAddTaskItem = async () => {
     const requestData: AddTaskItemReq = {
       task_name: taskName,
     };
 
-    return executeAfterAsyncProcess(dispatch(addTaskItem(Number(group_id), requestData)), () =>
-      setOpenForm(false)
-    );
+    try {
+      await dispatch(addTaskItem(Number(group_id), requestData));
+
+      setOpenForm(false);
+    } catch (error) {
+      alert(error.response.data.error.message.toString());
+    }
   };
 
   return (

--- a/src/containers/task/modules/listItem/TaskListItemComponentContainer.tsx
+++ b/src/containers/task/modules/listItem/TaskListItemComponentContainer.tsx
@@ -3,7 +3,6 @@ import { useDispatch } from 'react-redux';
 import { EditTaskItemReq, TaskListItem } from '../../../../reducks/groupTasks/types';
 import TaskListItemComponent from '../../../../components/task/modules/listItem/TaskListItemComponent/TaskListItemComponent';
 import { deleteTaskItem, editTaskItem } from '../../../../reducks/groupTasks/operations';
-import { executeAfterAsyncProcess } from '../../../../lib/function';
 
 interface TaskListItemComponentContainerProps {
   listItem: TaskListItem;
@@ -44,7 +43,7 @@ const TaskListItemComponentContainer = (props: TaskListItemComponentContainerPro
     }
   };
 
-  const handleEditTaskItem = () => {
+  const handleEditTaskItem = async () => {
     const requestData: EditTaskItemReq = {
       base_date: props.listItem.base_date,
       cycle_type: props.listItem.cycle_type,
@@ -53,16 +52,21 @@ const TaskListItemComponentContainer = (props: TaskListItemComponentContainerPro
       group_tasks_users_id: props.listItem.group_tasks_users_id,
     };
 
-    return executeAfterAsyncProcess(
-      dispatch(editTaskItem(props.listItem.group_id, props.listItem.id, requestData)),
-      () => setOpenForm(false)
-    );
+    try {
+      await dispatch(editTaskItem(props.listItem.group_id, props.listItem.id, requestData));
+
+      setOpenForm(false);
+    } catch (error) {
+      alert(error.response.data.error.message.toString());
+    }
   };
 
-  const handleDeleteTaskItem = () => {
-    return executeAfterAsyncProcess(
-      dispatch(deleteTaskItem(props.listItem.group_id, props.listItem.id))
-    );
+  const handleDeleteTaskItem = async () => {
+    try {
+      await dispatch(deleteTaskItem(props.listItem.group_id, props.listItem.id));
+    } catch (error) {
+      alert(error.response.data.error.message.toString());
+    }
   };
 
   const disabledButton = taskName === initialState.initialTaskName || taskName === '';

--- a/src/containers/task/page/taskTableArea/assignmentTaskModal/AssignmentTaskModalContainer.tsx
+++ b/src/containers/task/page/taskTableArea/assignmentTaskModal/AssignmentTaskModalContainer.tsx
@@ -11,7 +11,6 @@ import { getGroupTaskList } from '../../../../../reducks/groupTasks/selectors';
 import AssignTaskModal from '../../../../../components/task/modules/area/taskTableArea/assignTaskModal/AssignTaskModal';
 import SelectTaskName from '../../../../../components/task/modules/select/SelectTaskName';
 import { editTaskItem } from '../../../../../reducks/groupTasks/operations';
-import { executeAfterAsyncProcess } from '../../../../../lib/function';
 
 interface AssignmentTaskModalContainerProps {
   participatingTaskUsers: TaskUsers;
@@ -90,7 +89,7 @@ const AssignmentTaskModalContainer = (props: AssignmentTaskModalContainerProps) 
     setTaskUserId(Number(event.target.value));
   };
 
-  const handleAssignTaskItem = () => {
+  const handleAssignTaskItem = async () => {
     const requestData: EditTaskItemReq = {
       base_date: baseDate,
       cycle_type: cycleType,
@@ -99,10 +98,13 @@ const AssignmentTaskModalContainer = (props: AssignmentTaskModalContainerProps) 
       group_tasks_users_id: taskUserId,
     };
 
-    return executeAfterAsyncProcess(
-      dispatch(editTaskItem(props.groupId, taskItemId, requestData)),
-      () => setOpen(false)
-    );
+    try {
+      await dispatch(editTaskItem(props.groupId, taskItemId, requestData));
+
+      setOpen(false);
+    } catch (error) {
+      alert(error.response.data.error.message.toString());
+    }
   };
 
   const disabledButton =

--- a/src/containers/task/page/taskTableArea/assignmentTaskTable/editAssignmentTaskModal/EditAssignmentTaskModalContainer.tsx
+++ b/src/containers/task/page/taskTableArea/assignmentTaskTable/editAssignmentTaskModal/EditAssignmentTaskModalContainer.tsx
@@ -9,7 +9,6 @@ import {
 import { useDispatch } from 'react-redux';
 import { editTaskItem } from '../../../../../../reducks/groupTasks/operations';
 import EditAssignmentTaskModal from '../../../../../../components/task/modules/area/taskTableArea/assignTaskTable/editAssignTaskModal/EditAssignTaskModal';
-import { executeAfterAsyncProcess } from '../../../../../../lib/function';
 
 interface EditAssignmentTaskModalContainerProps {
   participatingTaskUsers: TaskUsers;
@@ -81,7 +80,7 @@ const EditAssignmentTaskModalContainer = (props: EditAssignmentTaskModalContaine
     setTaskUserId(Number(event.target.value));
   };
 
-  const handleEditAssignTaskItem = () => {
+  const handleEditAssignTaskItem = async () => {
     const requestData: EditTaskItemReq = {
       base_date: baseDate,
       cycle_type: cycleType,
@@ -90,13 +89,16 @@ const EditAssignmentTaskModalContainer = (props: EditAssignmentTaskModalContaine
       group_tasks_users_id: taskUserId,
     };
 
-    return executeAfterAsyncProcess(
-      dispatch(editTaskItem(props.groupId, taskItemId, requestData)),
-      () => setOpen(false)
-    );
+    try {
+      await dispatch(editTaskItem(props.groupId, taskItemId, requestData));
+
+      setOpen(false);
+    } catch (error) {
+      alert(error.response.data.error.message.toString());
+    }
   };
 
-  const handleReleaseTaskItem = () => {
+  const handleReleaseTaskItem = async () => {
     const requestData: EditTaskItemReq = {
       base_date: null,
       cycle_type: null,
@@ -105,7 +107,11 @@ const EditAssignmentTaskModalContainer = (props: EditAssignmentTaskModalContaine
       group_tasks_users_id: null,
     };
 
-    return executeAfterAsyncProcess(dispatch(editTaskItem(props.groupId, taskItemId, requestData)));
+    try {
+      await dispatch(editTaskItem(props.groupId, taskItemId, requestData));
+    } catch (error) {
+      alert(error.response.data.error.message.toString());
+    }
   };
 
   const disabledButton = () => {

--- a/src/containers/task/page/taskToolBarArea/editTaskUserModalContainer/taskUserForm/AddTaskUserFormContainer.tsx
+++ b/src/containers/task/page/taskToolBarArea/editTaskUserModalContainer/taskUserForm/AddTaskUserFormContainer.tsx
@@ -7,7 +7,6 @@ import {
 import { useDispatch } from 'react-redux';
 import TaskUserForm from '../../../../../../components/task/modules/form/taskUserForm/TaskUserForm';
 import { addTaskUsers } from '../../../../../../reducks/groupTasks/operations';
-import { executeAfterAsyncProcess } from '../../../../../../lib/function';
 
 interface AddTaskUserFormContainerProps {
   approvedGroup: Group;
@@ -52,15 +51,18 @@ const AddTaskUserFormContainer = (props: AddTaskUserFormContainerProps) => {
     props.groupTasksListForEachUser
   );
 
-  const handleAddTaskUsers = () => {
+  const handleAddTaskUsers = async () => {
     const requestData: AddGroupTaskUsersReq = {
       users_list: checkedUserIds,
     };
 
-    return executeAfterAsyncProcess(
-      dispatch(addTaskUsers(props.approvedGroup.group_id, requestData)),
-      () => props.handleCloseAddTaskUserForm()
-    );
+    try {
+      await dispatch(addTaskUsers(props.approvedGroup.group_id, requestData));
+
+      props.handleCloseAddTaskUserForm();
+    } catch (error) {
+      alert(error.response.data.error.message.toString());
+    }
   };
 
   return (

--- a/src/containers/task/page/taskToolBarArea/editTaskUserModalContainer/taskUserForm/DeleteTaskUserFormContainer.tsx
+++ b/src/containers/task/page/taskToolBarArea/editTaskUserModalContainer/taskUserForm/DeleteTaskUserFormContainer.tsx
@@ -8,7 +8,6 @@ import {
 import { useDispatch } from 'react-redux';
 import TaskUserForm from '../../../../../../components/task/modules/form/taskUserForm/TaskUserForm';
 import { deleteTaskUsers } from '../../../../../../reducks/groupTasks/operations';
-import { executeAfterAsyncProcess } from '../../../../../../lib/function';
 
 interface DeleteTaskUserFormContainerProps {
   approvedGroup: Group;
@@ -59,15 +58,18 @@ const DeleteTaskUserFormContainer = (props: DeleteTaskUserFormContainerProps) =>
     props.groupTasksListForEachUser
   );
 
-  const handleDeleteTaskUsers = () => {
+  const handleDeleteTaskUsers = async () => {
     const requestData: DeleteGroupTaskUsersReq = {
       users_list: checkedUserIds,
     };
 
-    return executeAfterAsyncProcess(
-      dispatch(deleteTaskUsers(props.approvedGroup.group_id, requestData)),
-      () => props.handleCloseDeleteTaskUserForm()
-    );
+    try {
+      await dispatch(deleteTaskUsers(props.approvedGroup.group_id, requestData));
+
+      props.handleCloseDeleteTaskUserForm();
+    } catch (error) {
+      alert(error.response.data.error.message.toString());
+    }
   };
 
   return (

--- a/src/lib/function.ts
+++ b/src/lib/function.ts
@@ -1,5 +1,4 @@
 import { colors } from './colorConstant';
-import { Action, Dispatch } from 'redux';
 
 export const bigCategoryColor = (bigCategoryName: string) => {
   if (bigCategoryName === '食費') {
@@ -34,18 +33,5 @@ export const bigCategoryColor = (bigCategoryName: string) => {
     return { backgroundColor: colors[14] };
   } else if (bigCategoryName === 'その他') {
     return { backgroundColor: colors[15] };
-  }
-};
-
-export const executeAfterAsyncProcess = async (
-  operation: (dispatch: Dispatch<Action>) => Promise<void>,
-  result?: () => void
-) => {
-  try {
-    await operation;
-
-    result && result();
-  } catch (error) {
-    alert(error);
   }
 };

--- a/test/group-tasks-test/GroupTasksOperations.test.ts
+++ b/test/group-tasks-test/GroupTasksOperations.test.ts
@@ -35,6 +35,7 @@ import {
   DeleteGroupTaskUsersReq,
   EditTaskItemReq,
 } from '../../src/reducks/groupTasks/types';
+import { todoServiceInstance } from '../../src/reducks/axiosConfig';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -45,7 +46,7 @@ const store = mockStore({
   router: [],
 });
 
-const axiosMock = new MockAdapter(axios);
+const axiosMock = new MockAdapter(todoServiceInstance);
 
 describe('async actions groupTasks', () => {
   beforeEach(() => {
@@ -54,7 +55,7 @@ describe('async actions groupTasks', () => {
 
   it('get groupTaskListForEachUser if fetch succeeds.', async () => {
     const groupId = 1;
-    const url = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks/users`;
+    const url = `/groups/${groupId}/tasks/users`;
     const signal = axios.CancelToken.source();
 
     const expectedAction = [
@@ -91,9 +92,9 @@ describe('async actions groupTasks', () => {
       users_list: users,
     };
 
-    const addUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks/users`;
-    const fetchTaskListForEachUserUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks/users`;
-    const fetchTaskListUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks`;
+    const addUrl = `/groups/${groupId}/tasks/users`;
+    const fetchTaskListUrl = `/groups/${groupId}/tasks`;
+    const fetchTaskListForEachUserUrl = `/groups/${groupId}/tasks/users`;
 
     const expectedAction = [
       {
@@ -106,18 +107,18 @@ describe('async actions groupTasks', () => {
       {
         type: GroupTasksActions.ADD_TASK_USERS,
         payload: {
+          groupTaskListLoading: false,
+          groupTaskList: addUsersTaskListResponse.group_tasks_list,
           groupTaskListForEachUserLoading: false,
           groupTaskListForEachUser:
             addUsersTaskListForEachUserResponse.group_tasks_list_for_each_user,
-          groupTaskListLoading: false,
-          groupTaskList: addUsersTaskListResponse.group_tasks_list,
         },
       },
     ];
 
     axiosMock.onPost(addUrl).reply(200, addTaskUsersResponse);
-    axiosMock.onGet(fetchTaskListForEachUserUrl).reply(200, addUsersTaskListForEachUserResponse);
     axiosMock.onGet(fetchTaskListUrl).reply(200, addUsersTaskListResponse);
+    axiosMock.onGet(fetchTaskListForEachUserUrl).reply(200, addUsersTaskListForEachUserResponse);
 
     await addTaskUsers(groupId, requestData)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAction);
@@ -131,9 +132,9 @@ describe('async actions groupTasks', () => {
       users_list: users,
     };
 
-    const deleteUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks/users`;
-    const fetchTaskListForEachUserUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks/users`;
-    const fetchTaskListUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks`;
+    const deleteUrl = `/groups/${groupId}/tasks/users`;
+    const fetchTaskListForEachUserUrl = `/groups/${groupId}/tasks/users`;
+    const fetchTaskListUrl = `/groups/${groupId}/tasks`;
 
     const expectedAction = [
       {
@@ -174,7 +175,7 @@ describe('async actions groupTasks', () => {
     const groupId = 1;
     const signal = axios.CancelToken.source();
 
-    const url = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks`;
+    const url = `/groups/${groupId}/tasks`;
 
     const expectedAction = [
       {
@@ -210,8 +211,8 @@ describe('async actions groupTasks', () => {
       task_name: taskName,
     };
 
-    const addUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks`;
-    const fetchUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks`;
+    const addUrl = `/groups/${groupId}/tasks`;
+    const fetchUrl = `/groups/${groupId}/tasks`;
 
     const expectedAction = [
       {
@@ -255,9 +256,9 @@ describe('async actions groupTasks', () => {
       group_tasks_users_id: groupTasksUsersId,
     };
 
-    const editUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks/${taskItemId}`;
-    const fetchTaskListUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks`;
-    const fetchTaskListForEachUserUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks/users`;
+    const editUrl = `/groups/${groupId}/tasks/${taskItemId}`;
+    const fetchTaskListUrl = `/groups/${groupId}/tasks`;
+    const fetchTaskListForEachUserUrl = `/groups/${groupId}/tasks/users`;
 
     const expectedAction = [
       {
@@ -293,9 +294,9 @@ describe('async actions groupTasks', () => {
     const groupId = 1;
     const taskItemId = 2;
 
-    const editUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks/${taskItemId}`;
-    const fetchTaskListUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks`;
-    const fetchTaskListForEachUserUrl = `${process.env.REACT_APP_TODO_API_HOST}/groups/${groupId}/tasks/users`;
+    const editUrl = `/groups/${groupId}/tasks/${taskItemId}`;
+    const fetchTaskListUrl = `/groups/${groupId}/tasks`;
+    const fetchTaskListForEachUserUrl = `/groups/${groupId}/tasks/users`;
 
     const expectedAction = [
       {


### PR DESCRIPTION
- タスクの追加、編集、削除で`executeAfterAsyncProcess()`関数を使用しないようにしました。
- `groupTasks`の`operations.ts`で`todoServiceInstance`を使用するようにしました。
- `executeAfterAsyncProcess()`関数を削除しました。