### PR TITLE
Add a process to hide redux logger and redux devtools in production environment

### DIFF
--- a/src/components/home/recentTransaction/recentTransactionBody/GroupRecentInputBody.tsx
+++ b/src/components/home/recentTransaction/recentTransactionBody/GroupRecentInputBody.tsx
@@ -57,16 +57,16 @@ const GroupRecentInputBody = (props: RecentInputBodyProps) => {
             <dt>
               <span className="recent-input__item-font">店名: </span>
               {groupTransaction.shop !== null
-                ? groupTransaction.shop.length > 13
-                  ? groupTransaction.shop.substring(0, 12) + '...'
+                ? groupTransaction.shop.length > 12
+                  ? groupTransaction.shop.substring(0, 11) + '...'
                   : groupTransaction.shop
                 : '-'}
             </dt>
             <dt>
               <span className="recent-input__item-font">メモ :</span>
               {groupTransaction.memo !== null
-                ? groupTransaction.memo.length > 13
-                  ? groupTransaction.memo.substring(0, 12) + '...'
+                ? groupTransaction.memo.length > 12
+                  ? groupTransaction.memo.substring(0, 11) + '...'
                   : groupTransaction.memo
                 : '-'}
             </dt>

--- a/src/components/home/recentTransaction/recentTransactionBody/RecentInputBody.tsx
+++ b/src/components/home/recentTransaction/recentTransactionBody/RecentInputBody.tsx
@@ -38,16 +38,16 @@ const RecentInputBody = (props: RecentInputBodyProps) => {
             <dt>
               <span className="recent-input__item-font">店名: </span>
               {transaction.shop !== null
-                ? transaction.shop.length > 13
-                  ? transaction.shop.substring(0, 12) + '...'
+                ? transaction.shop.length > 12
+                  ? transaction.shop.substring(0, 11) + '...'
                   : transaction.shop
                 : '-'}
             </dt>
             <dt>
               <span className="recent-input__item-font">メモ: </span>
               {transaction.memo !== null
-                ? transaction.memo.length > 13
-                  ? transaction.memo.substring(0, 12) + '...'
+                ? transaction.memo.length > 12
+                  ? transaction.memo.substring(0, 11) + '...'
                   : transaction.memo
                 : '-'}
             </dt>

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -1,5 +1,4 @@
 export const autoAddTransactionMessage =
   '購入完了時のチェックをつけると、 自動的に家計簿に追加されるようになります。';
 
-export const payerColorDescriptionMessage =
-  '支払者が分かるように、メンバーに割り当てられた色の下線を金額に引いています。';
+export const payerColorDescriptionMessage = '金額の下線の色は、支払いを行った人を表しています。';

--- a/src/reducks/store/store.ts
+++ b/src/reducks/store/store.ts
@@ -8,7 +8,7 @@ import { groupTransactionsReducer } from '../groupTransactions/reducers';
 import { connectRouter, routerMiddleware } from 'connected-react-router';
 import thunk from 'redux-thunk';
 import { History } from 'history';
-import { createLogger } from 'redux-logger';
+import logger from 'redux-logger';
 import { modalReducer } from '../modal/reducers';
 import { budgetsReducer } from '../budgets/reducers';
 import { groupBudgetsReducer } from '../groupBudgets/reducers';
@@ -28,11 +28,6 @@ const composeEnhancers =
   (typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
 
 export default function createStore(history: History) {
-  const logger = createLogger({
-    collapsed: true,
-    diff: true,
-  });
-
   const appReducer = combineReducers({
     router: connectRouter(history),
     users: usersReducer,
@@ -58,8 +53,10 @@ export default function createStore(history: History) {
     return appReducer(state, action);
   };
 
-  return reduxCreateStore(
-    rootReducer,
-    composeEnhancers(applyMiddleware(routerMiddleware(history), thunk, logger))
-  );
+  return process.env.NODE_ENV !== 'production'
+    ? reduxCreateStore(
+        rootReducer,
+        composeEnhancers(applyMiddleware(routerMiddleware(history), thunk, logger))
+      )
+    : reduxCreateStore(rootReducer, applyMiddleware(routerMiddleware(history), thunk));
 }


### PR DESCRIPTION
- 本番環境で`redux-logger, redux-devtools`が表示されていたので開発環境と本番環境で表示を切り替えるように修正しまし 
   た。

- `RecentInputBody, GroupRecentInputBody`で表示させているメモと店名の文字数が多い場合に末尾に ....をつけるようにして 
  いましたが改行された状態で末尾に追加されていたのでメモと店名の文字数の条件を修正しました。

- グループ画面で家計簿を追加した際に支払い者が分かるようにメンバーに割り当てられた色の下線を金額に引いている表示につ 
  いての説明文を修正しました。