### PR TITLE
Remove task data polling comments

### DIFF
--- a/src/containers/task/page/TaskPageContainer.tsx
+++ b/src/containers/task/page/TaskPageContainer.tsx
@@ -47,13 +47,13 @@ const TaskPageContainer = () => {
 
     if (!editing) {
       fetchGroupTasks(signal);
-      // const interval = setInterval(() => {
-      //   fetchGroupTasks(signal);
-      // }, 3000);
+      const interval = setInterval(() => {
+        fetchGroupTasks(signal);
+      }, 3000);
 
       return () => {
         signal.cancel();
-        // clearInterval(interval);
+        clearInterval(interval);
       };
     }
   }, [selectedDate, editing]);


### PR DESCRIPTION
- タスクデータのポーリングがコメントになっていた為、コメントを無効にしました。