### PR TITLE
Add useFetchTodoList function

### DIFF
--- a/src/components/home/todaySchedule/TodaySchedule.tsx
+++ b/src/components/home/todaySchedule/TodaySchedule.tsx
@@ -11,8 +11,8 @@ interface TodayScheduleProps {
   todoEditing: boolean;
   setTodoEditing: React.Dispatch<React.SetStateAction<boolean>>;
   pathName: string;
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   implementationTodoList: TodoListItem[];
   dueTodoList: TodoListItem[];
 }
@@ -29,8 +29,8 @@ const TodaySchedule = (props: TodayScheduleProps) => {
           leftItem={
             <TodayScheduleTodoListArea
               todoList={props.implementationTodoList}
-              currentYear={props.currentYear}
-              currentMonth={props.currentMonth}
+              selectedYearParam={props.selectedYearParam}
+              selectedMonthParam={props.selectedMonthParam}
               message={'今日の実施予定のToDoリストは、登録されていません。'}
               setEditing={props.setTodoEditing}
             />
@@ -38,8 +38,8 @@ const TodaySchedule = (props: TodayScheduleProps) => {
           rightItem={
             <TodayScheduleTodoListArea
               todoList={props.dueTodoList}
-              currentYear={props.currentYear}
-              currentMonth={props.currentMonth}
+              selectedYearParam={props.selectedYearParam}
+              selectedMonthParam={props.selectedMonthParam}
               message={'今日の締切予定のToDoリストは、登録されていません。'}
               setEditing={props.setTodoEditing}
             />
@@ -51,13 +51,13 @@ const TodaySchedule = (props: TodayScheduleProps) => {
         <h4>買い物リスト</h4>
         {props.pathName === 'group' ? (
           <GroupTodayScheduleShoppingListAreaContainer
-            currentYear={props.currentYear}
-            currentMonth={props.currentMonth}
+            currentYear={props.selectedYearParam}
+            currentMonth={props.selectedMonthParam}
           />
         ) : (
           <TodayScheduleShoppingListAreaContainer
-            currentYear={props.currentYear}
-            currentMonth={props.currentMonth}
+            currentYear={props.selectedYearParam}
+            currentMonth={props.selectedMonthParam}
           />
         )}
       </div>

--- a/src/components/home/todaySchedule/todoListArea/TodayScheduleTodoListArea.tsx
+++ b/src/components/home/todaySchedule/todoListArea/TodayScheduleTodoListArea.tsx
@@ -5,8 +5,8 @@ import TodoListItemComponentContainer from '../../../../containers/todo/modules/
 
 interface TodayScheduleTodoListAreaProps {
   todoList: TodoListItem[];
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   message: string;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -22,8 +22,8 @@ const TodayScheduleTodoListArea = (props: TodayScheduleTodoListAreaProps) => {
             return (
               <TodoListItemComponentContainer
                 listItem={listItem}
-                currentYear={props.currentYear}
-                currentMonth={props.currentMonth}
+                selectedYearParam={props.selectedYearParam}
+                selectedMonthParam={props.selectedMonthParam}
                 setEditing={props.setEditing}
                 key={listItem.id}
               />

--- a/src/components/todo/modules/area/expiredTodoListArea/ExpiredTodoListArea.tsx
+++ b/src/components/todo/modules/area/expiredTodoListArea/ExpiredTodoListArea.tsx
@@ -9,8 +9,8 @@ import cn from 'classnames';
 interface ExpiredTodoListAreaProps {
   expiredTodoList: DisplayTodoListItem[];
   displayExpiredTodoList: DisplayTodoListItem[];
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   readMore: boolean;
   setReadMore: React.Dispatch<React.SetStateAction<boolean>>;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
@@ -35,8 +35,8 @@ const ExpiredTodoListArea = (props: ExpiredTodoListAreaProps) => {
                       return (
                         <TodoListItemComponentContainer
                           listItem={item}
-                          currentYear={props.currentYear}
-                          currentMonth={props.currentMonth}
+                          selectedYearParam={props.selectedYearParam}
+                          selectedMonthParam={props.selectedMonthParam}
                           setEditing={props.setEditing}
                           key={item.id}
                         />

--- a/src/components/todo/modules/area/monthlyTodoListArea/MonthlyTodoListArea.tsx
+++ b/src/components/todo/modules/area/monthlyTodoListArea/MonthlyTodoListArea.tsx
@@ -11,8 +11,8 @@ interface MonthlyTodoListAreaProps {
   selectedMonth: number;
   setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
   setSelectedMonth: React.Dispatch<React.SetStateAction<number>>;
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -21,8 +21,8 @@ const MonthlyTodoListArea = (props: MonthlyTodoListAreaProps) => {
     <>
       <div className={styles.addButton}>
         <AddTodoListItemFormContainer
-          currentYear={props.currentYear}
-          currentMonth={props.currentMonth}
+          selectedYearParam={props.selectedYearParam}
+          selectedMonthParam={props.selectedMonthParam}
         />
       </div>
       <div className={styles.switchItem}>
@@ -44,16 +44,16 @@ const MonthlyTodoListArea = (props: MonthlyTodoListAreaProps) => {
             leftItem={
               <MonthlyImplementationDateTodoListContainer
                 selectedMonth={props.selectedMonth}
-                currentYear={props.currentYear}
-                currentMonth={props.currentMonth}
+                selectedYearParam={props.selectedYearParam}
+                selectedMonthParam={props.selectedMonthParam}
                 setEditing={props.setEditing}
               />
             }
             rightItem={
               <MonthlyDueDateTodoListContainer
                 selectedMonth={props.selectedMonth}
-                currentYear={props.currentYear}
-                currentMonth={props.currentMonth}
+                selectedYearParam={props.selectedYearParam}
+                selectedMonthParam={props.selectedMonthParam}
                 setEditing={props.setEditing}
               />
             }

--- a/src/components/todo/modules/area/todayTodoListArea/TodayTodoListArea.tsx
+++ b/src/components/todo/modules/area/todayTodoListArea/TodayTodoListArea.tsx
@@ -6,8 +6,8 @@ import AddTodoListItemFormContainer from '../../../../../containers/todo/modules
 import styles from './TodayTodoListArea.module.scss';
 
 interface TodayTodoListAreaProps {
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   editing: boolean;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -17,8 +17,8 @@ const TodayTodoListArea = (props: TodayTodoListAreaProps) => {
     <>
       <div className={styles.addButton}>
         <AddTodoListItemFormContainer
-          currentYear={props.currentYear}
-          currentMonth={props.currentMonth}
+          selectedYearParam={props.selectedYearParam}
+          selectedMonthParam={props.selectedMonthParam}
         />
       </div>
       <div className={styles.switchItem}>
@@ -28,15 +28,15 @@ const TodayTodoListArea = (props: TodayTodoListAreaProps) => {
             rightButtonLabel={'締切予定のToDo'}
             leftItem={
               <TodayImplementationDateTodoListContainer
-                currentYear={props.currentYear}
-                currentMonth={props.currentMonth}
+                selectedYearParam={props.selectedYearParam}
+                selectedMonthParam={props.selectedMonthParam}
                 setEditing={props.setEditing}
               />
             }
             rightItem={
               <TodayDueDateTodoListContainer
-                currentYear={props.currentYear}
-                currentMonth={props.currentMonth}
+                selectedYearParam={props.selectedYearParam}
+                selectedMonthParam={props.selectedMonthParam}
                 setEditing={props.setEditing}
               />
             }

--- a/src/components/todo/modules/list/TodoListComponent/TodoListComponent.tsx
+++ b/src/components/todo/modules/list/TodoListComponent/TodoListComponent.tsx
@@ -5,8 +5,8 @@ import TodoListItemComponentContainer from '../../../../../containers/todo/modul
 
 interface TodoListComponentProps {
   todoList: DisplayTodoListItem[];
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   message: string;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -27,8 +27,8 @@ const TodoListComponent = (props: TodoListComponentProps) => {
                     return (
                       <TodoListItemComponentContainer
                         listItem={item}
-                        currentYear={props.currentYear}
-                        currentMonth={props.currentMonth}
+                        selectedYearParam={props.selectedYearParam}
+                        selectedMonthParam={props.selectedMonthParam}
                         setEditing={props.setEditing}
                         formClassName={styles.childFormClassName}
                         key={item.id}

--- a/src/components/todo/page/TodoPage.tsx
+++ b/src/components/todo/page/TodoPage.tsx
@@ -21,8 +21,6 @@ interface TodoPageProps {
   setOpenSearchResultTodoList: React.Dispatch<React.SetStateAction<boolean>>;
   handleOpenSearch: () => void;
   handleCloseSearch: () => void;
-  currentYear: string;
-  currentMonth: string;
   pathName: string;
 }
 
@@ -42,8 +40,8 @@ const TodoPage = (props: TodoPageProps) => {
                   setCurrentItems={props.setCurrentTodayOrMonthly}
                   leftItem={
                     <TodayTodoAreaContainer
-                      currentYear={props.currentYear}
-                      currentMonth={props.currentMonth}
+                      selectedYear={props.selectedYear}
+                      selectedMonth={props.selectedMonth}
                       editing={props.editing}
                       setEditing={props.setEditing}
                     />
@@ -54,8 +52,6 @@ const TodoPage = (props: TodoPageProps) => {
                       selectedMonth={props.selectedMonth}
                       setSelectedYear={props.setSelectedYear}
                       setSelectedMonth={props.setSelectedMonth}
-                      currentYear={props.currentYear}
-                      currentMonth={props.currentMonth}
                       editing={props.editing}
                       setEditing={props.setEditing}
                     />
@@ -68,8 +64,8 @@ const TodoPage = (props: TodoPageProps) => {
             <div className={styles.rightContent}>
               <h4>期限切れToDoリスト</h4>
               <ExpiredTodoListAreaContainer
-                currentYear={props.currentYear}
-                currentMonth={props.currentMonth}
+                selectedYear={props.selectedYear}
+                selectedMonth={props.selectedMonth}
                 setEditing={props.setEditing}
                 readMoreBtnClassName={styles.childReadBtn}
               />

--- a/src/containers/home/todaySchedule/TodayScheduleContainer.tsx
+++ b/src/containers/home/todaySchedule/TodayScheduleContainer.tsx
@@ -85,8 +85,8 @@ const TodayScheduleContainer = (props: TodayScheduleContainerProps) => {
       todoEditing={props.todoEditing}
       setTodoEditing={props.setTodoEditing}
       pathName={pathName}
-      currentYear={todayYear}
-      currentMonth={todayMonth}
+      selectedYearParam={todayYear}
+      selectedMonthParam={todayMonth}
       implementationTodoList={
         pathName === 'group' ? groupImplementationTodoList : implementationTodoList
       }

--- a/src/containers/todo/modules/area/expiredTodoListArea/ExpiredTodoListAreaContainer.tsx
+++ b/src/containers/todo/modules/area/expiredTodoListArea/ExpiredTodoListAreaContainer.tsx
@@ -13,10 +13,11 @@ import {
 import { useLocation } from 'react-router';
 import { fetchExpiredTodoList } from '../../../../../reducks/todoList/operations';
 import { DisplayTodoList, DisplayTodoListItem } from '../../../../../reducks/todoList/types';
+import { generateZeroPaddingMonth } from '../../../../../lib/date';
 
 interface ExpiredTodoListAreaContainerProps {
-  currentYear: string;
-  currentMonth: string;
+  selectedYear: number;
+  selectedMonth: number;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
   readMoreBtnClassName: string;
 }
@@ -24,6 +25,8 @@ interface ExpiredTodoListAreaContainerProps {
 const ExpiredTodoListAreaContainer = (props: ExpiredTodoListAreaContainerProps) => {
   const dispatch = useDispatch();
   const pathName = useLocation().pathname.split('/')[1];
+  const selectedYearParam = String(props.selectedYear);
+  const selectedMonthParam = generateZeroPaddingMonth(props.selectedMonth);
 
   const expiredTodoList = useSelector(getExpiredTodoList);
   const groupExpiredTodoList = useSelector(getGroupExpiredTodoList);
@@ -93,8 +96,8 @@ const ExpiredTodoListAreaContainer = (props: ExpiredTodoListAreaContainerProps) 
     <ExpiredTodoListArea
       expiredTodoList={todoList}
       displayExpiredTodoList={displayTodoList}
-      currentYear={props.currentYear}
-      currentMonth={props.currentMonth}
+      selectedYearParam={selectedYearParam}
+      selectedMonthParam={selectedMonthParam}
       readMore={readMore}
       setReadMore={setReadMore}
       setEditing={props.setEditing}

--- a/src/containers/todo/modules/area/monthlyTodoListArea/Items/MonthlyDueDateTodoListContainer.tsx
+++ b/src/containers/todo/modules/area/monthlyTodoListArea/Items/MonthlyDueDateTodoListContainer.tsx
@@ -8,8 +8,8 @@ import { DisplayTodoList } from '../../../../../../reducks/todoList/types';
 
 interface MonthlyDueDateTodoListContainerProps {
   selectedMonth: number;
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -40,8 +40,8 @@ const MonthlyDueDateTodoListContainer = (props: MonthlyDueDateTodoListContainerP
   return (
     <TodoListComponent
       todoList={todoList}
-      currentYear={props.currentYear}
-      currentMonth={props.currentMonth}
+      selectedYearParam={props.selectedYearParam}
+      selectedMonthParam={props.selectedMonthParam}
       message={`${props.selectedMonth}月の締切予定のToDoリストは、登録されていません。`}
       setEditing={props.setEditing}
     />

--- a/src/containers/todo/modules/area/monthlyTodoListArea/Items/MonthlyImplementationDateTodoListContainer.tsx
+++ b/src/containers/todo/modules/area/monthlyTodoListArea/Items/MonthlyImplementationDateTodoListContainer.tsx
@@ -8,8 +8,9 @@ import { DisplayTodoList } from '../../../../../../reducks/todoList/types';
 
 interface MonthlyImplementationDateTodoListContainerProps {
   selectedMonth: number;
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
+
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -42,8 +43,8 @@ const MonthlyImplementationDateTodoListContainer = (
   return (
     <TodoListComponent
       todoList={todoList}
-      currentYear={props.currentYear}
-      currentMonth={props.currentMonth}
+      selectedYearParam={props.selectedYearParam}
+      selectedMonthParam={props.selectedMonthParam}
       message={`${props.selectedMonth}月の実施予定のToDoリストは、登録されていません。`}
       setEditing={props.setEditing}
     />

--- a/src/containers/todo/modules/area/monthlyTodoListArea/MonthlyTodoListAreaContainer.tsx
+++ b/src/containers/todo/modules/area/monthlyTodoListArea/MonthlyTodoListAreaContainer.tsx
@@ -9,14 +9,13 @@ import {
 import { fetchGroups } from '../../../../../reducks/groups/operations';
 import { fetchMonthlyTodoList } from '../../../../../reducks/todoList/operations';
 import MonthlyTodoListArea from '../../../../../components/todo/modules/area/monthlyTodoListArea/MonthlyTodoListArea';
+import { generateZeroPaddingMonth } from '../../../../../lib/date';
 
 interface MonthlyTodoListAreaContainerProps {
   selectedYear: number;
   selectedMonth: number;
   setSelectedYear: React.Dispatch<React.SetStateAction<number>>;
   setSelectedMonth: React.Dispatch<React.SetStateAction<number>>;
-  currentYear: string;
-  currentMonth: string;
   editing: boolean;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -26,11 +25,14 @@ const MonthlyTodoListAreaContainer = (props: MonthlyTodoListAreaContainerProps) 
   const pathName = useLocation().pathname.split('/')[1];
   const { group_id } = useParams<{ group_id: string }>();
 
+  const selectedYearParam = String(props.selectedYear);
+  const selectedMonthParam = generateZeroPaddingMonth(props.selectedMonth);
+
   const fetchGroupTodoList = (signal: CancelTokenSource) => {
     dispatch(fetchGroups(signal));
     dispatch(fetchGroupExpiredTodoList(Number(group_id), signal));
     dispatch(
-      fetchGroupMonthlyTodoList(Number(group_id), props.currentYear, props.currentMonth, signal)
+      fetchGroupMonthlyTodoList(Number(group_id), selectedYearParam, selectedMonthParam, signal)
     );
   };
 
@@ -51,7 +53,7 @@ const MonthlyTodoListAreaContainer = (props: MonthlyTodoListAreaContainerProps) 
   useEffect(() => {
     if (pathName !== 'group') {
       const signal = axios.CancelToken.source();
-      dispatch(fetchMonthlyTodoList(props.currentYear, props.currentMonth, signal));
+      dispatch(fetchMonthlyTodoList(selectedYearParam, selectedMonthParam, signal));
       return () => signal.cancel();
     }
   }, [props.selectedYear, props.selectedMonth]);
@@ -62,8 +64,8 @@ const MonthlyTodoListAreaContainer = (props: MonthlyTodoListAreaContainerProps) 
       selectedMonth={props.selectedMonth}
       setSelectedYear={props.setSelectedYear}
       setSelectedMonth={props.setSelectedMonth}
-      currentYear={props.currentYear}
-      currentMonth={props.currentMonth}
+      selectedYearParam={selectedYearParam}
+      selectedMonthParam={selectedMonthParam}
       setEditing={props.setEditing}
     />
   );

--- a/src/containers/todo/modules/area/todayTodoListArea/Items/TodayDueDateTodoListContainer.tsx
+++ b/src/containers/todo/modules/area/todayTodoListArea/Items/TodayDueDateTodoListContainer.tsx
@@ -7,8 +7,8 @@ import { useLocation } from 'react-router';
 import { DisplayTodoList } from '../../../../../../reducks/todoList/types';
 
 interface TodayDueDateTodoListContainerProps {
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -38,8 +38,8 @@ const TodayDueDateTodoListContainer = (props: TodayDueDateTodoListContainerProps
   return (
     <TodoListComponent
       todoList={todoList}
-      currentYear={props.currentYear}
-      currentMonth={props.currentMonth}
+      selectedYearParam={props.selectedYearParam}
+      selectedMonthParam={props.selectedMonthParam}
       message={'今日の締切予定のToDoリストは、登録されていません。'}
       setEditing={props.setEditing}
     />

--- a/src/containers/todo/modules/area/todayTodoListArea/Items/TodayImplementationDateTodoListContainer.tsx
+++ b/src/containers/todo/modules/area/todayTodoListArea/Items/TodayImplementationDateTodoListContainer.tsx
@@ -7,8 +7,8 @@ import { useLocation } from 'react-router';
 import { DisplayTodoList } from '../../../../../../reducks/todoList/types';
 
 interface TodayImplementationDateTodoListContainerProps {
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -40,8 +40,8 @@ const TodayImplementationDateTodoListContainer = (
   return (
     <TodoListComponent
       todoList={todoList}
-      currentYear={props.currentYear}
-      currentMonth={props.currentMonth}
+      selectedYearParam={props.selectedYearParam}
+      selectedMonthParam={props.selectedMonthParam}
       message={'今日の実施予定のToDoリストは、登録されていません。'}
       setEditing={props.setEditing}
     />

--- a/src/containers/todo/modules/area/todayTodoListArea/TodayTodoListAreaContainer.tsx
+++ b/src/containers/todo/modules/area/todayTodoListArea/TodayTodoListAreaContainer.tsx
@@ -10,10 +10,11 @@ import { useDispatch } from 'react-redux';
 import { useLocation, useParams } from 'react-router';
 import { customDate, customMonth, year } from '../../../../../lib/constant';
 import TodayTodoListArea from '../../../../../components/todo/modules/area/todayTodoListArea/TodayTodoListArea';
+import { generateZeroPaddingMonth } from '../../../../../lib/date';
 
 interface TodayTodoAreaContainerProps {
-  currentYear: string;
-  currentMonth: string;
+  selectedYear: number;
+  selectedMonth: number;
   editing: boolean;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -23,14 +24,18 @@ const TodayTodoAreaContainer = (props: TodayTodoAreaContainerProps) => {
   const pathName = useLocation().pathname.split('/')[1];
   const { group_id } = useParams<{ group_id: string }>();
 
-  const todayYear = String(year);
-  const todayMonth = customMonth;
-  const todayDate = customDate;
+  const currentYear = String(year);
+  const currentMonth = customMonth;
+  const currentDate = customDate;
+  const selectedYearParam = String(props.selectedYear);
+  const selectedMonthParam = generateZeroPaddingMonth(props.selectedMonth);
 
   const fetchGroupTodoList = (signal: CancelTokenSource) => {
     dispatch(fetchGroups(signal));
     dispatch(fetchGroupExpiredTodoList(Number(group_id), signal));
-    dispatch(fetchGroupTodayTodoList(Number(group_id), todayYear, todayMonth, todayDate, signal));
+    dispatch(
+      fetchGroupTodayTodoList(Number(group_id), currentYear, currentMonth, currentDate, signal)
+    );
   };
 
   useEffect(() => {
@@ -45,20 +50,20 @@ const TodayTodoAreaContainer = (props: TodayTodoAreaContainerProps) => {
         clearInterval(interval);
       };
     }
-  }, [todayYear, todayMonth, todayDate, props.editing]);
+  }, [currentYear, currentMonth, currentDate, props.editing]);
 
   useEffect(() => {
     if (pathName !== 'group') {
       const signal = axios.CancelToken.source();
-      dispatch(fetchTodayTodoList(todayYear, todayMonth, todayDate, signal));
+      dispatch(fetchTodayTodoList(currentYear, currentMonth, currentDate, signal));
       return () => signal.cancel();
     }
-  }, [todayYear, todayMonth, todayDate]);
+  }, [currentYear, currentMonth, currentDate]);
 
   return (
     <TodayTodoListArea
-      currentYear={props.currentYear}
-      currentMonth={props.currentMonth}
+      selectedYearParam={selectedYearParam}
+      selectedMonthParam={selectedMonthParam}
       editing={props.editing}
       setEditing={props.setEditing}
     />

--- a/src/containers/todo/modules/form/AddTodoListItemFormContainer.tsx
+++ b/src/containers/todo/modules/form/AddTodoListItemFormContainer.tsx
@@ -62,7 +62,7 @@ const AddTodoListItemFormContainer = (props: AddTodoListItemFormContainerProps) 
     }
   };
 
-  const { getFetchTodoList } = useFetchTodoList();
+  const { fetchTodoList } = useFetchTodoList();
 
   const disabledButton =
     implementationDate === null ||
@@ -104,7 +104,7 @@ const AddTodoListItemFormContainer = (props: AddTodoListItemFormContainerProps) 
     } else {
       try {
         await dispatch(addTodoListItem(addRequestData));
-        await getFetchTodoList(params);
+        await fetchTodoList(params);
 
         setOpenAddTodoForm(false);
       } catch (error) {

--- a/src/containers/todo/modules/form/AddTodoListItemFormContainer.tsx
+++ b/src/containers/todo/modules/form/AddTodoListItemFormContainer.tsx
@@ -5,11 +5,12 @@ import { addGroupTodoListItem } from '../../../../reducks/groupTodoList/operatio
 import { customDate, customMonth, date, year } from '../../../../lib/constant';
 import { useLocation, useParams } from 'react-router';
 import AddTodoListItemForm from '../../../../components/todo/modules/form/addTodoListItemForm/AddTodoListItemForm';
-import { AddTodoListItemReq } from '../../../../reducks/todoList/types';
+import { AddTodoListItemReq, FetchTodoListParams } from '../../../../reducks/todoList/types';
+import { useFetchTodoList } from '../../../../hooks/todo/useFetchTodoList';
 
 interface AddTodoListItemFormContainerProps {
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
 }
 
 const initialState = {
@@ -61,12 +62,22 @@ const AddTodoListItemFormContainer = (props: AddTodoListItemFormContainerProps) 
     }
   };
 
+  const { getFetchTodoList } = useFetchTodoList();
+
   const disabledButton =
     implementationDate === null ||
     dueDate === null ||
     todoContent === initialState.initialTodoContent;
 
   const handleAddTodoListItem = async () => {
+    const params: FetchTodoListParams = {
+      currentYear: String(year),
+      currentMonth: customMonth,
+      currentDate: customDate,
+      selectedYear: props.selectedYearParam,
+      selectedMonth: props.selectedMonthParam,
+    };
+
     const addRequestData: AddTodoListItemReq = {
       implementation_date: implementationDate,
       due_date: dueDate,
@@ -81,8 +92,8 @@ const AddTodoListItemFormContainer = (props: AddTodoListItemFormContainerProps) 
             String(year),
             customMonth,
             customDate,
-            props.currentYear,
-            props.currentMonth,
+            props.selectedYearParam,
+            props.selectedMonthParam,
             addRequestData
           )
         );
@@ -92,16 +103,9 @@ const AddTodoListItemFormContainer = (props: AddTodoListItemFormContainerProps) 
       }
     } else {
       try {
-        await dispatch(
-          addTodoListItem(
-            String(year),
-            customMonth,
-            customDate,
-            props.currentYear,
-            props.currentMonth,
-            addRequestData
-          )
-        );
+        await dispatch(addTodoListItem(addRequestData));
+        await getFetchTodoList(params);
+
         setOpenAddTodoForm(false);
       } catch (error) {
         alert(error.response.data.error.message.toString());

--- a/src/containers/todo/modules/listItem/TodoListItemComponentContainer.tsx
+++ b/src/containers/todo/modules/listItem/TodoListItemComponentContainer.tsx
@@ -10,10 +10,11 @@ import { dateStringToDate } from '../../../../lib/date';
 import { customDate, customMonth, year } from '../../../../lib/constant';
 import { useLocation, useParams } from 'react-router';
 import TodoListItemComponent from '../../../../components/todo/modules/listItem/todoListItemComponent/TodoListItemComponent';
+
 interface TodoListItemComponentContainerProps {
   listItem: TodoListItem;
-  currentYear: string;
-  currentMonth: string;
+  selectedYearParam: string;
+  selectedMonthParam: string;
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
   formClassName?: string;
 }
@@ -121,8 +122,8 @@ const TodoListItemComponentContainer = (props: TodoListItemComponentContainerPro
             String(year),
             customMonth,
             customDate,
-            props.currentYear,
-            props.currentMonth,
+            props.selectedYearParam,
+            props.selectedMonthParam,
             requestData
           )
         );
@@ -139,8 +140,8 @@ const TodoListItemComponentContainer = (props: TodoListItemComponentContainerPro
             String(year),
             customMonth,
             customDate,
-            props.currentYear,
-            props.currentMonth,
+            props.selectedYearParam,
+            props.selectedMonthParam,
             requestData
           )
         );
@@ -169,8 +170,8 @@ const TodoListItemComponentContainer = (props: TodoListItemComponentContainerPro
             String(year),
             customMonth,
             customDate,
-            props.currentYear,
-            props.currentMonth,
+            props.selectedYearParam,
+            props.selectedMonthParam,
             requestData
           )
         );
@@ -186,8 +187,8 @@ const TodoListItemComponentContainer = (props: TodoListItemComponentContainerPro
             String(year),
             customMonth,
             customDate,
-            props.currentYear,
-            props.currentMonth,
+            props.selectedYearParam,
+            props.selectedMonthParam,
             requestData
           )
         );
@@ -209,8 +210,8 @@ const TodoListItemComponentContainer = (props: TodoListItemComponentContainerPro
             String(year),
             customMonth,
             customDate,
-            props.currentYear,
-            props.currentMonth
+            props.selectedYearParam,
+            props.selectedMonthParam
           )
         );
       } catch (error) {
@@ -224,8 +225,8 @@ const TodoListItemComponentContainer = (props: TodoListItemComponentContainerPro
             String(year),
             customMonth,
             customDate,
-            props.currentYear,
-            props.currentMonth
+            props.selectedYearParam,
+            props.selectedMonthParam
           )
         );
       } catch (error) {

--- a/src/containers/todo/page/TodoPageContainer.tsx
+++ b/src/containers/todo/page/TodoPageContainer.tsx
@@ -6,7 +6,6 @@ import { useLocation } from 'react-router';
 import { fetchGroups } from '../../../reducks/groups/operations';
 import { TodayOrMonthly } from '../../../reducks/shoppingList/types';
 import TodoPage from '../../../components/todo/page/TodoPage';
-import { generateZeroPaddingMonth } from '../../../lib/date';
 
 const TodoPageContainer = () => {
   const dispatch = useDispatch();
@@ -18,9 +17,6 @@ const TodoPageContainer = () => {
   const [editing, setEditing] = useState(false);
   const [selectedYear, setSelectedYear] = useState<number>(year);
   const [selectedMonth, setSelectedMonth] = useState<number>(month);
-
-  const currentYear = String(selectedYear);
-  const currentMonth = generateZeroPaddingMonth(selectedMonth);
 
   useEffect(() => {
     if (pathName !== 'group') {
@@ -61,8 +57,6 @@ const TodoPageContainer = () => {
       setOpenSearchResultTodoList={setOpenSearchResultTodoList}
       handleOpenSearch={handleOpenSearch}
       handleCloseSearch={handleCloseSearch}
-      currentYear={currentYear}
-      currentMonth={currentMonth}
       pathName={pathName}
     />
   );

--- a/src/hooks/todo/useFetchTodoList.ts
+++ b/src/hooks/todo/useFetchTodoList.ts
@@ -4,20 +4,18 @@ import {
   fetchMonthlyTodoList,
   fetchTodayTodoList,
 } from '../../reducks/todoList/operations';
-import axios, { CancelTokenSource } from 'axios';
 import { FetchTodoListParams } from '../../reducks/todoList/types';
 
 export const useFetchTodoList = () => {
   const dispatch = useDispatch();
-  const signal: CancelTokenSource = axios.CancelToken.source();
 
-  const getFetchTodoList = (props: FetchTodoListParams) => {
+  const fetchTodoList = (props: FetchTodoListParams) => {
     const { currentYear, currentMonth, currentDate, selectedYear, selectedMonth } = props;
 
-    dispatch(fetchExpiredTodoList(signal));
-    dispatch(fetchTodayTodoList(currentYear, currentMonth, currentDate, signal));
-    dispatch(fetchMonthlyTodoList(selectedYear, selectedMonth, signal));
+    dispatch(fetchExpiredTodoList());
+    dispatch(fetchTodayTodoList(currentYear, currentMonth, currentDate));
+    dispatch(fetchMonthlyTodoList(selectedYear, selectedMonth));
   };
 
-  return { getFetchTodoList };
+  return { fetchTodoList };
 };

--- a/src/hooks/todo/useFetchTodoList.ts
+++ b/src/hooks/todo/useFetchTodoList.ts
@@ -1,0 +1,23 @@
+import { useDispatch } from 'react-redux';
+import {
+  fetchExpiredTodoList,
+  fetchMonthlyTodoList,
+  fetchTodayTodoList,
+} from '../../reducks/todoList/operations';
+import axios, { CancelTokenSource } from 'axios';
+import { FetchTodoListParams } from '../../reducks/todoList/types';
+
+export const useFetchTodoList = () => {
+  const dispatch = useDispatch();
+  const signal: CancelTokenSource = axios.CancelToken.source();
+
+  const getFetchTodoList = (props: FetchTodoListParams) => {
+    const { currentYear, currentMonth, currentDate, selectedYear, selectedMonth } = props;
+
+    dispatch(fetchExpiredTodoList(signal));
+    dispatch(fetchTodayTodoList(currentYear, currentMonth, currentDate, signal));
+    dispatch(fetchMonthlyTodoList(selectedYear, selectedMonth, signal));
+  };
+
+  return { getFetchTodoList };
+};

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -1,3 +1,5 @@
+import { date } from '../../lib/constant';
+
 const initialState = {
   users: {
     user_id: '',
@@ -285,6 +287,15 @@ const initialState = {
     searchTodoListError: {
       message: '',
       statusCode: 0,
+    },
+    todoListItem: {
+      id: 0,
+      posted_date: date,
+      updated_date: date,
+      implementation_date: '',
+      due_date: '',
+      todo_content: '',
+      complete_flag: false,
     },
     todoListError: {
       message: '',

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -290,6 +290,15 @@ export interface State {
       message: string;
       statusCode: number;
     };
+    todoListItem: {
+      id: number;
+      posted_date: Date | null;
+      updated_date: Date | null;
+      implementation_date: string;
+      due_date: string;
+      todo_content: string;
+      complete_flag: boolean;
+    };
     todoListError: {
       message: string;
       statusCode: number;

--- a/src/reducks/todoList/actions.ts
+++ b/src/reducks/todoList/actions.ts
@@ -1,4 +1,4 @@
-import { TodoList } from './types';
+import { TodoList, TodoListItem } from './types';
 export type todoListsActions = ReturnType<
   | typeof startFetchExpiredTodoListAction
   | typeof fetchExpiredTodoListAction
@@ -234,25 +234,10 @@ export const startAddTodoListItemAction = () => {
 };
 
 export const ADD_TODO_LIST_ITEM = 'ADD_TODO_LIST_ITEM';
-export const addTodoListItemAction = (
-  expiredTodoList: TodoList,
-  todayImplementationTodoList: TodoList,
-  todayDueTodoList: TodoList,
-  monthlyImplementationTodoList: TodoList,
-  monthlyDueTodoList: TodoList
-) => {
+export const addTodoListItemAction = (todoListItem: TodoListItem) => {
   return {
     type: ADD_TODO_LIST_ITEM,
-    payload: {
-      expiredTodoListLoading: false,
-      expiredTodoList: expiredTodoList,
-      todayTodoListLoading: false,
-      todayImplementationTodoList: todayImplementationTodoList,
-      todayDueTodoList: todayDueTodoList,
-      monthlyTodoListLoading: false,
-      monthlyImplementationTodoList: monthlyImplementationTodoList,
-      monthlyDueTodoList: monthlyDueTodoList,
-    },
+    payload: { todoListItem: todoListItem },
   };
 };
 

--- a/src/reducks/todoList/operations.ts
+++ b/src/reducks/todoList/operations.ts
@@ -50,14 +50,17 @@ import dayjs from 'dayjs';
 import { openTextModalAction } from '../modal/actions';
 import { todoServiceInstance } from '../axiosConfig';
 
-export const fetchExpiredTodoList = (signal: CancelTokenSource) => {
+export const fetchExpiredTodoList = (signal?: CancelTokenSource) => {
   return async (dispatch: Dispatch<Action>) => {
     dispatch(startFetchExpiredTodoListAction());
 
     try {
-      const result = await todoServiceInstance.get<FetchExpiredTodoListRes>(`/todo-list/expired`, {
-        cancelToken: signal.token,
-      });
+      const result = await todoServiceInstance.get<FetchExpiredTodoListRes>(
+        `/todo-list/expired`,
+        signal && {
+          cancelToken: signal.token,
+        }
+      );
       const expiredTodoList: TodoList = result.data.expired_todo_list;
 
       dispatch(fetchExpiredTodoListAction(expiredTodoList));
@@ -77,7 +80,7 @@ export const fetchTodayTodoList = (
   year: string,
   month: string,
   date: string,
-  signal: CancelTokenSource
+  signal?: CancelTokenSource
 ) => {
   return async (dispatch: Dispatch<Action>) => {
     dispatch(startFetchTodayTodoListAction());
@@ -85,7 +88,7 @@ export const fetchTodayTodoList = (
     try {
       const result = await todoServiceInstance.get<FetchTodayTodoListRes>(
         `/todo-list/${year}-${month}-${date}`,
-        {
+        signal && {
           cancelToken: signal.token,
         }
       );
@@ -106,14 +109,14 @@ export const fetchTodayTodoList = (
   };
 };
 
-export const fetchMonthlyTodoList = (year: string, month: string, signal: CancelTokenSource) => {
+export const fetchMonthlyTodoList = (year: string, month: string, signal?: CancelTokenSource) => {
   return async (dispatch: Dispatch<Action>) => {
     dispatch(startFetchMonthlyTodoListAction());
 
     try {
       const result = await todoServiceInstance.get<FetchMonthlyTodoListRes>(
         `/todo-list/${year}-${month}`,
-        {
+        signal && {
           cancelToken: signal.token,
         }
       );

--- a/src/reducks/todoList/operations.ts
+++ b/src/reducks/todoList/operations.ts
@@ -35,7 +35,6 @@ import {
 } from './actions';
 import {
   AddTodoListItemReq,
-  AddTodoListItemRes,
   DeleteTodoListItemRes,
   EditTodoListItemReq,
   EditTodoListItemRes,
@@ -45,6 +44,7 @@ import {
   FetchTodayTodoListRes,
   SearchTodoRequestData,
   TodoList,
+  TodoListItem,
 } from './types';
 import dayjs from 'dayjs';
 import { openTextModalAction } from '../modal/actions';
@@ -175,19 +175,12 @@ export const fetchSearchTodoList = (searchRequestData: {
   };
 };
 
-export const addTodoListItem = (
-  year: string,
-  month: string,
-  date: string,
-  currentYear: string,
-  currentMonth: string,
-  requestData: AddTodoListItemReq
-) => {
+export const addTodoListItem = (requestData: AddTodoListItemReq) => {
   return async (dispatch: Dispatch<Action>) => {
     dispatch(startAddTodoListItemAction());
 
     try {
-      await todoServiceInstance.post<AddTodoListItemRes>(
+      const res = await todoServiceInstance.post<TodoListItem>(
         `/todo-list`,
         JSON.stringify(requestData, function (key, value) {
           if (key === 'implementation_date') {
@@ -199,45 +192,7 @@ export const addTodoListItem = (
         })
       );
 
-      const fetchExpiredResult = todoServiceInstance.get<FetchExpiredTodoListRes>(
-        `/todo-list/expired`
-      );
-
-      const fetchTodayResult = todoServiceInstance.get<FetchTodayTodoListRes>(
-        `/todo-list/${year}-${month}-${date}`
-      );
-
-      const fetchMonthlyResult = todoServiceInstance.get<FetchMonthlyTodoListRes>(
-        `/todo-list/${currentYear}-${currentMonth}`
-      );
-
-      const expiredResponse = await fetchExpiredResult;
-      const todayResponse = await fetchTodayResult;
-      const monthlyResponse = await fetchMonthlyResult;
-
-      const expiredTodoList = expiredResponse.data.expired_todo_list;
-
-      const todayMessage = todayResponse.data.message;
-      const todayImplementationTodoList = todayMessage
-        ? []
-        : todayResponse.data.implementation_todo_list;
-      const todayDuesTodoList = todayMessage ? [] : todayResponse.data.due_todo_list;
-
-      const monthlyMessage = monthlyResponse.data.message;
-      const monthlyImplementationTodoList = monthlyMessage
-        ? []
-        : monthlyResponse.data.implementation_todo_list;
-      const monthlyDuesTodoList = monthlyMessage ? [] : monthlyResponse.data.due_todo_list;
-
-      dispatch(
-        addTodoListItemAction(
-          expiredTodoList,
-          todayImplementationTodoList,
-          todayDuesTodoList,
-          monthlyImplementationTodoList,
-          monthlyDuesTodoList
-        )
-      );
+      dispatch(addTodoListItemAction(res.data));
     } catch (error) {
       dispatch(
         failedAddTodoListItemAction(error.response.status, error.response.data.error.message)

--- a/src/reducks/todoList/types.ts
+++ b/src/reducks/todoList/types.ts
@@ -16,16 +16,6 @@ export interface AddTodoListItemReq {
   todo_content: string;
 }
 
-export interface AddTodoListItemRes {
-  id: number;
-  posted_date: Date | null;
-  updated_date: Date | null;
-  implementation_date: string;
-  due_date: string;
-  todo_content: string;
-  complete_flag: boolean;
-}
-
 export interface EditTodoListItemReq {
   implementation_date: Date | null;
   due_date: Date | null;
@@ -85,3 +75,11 @@ export interface DisplayTodoListItem {
 }
 
 export interface DisplayTodoList extends Array<DisplayTodoListItem> {}
+
+export interface FetchTodoListParams {
+  currentYear: string;
+  currentMonth: string;
+  currentDate: string;
+  selectedYear: string;
+  selectedMonth: string;
+}

--- a/test/todolist-test/TodoListOperations.test.ts
+++ b/test/todolist-test/TodoListOperations.test.ts
@@ -196,12 +196,6 @@ describe('async actions todoLists', () => {
   });
 
   it('add todoList if fetch succeeds.', async () => {
-    const year = '2020';
-    const month = '09';
-    const date = '27';
-    const currentYear = '2020';
-    const currentMonth = '09';
-
     const implementationDate = new Date('2020-09-28T00:00:00Z');
     const dueDate = new Date('2020-09-29T00:00:00Z');
     const todoContent = '買い物へゆく';
@@ -212,10 +206,7 @@ describe('async actions todoLists', () => {
       todo_content: todoContent,
     };
 
-    const addUrl = `/todo-list`;
-    const fetchExpiredUrl = `/todo-list/expired`;
-    const fetchTodayUrl = `/todo-list/${year}-${month}-${date}`;
-    const fetchMonthlyUrl = `/todo-list/${currentYear}-${currentMonth}`;
+    const url = `/todo-list`;
 
     const expectedAction = [
       {
@@ -229,32 +220,14 @@ describe('async actions todoLists', () => {
       {
         type: TodoListActions.ADD_TODO_LIST_ITEM,
         payload: {
-          expiredTodoListLoading: false,
-          expiredTodoList: addExpiredTodoListResponse.expired_todo_list,
-          todayTodoListLoading: false,
-          todayImplementationTodoList: addTodayTodoListResponse.implementation_todo_list,
-          todayDueTodoList: addTodayTodoListResponse.due_todo_list,
-          monthlyTodoListLoading: false,
-          monthlyImplementationTodoList: addMonthlyTodoListResponse.implementation_todo_list,
-          monthlyDueTodoList: addMonthlyTodoListResponse.due_todo_list,
+          todoListItem: addTodoListItemResponse,
         },
       },
     ];
 
-    axiosMock.onPost(addUrl).reply(200, addTodoListItemResponse);
-    axiosMock.onGet(fetchExpiredUrl).reply(200, addExpiredTodoListResponse);
-    axiosMock.onGet(fetchTodayUrl).reply(200, addTodayTodoListResponse);
-    axiosMock.onGet(fetchMonthlyUrl).reply(200, addMonthlyTodoListResponse);
+    axiosMock.onPost(url).reply(200, addTodoListItemResponse);
 
-    await addTodoListItem(
-      year,
-      month,
-      date,
-      currentYear,
-      currentMonth,
-      requestData
-      // @ts-ignore
-    )(store.dispatch);
+    await addTodoListItem(requestData)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAction);
   });
 


### PR DESCRIPTION
- カスタムフックとして`useFetchTodoList`を作成しました。
  Todoアイテムの追加時の他に編集、削除時にも共通の挙動を行うため、カスタムフックとして切り出しました。

- Todoアイテムの追加が成功したら`useFetchTodoList`内の`getFetchTodoList()`を実行させるようにしました。
  各Todoリスト(today, monthly, expired)を`GET`するようにしました。
- store で`todoListItem`を管理するようにしました。
  成功か失敗かを判定させるために管理させるようにしました。
- Todoアイテムの追加が成功した場合はレスポンスのデータを store で管理する`todoListItem`に送るようにしました。