### PR TITLE
Add useFetchGroupTodoList function

### DIFF
--- a/src/containers/todo/modules/form/AddTodoListItemFormContainer.tsx
+++ b/src/containers/todo/modules/form/AddTodoListItemFormContainer.tsx
@@ -92,7 +92,7 @@ const AddTodoListItemFormContainer = (props: AddTodoListItemFormContainerProps) 
       const groupParams: FetchGroupTodoListParams = { groupId, ...params };
 
       try {
-        await dispatch(addGroupTodoListItem(Number(group_id), addRequestData));
+        await dispatch(addGroupTodoListItem(groupId, addRequestData));
         await fetchGroupTodoList(groupParams);
 
         setOpenAddTodoForm(false);

--- a/src/containers/todo/modules/form/AddTodoListItemFormContainer.tsx
+++ b/src/containers/todo/modules/form/AddTodoListItemFormContainer.tsx
@@ -7,6 +7,8 @@ import { useLocation, useParams } from 'react-router';
 import AddTodoListItemForm from '../../../../components/todo/modules/form/addTodoListItemForm/AddTodoListItemForm';
 import { AddTodoListItemReq, FetchTodoListParams } from '../../../../reducks/todoList/types';
 import { useFetchTodoList } from '../../../../hooks/todo/useFetchTodoList';
+import { useFetchGroupTodoList } from '../../../../hooks/todo/useFetchGroupTodoList';
+import { FetchGroupTodoListParams } from '../../../../reducks/groupTodoList/types';
 
 interface AddTodoListItemFormContainerProps {
   selectedYearParam: string;
@@ -24,6 +26,9 @@ const AddTodoListItemFormContainer = (props: AddTodoListItemFormContainerProps) 
   const pathName = useLocation().pathname.split('/')[1];
   const { group_id } = useParams<{ group_id: string }>();
   const inputTodoRef = useRef<HTMLDivElement>(null);
+
+  const { fetchTodoList } = useFetchTodoList();
+  const { fetchGroupTodoList } = useFetchGroupTodoList();
 
   const [openAddTodoForm, setOpenAddTodoForm] = useState(false);
   const [implementationDate, setImplementationDate] = useState<Date | null>(
@@ -62,8 +67,6 @@ const AddTodoListItemFormContainer = (props: AddTodoListItemFormContainerProps) 
     }
   };
 
-  const { fetchTodoList } = useFetchTodoList();
-
   const disabledButton =
     implementationDate === null ||
     dueDate === null ||
@@ -85,18 +88,13 @@ const AddTodoListItemFormContainer = (props: AddTodoListItemFormContainerProps) 
     };
 
     if (pathName === 'group') {
+      const groupId = Number(group_id);
+      const groupParams: FetchGroupTodoListParams = { groupId, ...params };
+
       try {
-        await dispatch(
-          addGroupTodoListItem(
-            Number(group_id),
-            String(year),
-            customMonth,
-            customDate,
-            props.selectedYearParam,
-            props.selectedMonthParam,
-            addRequestData
-          )
-        );
+        await dispatch(addGroupTodoListItem(Number(group_id), addRequestData));
+        await fetchGroupTodoList(groupParams);
+
         setOpenAddTodoForm(false);
       } catch (error) {
         alert(error.response.data.error.message.toString());

--- a/src/hooks/todo/useFetchGroupTodoList.ts
+++ b/src/hooks/todo/useFetchGroupTodoList.ts
@@ -1,0 +1,21 @@
+import { useDispatch } from 'react-redux';
+import {
+  fetchGroupExpiredTodoList,
+  fetchGroupMonthlyTodoList,
+  fetchGroupTodayTodoList,
+} from '../../reducks/groupTodoList/operations';
+import { FetchGroupTodoListParams } from '../../reducks/groupTodoList/types';
+
+export const useFetchGroupTodoList = () => {
+  const dispatch = useDispatch();
+
+  const fetchGroupTodoList = (props: FetchGroupTodoListParams) => {
+    const { groupId, currentYear, currentMonth, currentDate, selectedYear, selectedMonth } = props;
+
+    dispatch(fetchGroupExpiredTodoList(groupId));
+    dispatch(fetchGroupTodayTodoList(groupId, currentYear, currentMonth, currentDate));
+    dispatch(fetchGroupMonthlyTodoList(groupId, selectedYear, selectedMonth));
+  };
+
+  return { fetchGroupTodoList };
+};

--- a/src/reducks/groupTodoList/actions.ts
+++ b/src/reducks/groupTodoList/actions.ts
@@ -1,4 +1,4 @@
-import { GroupTodoList } from './types';
+import { GroupTodoList, GroupTodoListItem } from './types';
 import { TodoList } from '../todoList/types';
 export type groupTodoListsActions = ReturnType<
   | typeof startFetchGroupExpiredTodoListAction
@@ -235,24 +235,11 @@ export const startAddGroupTodoListItemAction = () => {
 };
 
 export const ADD_GROUP_TODO_LIST_ITEM = 'ADD_GROUP_TODO_LIST_ITEM';
-export const addGroupTodoListItemAction = (
-  expiredTodoList: GroupTodoList,
-  todayImplementationTodoList: GroupTodoList,
-  todayDueTodoList: GroupTodoList,
-  monthlyImplementationTodoList: GroupTodoList,
-  monthlyDueTodoList: GroupTodoList
-) => {
+export const addGroupTodoListItemAction = (groupTodoListItem: GroupTodoListItem) => {
   return {
     type: ADD_GROUP_TODO_LIST_ITEM,
     payload: {
-      groupExpiredTodoListLoading: false,
-      groupExpiredTodoList: expiredTodoList,
-      groupTodayTodoListLoading: false,
-      groupTodayImplementationTodoList: todayImplementationTodoList,
-      groupTodayDueTodoList: todayDueTodoList,
-      groupMonthlyTodoListLoading: false,
-      groupMonthlyImplementationTodoList: monthlyImplementationTodoList,
-      groupMonthlyDueTodoList: monthlyDueTodoList,
+      groupTodoListItem: groupTodoListItem,
     },
   };
 };

--- a/src/reducks/groupTodoList/operations.ts
+++ b/src/reducks/groupTodoList/operations.ts
@@ -56,8 +56,8 @@ export const fetchGroupExpiredTodoList = (groupId: number, signal?: CancelTokenS
     try {
       const result = await todoServiceInstance.get<FetchGroupExpiredTodoListRes>(
         `/groups/${groupId}/todo-list/expired`,
-        signal && {
-          cancelToken: signal.token,
+        {
+          cancelToken: signal?.token,
         }
       );
       const groupExpiredTodoList: GroupTodoList = result.data.expired_group_todo_list;
@@ -91,8 +91,8 @@ export const fetchGroupTodayTodoList = (
     try {
       const result = await todoServiceInstance.get<FetchGroupTodayTodoListRes>(
         `/groups/${groupId}/todo-list/${year}-${month}-${date}`,
-        signal && {
-          cancelToken: signal.token,
+        {
+          cancelToken: signal?.token,
         }
       );
 
@@ -128,8 +128,8 @@ export const fetchGroupMonthlyTodoList = (
     try {
       const result = await todoServiceInstance.get<FetchGroupMonthlyTodoListRes>(
         `/groups/${groupId}/todo-list/${year}-${month}`,
-        signal && {
-          cancelToken: signal.token,
+        {
+          cancelToken: signal?.token,
         }
       );
 

--- a/src/reducks/groupTodoList/types.ts
+++ b/src/reducks/groupTodoList/types.ts
@@ -33,17 +33,6 @@ export interface AddGroupTodoListItemReq {
   todo_content: string;
 }
 
-export interface AddGroupTodoListItemRes {
-  id: number;
-  posted_date: Date | null;
-  updated_date: Date | null;
-  implementation_date: string;
-  due_date: string;
-  todo_content: string;
-  complete_flag: boolean;
-  user_id: string;
-}
-
 export interface EditGroupTodoListItemReq {
   implementation_date: Date | null;
   due_date: Date | null;
@@ -69,4 +58,13 @@ export interface DeleteGroupTodoListItemRes {
 export interface FetchGroupSearchTodoListRes {
   search_todo_list: GroupTodoList;
   message: string;
+}
+
+export interface FetchGroupTodoListParams {
+  groupId: number;
+  currentYear: string;
+  currentMonth: string;
+  currentDate: string;
+  selectedYear: string;
+  selectedMonth: string;
 }

--- a/src/reducks/store/initialState.ts
+++ b/src/reducks/store/initialState.ts
@@ -329,6 +329,16 @@ const initialState = {
       message: '',
       statusCode: 0,
     },
+    groupTodoListItem: {
+      id: 0,
+      posted_date: date,
+      updated_date: date,
+      implementation_date: '',
+      due_date: '',
+      todo_content: '',
+      complete_flag: false,
+      user_id: '',
+    },
     groupTodoListError: {
       message: '',
       statusCode: 0,

--- a/src/reducks/store/types.ts
+++ b/src/reducks/store/types.ts
@@ -331,6 +331,16 @@ export interface State {
       message: string;
       statusCode: number;
     };
+    groupTodoListItem: {
+      id: number;
+      posted_date: Date | null;
+      updated_date: Date | null;
+      implementation_date: string;
+      due_date: string;
+      todo_content: string;
+      complete_flag: boolean;
+      user_id: string;
+    };
     groupTodoListError: {
       message: string;
       statusCode: number;

--- a/src/reducks/todoList/operations.ts
+++ b/src/reducks/todoList/operations.ts
@@ -55,12 +55,9 @@ export const fetchExpiredTodoList = (signal?: CancelTokenSource) => {
     dispatch(startFetchExpiredTodoListAction());
 
     try {
-      const result = await todoServiceInstance.get<FetchExpiredTodoListRes>(
-        `/todo-list/expired`,
-        signal && {
-          cancelToken: signal.token,
-        }
-      );
+      const result = await todoServiceInstance.get<FetchExpiredTodoListRes>(`/todo-list/expired`, {
+        cancelToken: signal?.token,
+      });
       const expiredTodoList: TodoList = result.data.expired_todo_list;
 
       dispatch(fetchExpiredTodoListAction(expiredTodoList));
@@ -88,8 +85,8 @@ export const fetchTodayTodoList = (
     try {
       const result = await todoServiceInstance.get<FetchTodayTodoListRes>(
         `/todo-list/${year}-${month}-${date}`,
-        signal && {
-          cancelToken: signal.token,
+        {
+          cancelToken: signal?.token,
         }
       );
       const message = result.data.message;
@@ -116,8 +113,8 @@ export const fetchMonthlyTodoList = (year: string, month: string, signal?: Cance
     try {
       const result = await todoServiceInstance.get<FetchMonthlyTodoListRes>(
         `/todo-list/${year}-${month}`,
-        signal && {
-          cancelToken: signal.token,
+        {
+          cancelToken: signal?.token,
         }
       );
       const message = result.data.message;

--- a/src/reducks/todoList/types.ts
+++ b/src/reducks/todoList/types.ts
@@ -1,3 +1,5 @@
+import { FetchGroupTodoListParams } from '../groupTodoList/types';
+
 export interface TodoListItem {
   id: number;
   posted_date: Date | null;
@@ -76,10 +78,4 @@ export interface DisplayTodoListItem {
 
 export interface DisplayTodoList extends Array<DisplayTodoListItem> {}
 
-export interface FetchTodoListParams {
-  currentYear: string;
-  currentMonth: string;
-  currentDate: string;
-  selectedYear: string;
-  selectedMonth: string;
-}
+export type FetchTodoListParams = Omit<FetchGroupTodoListParams, 'groupId'>;

--- a/test/group-todolist-test/GroupTodoListOperations.test.ts
+++ b/test/group-todolist-test/GroupTodoListOperations.test.ts
@@ -8,9 +8,6 @@ import fetchGroupTodayTodoListResponse from './fetchGroupTodayTodoListResponse/f
 import fetchGroupMonthlyTodoListResponse from './fetchGroupMonthlyTodoListResponse/fetchGroupMonthlyTodoListResponse.json';
 import fetchGroupSearchTodoListResponse from './fetchGroupSearchTodoListResponse/fetchGroupSearchTodoListResponse.json';
 import addGroupTodoListItemResponse from './addGroupTodoListItemResponse/addGroupTodoListItemResponse.json';
-import addGroupExpiredTodoListResponse from './addGroupTodoListItemResponse/addGroupExpiredTodoListResponse.json';
-import addGroupTodayTodoListResponse from './addGroupTodoListItemResponse/addGroupTodayTodoListResponse.json';
-import addGroupMonthlyTodoListResponse from './addGroupTodoListItemResponse/addGroupMonthlyTodoListResponse.json';
 import editGroupTodoListItemResponse from './editGroupTodoListItemResponse/editGroupTodoListItemResponse.json';
 import editGroupExpiredTodoListResponse from './editGroupTodoListItemResponse/editGroupExpiredTodoListResponse.json';
 import editGroupTodayTodoListResponse from './editGroupTodoListItemResponse/editGroupTodayTodoListResponse.json';
@@ -207,11 +204,6 @@ describe('async actions groupTodoLists', () => {
 
   it('add groupTodoList if fetch succeeds.', async () => {
     const groupId = 1;
-    const year = '2020';
-    const month = '09';
-    const date = '27';
-    const currentYear = '2020';
-    const currentMonth = '09';
 
     const implementationDate = new Date('2020-09-27T00:00:00');
     const dueDate = new Date('2020-09-29T00:00:00');
@@ -223,10 +215,7 @@ describe('async actions groupTodoLists', () => {
       todo_content: todoContent,
     };
 
-    const addUrl = `/groups/${groupId}/todo-list`;
-    const fetchExpiredUrl = `/groups/${groupId}/todo-list/expired`;
-    const fetchTodayUrl = `/groups/${groupId}/todo-list/${year}-${month}-${date}`;
-    const fetchMonthlyUrl = `/groups/${groupId}/todo-list/${currentYear}-${currentMonth}`;
+    const url = `/groups/${groupId}/todo-list`;
 
     const expectedAction = [
       {
@@ -240,34 +229,14 @@ describe('async actions groupTodoLists', () => {
       {
         type: GroupTodoListActions.ADD_GROUP_TODO_LIST_ITEM,
         payload: {
-          groupExpiredTodoListLoading: false,
-          groupExpiredTodoList: addGroupExpiredTodoListResponse.expired_group_todo_list,
-          groupTodayTodoListLoading: false,
-          groupTodayImplementationTodoList: addGroupTodayTodoListResponse.implementation_todo_list,
-          groupTodayDueTodoList: addGroupTodayTodoListResponse.due_todo_list,
-          groupMonthlyTodoListLoading: false,
-          groupMonthlyImplementationTodoList:
-            addGroupMonthlyTodoListResponse.implementation_todo_list,
-          groupMonthlyDueTodoList: addGroupMonthlyTodoListResponse.due_todo_list,
+          groupTodoListItem: addGroupTodoListItemResponse,
         },
       },
     ];
 
-    axiosMock.onPost(addUrl).reply(200, addGroupTodoListItemResponse);
-    axiosMock.onGet(fetchExpiredUrl).reply(200, addGroupExpiredTodoListResponse);
-    axiosMock.onGet(fetchTodayUrl).reply(200, addGroupTodayTodoListResponse);
-    axiosMock.onGet(fetchMonthlyUrl).reply(200, addGroupMonthlyTodoListResponse);
+    axiosMock.onPost(url).reply(200, addGroupTodoListItemResponse);
 
-    await addGroupTodoListItem(
-      groupId,
-      year,
-      month,
-      date,
-      currentYear,
-      currentMonth,
-      requestData
-      // @ts-ignore
-    )(store.dispatch);
+    await addGroupTodoListItem(groupId, requestData)(store.dispatch);
     expect(store.getActions()).toEqual(expectedAction);
   });
 


### PR DESCRIPTION
- カスタムフックとして、`useFetchGroupTodoList`を追加しました。
グループのTodoアイテムの追加時の他に編集、削除時にも共通の挙動を行うため、カスタムフックとして切り出しました。

- グループのTodoアイテムの追加が成功したら`useFetchGroupTodoList`内の`fetchGroupTodoList()`を実行させるようにしました。
各グループTodoリスト(today, monthly, expired)を`GET`するようにしました。
  
- アイテム追加後のデータ取得の関数はキャンセルを実行させることは無いので、引数に`signal`を持たせないようにしました。
そのため、データ取得時に実行させる`fetchGroupExpiredTodoList()`、`fetchGroupTodayTodoList()`、`fetchGroupMonthlyTodoList()`の`signal`をオプショナルに変更しました。

- store で`groupTodoListItem`を管理するようにしました。
成功か失敗かを判定させるために管理するようにしました。

- グループのTodoアイテムの追加が成功した場合は、 store で管理する`groupTodoListItem`を更新するようにしました。